### PR TITLE
Hold balanced-forecast days for the cheap window instead of unlocking pre-dawn

### DIFF
--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -300,6 +300,9 @@ EXTERNAL_NET_BALANCE_CANDIDATES: list[str] = ["sensor.balance_neto"]
 # Weekly Full Charge Delay Constants
 CHARGE_EFFICIENCY = 0.85  # Conservative factor for charge power estimation
 DELAY_SAFETY_FACTOR = 1.3  # 30% margin on energy balance
+DELAY_BALANCE_DEADBAND_KWH = 0.5  # Deadband on the binary "grid needed today?" gate
+#   so a near-balanced day (raw forecast ~= consumption) does not flip into a false
+#   pre-dawn deficit unlock. See ChargeDelayManager._should_delay_charge (#4).
 LOW_FORECAST_THRESHOLD_FACTOR = 1.5  # forecast < 1.5 × capacity → bad solar day
 T_START_THRESHOLD_KWH = 0.1  # Threshold to detect solar production start
 T_START_FALLBACK_HOUR = 11  # If no T_start by 11:00, unlock immediately

--- a/custom_components/omnibattery/control/charge_delay.py
+++ b/custom_components/omnibattery/control/charge_delay.py
@@ -28,6 +28,7 @@ from homeassistant.util import dt as dt_util
 
 from ..const import (
     CHARGE_EFFICIENCY,
+    DELAY_BALANCE_DEADBAND_KWH,
     DELAY_SAFETY_FACTOR,
     DELAY_SOC_SETPOINT_HYSTERESIS,
     DOMAIN,
@@ -355,21 +356,34 @@ class ChargeDelayManager:
             usable_energy_kwh = max(0, ((avg_soc - min_soc) / 100) * total_capacity_kwh)
             avg_consumption_kwh = ctrl._consumption_tracker.get_avg_daily_consumption()
             prev_cache = ctrl._charge_delay_forecast_cache
+            # Binary "is grid needed today?" gate. Use the RAW forecast, not the
+            # 0.85 haircut applied below: the haircut is a conservatism for the
+            # energy SCHEDULING math, but on this all-or-nothing gate it turns a
+            # balanced day (raw forecast ~= consumption) into a false deficit and a
+            # latched pre-dawn unlock (#4). A small deadband absorbs sensor noise so
+            # a near-balanced day still holds for the cheap window.
             ctrl._charge_delay_balance_needs_charge = (
-                (usable_energy_kwh + forecast_today) < avg_consumption_kwh
+                (usable_energy_kwh + raw_forecast)
+                < (avg_consumption_kwh - DELAY_BALANCE_DEADBAND_KWH)
             )
             ctrl._charge_delay_forecast_cache = forecast_today
             _LOGGER.info(
-                "Charge Delay: Forecast %s (%.2f → %.2f kWh) → "
-                "balance: %.2f usable + %.2f solar = %.2f kWh vs %.2f kWh consumption → %s",
+                "Charge Delay: Forecast %s (raw %.2f, scheduling %.2f kWh) → "
+                "balance: %.2f usable + %.2f solar = %.2f kWh vs %.2f kWh consumption "
+                "(deadband %.2f) → %s",
                 "initialised" if prev_cache is None else "changed",
-                prev_cache if prev_cache is not None else 0.0, forecast_today,
-                usable_energy_kwh, forecast_today, usable_energy_kwh + forecast_today,
-                avg_consumption_kwh,
+                raw_forecast, forecast_today,
+                usable_energy_kwh, raw_forecast, usable_energy_kwh + raw_forecast,
+                avg_consumption_kwh, DELAY_BALANCE_DEADBAND_KWH,
                 "grid needed (unlock delay)" if ctrl._charge_delay_balance_needs_charge else "solar sufficient (keep delay)",
             )
 
         if ctrl._charge_delay_balance_needs_charge:
+            # Genuine grid-deficit day: rather than unlocking immediately (often a
+            # pre-dawn price peak), hold until the cheapest import hour before solar
+            # is due, so the unavoidable grid charge lands in the cheap window (#4).
+            if self._low_forecast_price_release(now_h):
+                return True
             return _unlock("low_forecast")
 
         # --- Exception 3: No T_start detected ---
@@ -576,6 +590,33 @@ class ChargeDelayManager:
         if cur_price is not None and cur_price <= best_p + eps:
             return now_h
         return best_h
+
+    def _low_forecast_price_release(self, now_h: float) -> bool:
+        """Hold a genuine grid-deficit day until its cheapest import hour.
+
+        On a balanced/low-forecast day the battery must take some grid charge, but
+        unlocking the moment the deficit is detected (often pre-dawn) charges at a
+        price peak. Instead, hold until the cheapest price slot in the window before
+        solar production is expected, so the unavoidable import lands in the cheap
+        window (#4). Reuses :meth:`_price_optimal_release_h` (min-price slot in a
+        feasible window — the same selection serves cheapest-import here as it does
+        cheapest-export for the PV-surplus hold).
+
+        Returns True to keep holding, False to unlock now: when the current hour is
+        already the cheapest, when no price data is available (legacy immediate
+        unlock preserved), or when there is no pre-solar slack left.
+        """
+        ctrl = self._controller
+        edge_h = ctrl._solar_t_start if ctrl._solar_t_start is not None else T_START_FALLBACK_HOUR
+        if edge_h <= now_h:
+            return False  # solar already due/past — no cheap pre-solar window
+        release_h = self._price_optimal_release_h(now_h, edge_h)
+        if release_h is None or now_h + 1e-6 >= release_h:
+            return False  # no price data, or now is the cheapest feasible hour
+        hhmm = ctrl._consumption_tracker.h_to_hhmm(release_h)
+        ctrl._charge_delay_status["estimated_unlock_time"] = hhmm
+        ctrl._charge_delay_status["state"] = f"Delayed (cheap import {hhmm} est.)"
+        return True
 
     def _estimate_energy_balance_unlock_h(
         self,

--- a/custom_components/omnibattery/control/charge_delay.py
+++ b/custom_components/omnibattery/control/charge_delay.py
@@ -505,9 +505,77 @@ class ChargeDelayManager:
             )
             return _unlock("time_backup")
 
+        # --- Price-aware release (within the proven-feasible window only) ---
+        # The checks above keep the delay until the feasibility edge
+        # (energy_balance / time_backup), which is the LATEST safe release and is
+        # often a pricier afternoon hour than the midday export trough. Pull the
+        # release FORWARD to the cheapest export hour inside the still-feasible
+        # window [now, est_unlock_h], so self-charging sacrifices the least export
+        # (teruglever) revenue. SOC target stays fully protected: the window never
+        # extends past the edge, and the hard energy/time unlocks above remain the
+        # floor. Degrades to legacy edge-release when no price data is available.
+        release_h = self._price_optimal_release_h(now_h, est_unlock_h)
+        if release_h is not None:
+            if now_h + 1e-6 < release_h:
+                # A cheaper feasible hour lies ahead, keep holding for it.
+                status["estimated_unlock_time"] = _h_to_hhmm(release_h)
+                status["state"] = f"Delayed (price, {_h_to_hhmm(release_h)} est.)"
+                return True
+            # Current hour is the cheapest feasible export hour, release now.
+            _LOGGER.info(
+                "Charge Delay: now (%.2fh) is cheapest feasible export hour up to "
+                "%.2fh - unlocking (reason: price_optimal)",
+                now_h, est_unlock_h,
+            )
+            return _unlock("price_optimal")
+
         # All checks passed - keep delay active
         status["state"] = f"Delayed ({status['estimated_unlock_time']} est.)"
         return True
+
+    def _price_optimal_release_h(self, now_h: float, edge_h: float) -> float | None:
+        """Cheapest export hour to begin charging within [now_h, edge_h].
+
+        Returns the start hour (float, today) of the lowest-priced price slot whose
+        start lies in the still-feasible window. Returns ``now_h`` when the current
+        slot is itself the cheapest (within a small epsilon, so we never hold for a
+        negligible gain). Returns ``None`` when no usable price data exists, in
+        which case the caller keeps the legacy edge-release behaviour.
+
+        This only ever moves the release EARLIER than the feasibility edge; it never
+        defers past it, so the SOC-target safety margin enforced upstream is intact.
+        """
+        ctrl = self._controller
+        pricing = getattr(ctrl, "_pricing_mgr", None)
+        if pricing is None or not getattr(ctrl, "price_sensor", None):
+            return None
+        try:
+            # Already today-only and future-only (slot.end > now); quiet so this
+            # per-cycle poll does not spam the price-parse log.
+            slots = pricing.get_future_price_slots()
+        except Exception:  # defensive: a price-parse failure must not break the delay gate
+            _LOGGER.debug("Charge Delay: price parse failed, skipping price-aware release", exc_info=True)
+            return None
+        if not slots:
+            return None
+
+        candidates = []  # (start_hour, price)
+        cur_price = None
+        for s in slots:
+            s_h = s.start.hour + s.start.minute / 60.0
+            if s_h > edge_h + 1e-6:  # slot starts after the feasibility edge
+                continue
+            candidates.append((s_h, s.price))
+            if s_h <= now_h + 1e-9:  # slot covering the current moment
+                cur_price = s.price
+        if not candidates:
+            return None
+
+        eps = 0.005  # EUR/kWh: ignore sub-cent differences, prefer releasing sooner
+        best_h, best_p = min(candidates, key=lambda c: (c[1], c[0]))
+        if cur_price is not None and cur_price <= best_p + eps:
+            return now_h
+        return best_h
 
     def _estimate_energy_balance_unlock_h(
         self,

--- a/custom_components/omnibattery/pricing/engine.py
+++ b/custom_components/omnibattery/pricing/engine.py
@@ -185,28 +185,39 @@ class PricingManager:
         else:
             _LOGGER.warning("Dynamic pricing: tibber.get_prices returned no usable slots")
 
-    def _parse_price_data(self, *, horizon_end=None) -> list:
+    def get_future_price_slots(self, horizon_end=None) -> list:
+        """Public accessor for parsed future PriceSlots (today, future-only).
+
+        Thin, quiet wrapper around :meth:`_parse_price_data` for other managers
+        (e.g. the charge-delay price-aware release) that poll prices every control
+        cycle and must not spam the log. Logging is demoted to debug level here.
+        """
+        return self._parse_price_data(horizon_end=horizon_end, quiet=True)
+
+    def _parse_price_data(self, *, horizon_end=None, quiet=False) -> list:
         """Read price sensor and return list[PriceSlot] for remaining slots up to horizon_end.
 
         Dispatches to the correct parser based on price_integration_type.
         When horizon_end is None, defaults to end of current day (today 23:59:59).
-        Returns empty list on error.
+        Returns empty list on error. When quiet=True, status logging is demoted to
+        debug so high-frequency callers do not spam the log.
         """
+        _warn = _LOGGER.debug if quiet else _LOGGER.warning
         if self._controller.price_integration_type == PRICE_INTEGRATION_TIBBER:
             # Service-based: use the cached slots refreshed by _maybe_refresh_tibber_prices.
             raw_slots = list(self._controller._tibber_price_slots)
             if not raw_slots:
-                _LOGGER.warning("Dynamic pricing: no Tibber price data cached")
+                _warn("Dynamic pricing: no Tibber price data cached")
                 self._controller._price_data_status = "no_slots"
                 return []
         elif not self._controller.price_sensor:
-            _LOGGER.warning("Dynamic pricing: no price sensor configured")
+            _warn("Dynamic pricing: no price sensor configured")
             self._controller._price_data_status = "no_sensor"
             return []
         else:
             state = self._hass.states.get(self._controller.price_sensor)
             if state is None or state.state in ("unknown", "unavailable"):
-                _LOGGER.warning("Dynamic pricing: price sensor %s unavailable", self._controller.price_sensor)
+                _warn("Dynamic pricing: price sensor %s unavailable", self._controller.price_sensor)
                 self._controller._price_data_status = "sensor_unavailable"
                 return []
 
@@ -224,7 +235,7 @@ class PricingManager:
                 raw_slots = calculations.parse_nordpool_prices(attrs)
 
             if not raw_slots:
-                _LOGGER.warning(
+                _warn(
                     "Dynamic pricing: no price data parsed from %s (integration=%s)",
                     self._controller.price_sensor, self._controller.price_integration_type
                 )
@@ -239,7 +250,9 @@ class PricingManager:
         effective_horizon = horizon_end if horizon_end is not None else end_of_day
         filtered = [s for s in raw_slots if s.end > now and s.start <= effective_horizon]
         self._controller._price_data_status = f"ok ({len(filtered)} slots)"
-        _LOGGER.info("Dynamic pricing: parsed %d slots (%d within horizon)", len(raw_slots), len(filtered))
+        (_LOGGER.debug if quiet else _LOGGER.info)(
+            "Dynamic pricing: parsed %d slots (%d within horizon)", len(raw_slots), len(filtered)
+        )
         return filtered
 
     # =========================================================================

--- a/tests/test_charge_delay.py
+++ b/tests/test_charge_delay.py
@@ -238,8 +238,9 @@ def test_zero_capacity_unlocks():
 
 
 def test_balance_needs_charge_unlocks_low_forecast():
-    # avg_soc 30, min_soc 20, capacity 10 -> usable ~1 kWh; forecast 1*0.85=0.85;
-    # consumption 5 -> (1 + 0.85) < 5 -> grid needed -> unlock(low_forecast)
+    # avg_soc 30, min_soc 20, capacity 10 -> usable 1 kWh; RAW forecast 1.0;
+    # consumption 5, deadband 0.5 -> (1 + 1.0) < (5 - 0.5) -> grid needed.
+    # No pricing manager -> price-aware release is a no-op -> unlock(low_forecast).
     ctrl = _controller(
         coordinators=[_coord(soc=30, total_energy=10.0, min_soc=20)],
         _consumption_tracker=_tracker(get_avg_daily_consumption=lambda: 5.0),
@@ -247,6 +248,64 @@ def test_balance_needs_charge_unlocks_low_forecast():
     mgr = _make_mgr(ctrl, states={"sensor.forecast": _state(1.0)})
     assert mgr._should_delay_charge(80) is False
     assert ctrl._charge_delay_status["unlock_reason"] == "low_forecast"
+
+
+def test_balanced_day_holds_with_deadband():
+    # #4 concrete day: usable ~0.4 + raw forecast 15.76 vs 15.40 consumption.
+    # Pre-fix the 0.85 haircut (15.76 -> 13.40) flipped this into a false deficit
+    # and a latched pre-dawn unlock. With the raw forecast + deadband the gate now
+    # reads it as solar-sufficient and keeps the delay armed.
+    ctrl = _controller(
+        coordinators=[_coord(soc=24, total_energy=10.0, min_soc=20)],
+        _consumption_tracker=_tracker(get_avg_daily_consumption=lambda: 15.40),
+    )
+    mgr = _make_mgr(ctrl, states={"sensor.forecast": _state(15.76)})
+    mgr._should_delay_charge(80)
+    assert ctrl._charge_delay_balance_needs_charge is False
+
+
+def test_low_forecast_price_release_holds_for_cheaper_hour():
+    # Genuine deficit, cheaper import hour ahead before solar -> hold, do not unlock.
+    ctrl = _controller(_solar_t_start=8.0)
+    mgr = _make_mgr(ctrl)
+    mgr._price_optimal_release_h = lambda now_h, edge_h: 7.0
+    assert mgr._low_forecast_price_release(5.0) is True
+    assert ctrl._charge_delay_status["estimated_unlock_time"] == "07:00"
+    assert "cheap import" in ctrl._charge_delay_status["state"]
+
+
+def test_low_forecast_price_release_unlocks_when_now_cheapest():
+    ctrl = _controller(_solar_t_start=8.0)
+    mgr = _make_mgr(ctrl)
+    mgr._price_optimal_release_h = lambda now_h, edge_h: now_h  # current slot cheapest
+    assert mgr._low_forecast_price_release(5.0) is False
+
+
+def test_low_forecast_price_release_unlocks_without_price_data():
+    ctrl = _controller(_solar_t_start=8.0)
+    mgr = _make_mgr(ctrl)
+    mgr._price_optimal_release_h = lambda now_h, edge_h: None  # no price data
+    assert mgr._low_forecast_price_release(5.0) is False
+
+
+def test_low_forecast_price_release_unlocks_when_no_presolar_slack():
+    # now is already past solar start -> no cheap pre-solar window, unlock now.
+    ctrl = _controller(_solar_t_start=8.0)
+    mgr = _make_mgr(ctrl)
+    called = []
+    mgr._price_optimal_release_h = lambda now_h, edge_h: called.append(1) or 9.0
+    assert mgr._low_forecast_price_release(9.0) is False
+    assert called == []  # short-circuits before touching prices
+
+
+def test_low_forecast_price_release_uses_fallback_when_no_t_start():
+    # No T_start yet (pre-dawn): the window edge falls back to T_START_FALLBACK_HOUR.
+    ctrl = _controller(_solar_t_start=None)
+    mgr = _make_mgr(ctrl)
+    edges = []
+    mgr._price_optimal_release_h = lambda now_h, edge_h: edges.append(edge_h) or 7.0
+    assert mgr._low_forecast_price_release(5.0) is True
+    assert edges == [11]  # T_START_FALLBACK_HOUR
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_charge_delay.py
+++ b/tests/test_charge_delay.py
@@ -389,3 +389,78 @@ def test_setpoint_blocks_noop_when_feature_disabled():
     ctrl = _setpoint_controller([leader], _delay_soc_setpoint_enabled=False)
     _mgr_for(ctrl).refresh_setpoint_blocks()
     assert ctrl.blocks.get("charge_delay_setpoint", set()) == set()
+
+
+# ----------------------------------------------------------------------
+# _price_optimal_release_h: price-aware release within the feasible window
+# ----------------------------------------------------------------------
+from datetime import timedelta  # noqa: E402
+
+from homeassistant.util import dt as dt_util  # noqa: E402
+
+from custom_components.omnibattery.pricing import (  # noqa: E402
+    PriceSlot,
+)
+
+
+def _slot(hour, price):
+    """Hourly PriceSlot for today at ``hour`` (matches the manager's today check)."""
+    start = dt_util.now().replace(
+        hour=int(hour), minute=0, second=0, microsecond=0
+    )
+    return PriceSlot(start=start, end=start + timedelta(hours=1), price=price)
+
+
+def _price_ctrl(slots, **overrides):
+    return _controller(
+        price_sensor="sensor.price",
+        _pricing_mgr=SimpleNamespace(get_future_price_slots=lambda horizon_end=None: slots),
+        **overrides,
+    )
+
+
+def test_price_release_none_without_sensor():
+    # No price_sensor / pricing manager → legacy edge release (returns None).
+    mgr = _make_mgr(_controller())
+    assert mgr._price_optimal_release_h(11.0, 16.0) is None
+
+
+def test_price_release_none_on_empty_slots():
+    mgr = _make_mgr(_price_ctrl([]))
+    assert mgr._price_optimal_release_h(11.0, 16.0) is None
+
+
+def test_price_release_holds_for_cheaper_hour_ahead():
+    # Cheapest feasible hour is 13:00 (the trough); at 11:00 with edge 16:00 → hold.
+    slots = [_slot(11, 0.21), _slot(12, 0.17), _slot(13, 0.14), _slot(14, 0.18)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 16.0) == 13.0
+
+
+def test_price_release_now_when_current_is_cheapest():
+    slots = [_slot(11, 0.14), _slot(12, 0.17), _slot(13, 0.21)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 16.0) == 11.0
+
+
+def test_price_release_ignores_slots_past_edge():
+    # The 13:00 trough sits past the feasibility edge (12.5) → unreachable, so the
+    # cheapest *feasible* hour (12:00) wins. This is today's tight-solar shape: the
+    # edge precedes the trough, so the trough cannot be captured without risking SOC.
+    slots = [_slot(11, 0.21), _slot(12, 0.17), _slot(13, 0.14)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 12.5) == 12.0
+
+
+def test_price_release_epsilon_prefers_releasing_now():
+    # A negligibly-cheaper hour ahead (< 0.005 €/kWh) must not trigger a hold.
+    slots = [_slot(11, 0.150), _slot(13, 0.147)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 16.0) == 11.0
+
+
+def test_price_release_counts_current_partial_hour():
+    # Called mid-hour (11:30): the 11:00 slot still covers now and counts as current.
+    slots = [_slot(11, 0.14), _slot(12, 0.20)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.5, 16.0) == 11.5


### PR DESCRIPTION
Fixes #4.

On a day where forecast roughly equals consumption, the charge delay unlocked before sunrise (`reason: low_forecast`) and latched for the rest of the day, so the battery soaked morning PV at peak price instead of holding for the cheap midday hours.

Two compounding causes, both addressed:

**1. False deficit from the haircut.** The binary "is grid needed today?" gate applied the 0.85 scheduling haircut to the forecast, turning a balanced day (raw 15.76 kWh vs 15.40 kWh consumption) into a deficit. The gate now compares the *raw* forecast with a small deadband (`DELAY_BALANCE_DEADBAND_KWH = 0.5`); the haircut stays where it belongs, on the downstream energy-scheduling math. A near-balanced day keeps the delay armed.

**2. Pre-dawn unlock not price-aware.** A genuine deficit unlocked immediately, at whatever (often pre-dawn peak) price. It now holds until the cheapest import hour before solar is due, via `_low_forecast_price_release` reusing `_price_optimal_release_h`. Min-price-slot selection serves cheapest-import here exactly as it serves cheapest-export for the PV-surplus hold. Falls back to the legacy immediate unlock when no price data is available or no pre-solar slack remains.

Notes:
- **Depends on #12** (reuses its `_price_optimal_release_h` / `get_future_price_slots`). This PR is branched on top of #12, so until #12 merges the diff below also shows #12's changes; it auto-shrinks to just this commit once #12 lands. Please review/merge #12 first.
- Added 6 tests: deadband holds the balanced day; price-aware release holds for a cheaper hour, unlocks when now is cheapest / no price data / no pre-solar slack, and falls back to `T_START_FALLBACK_HOUR` when `T_start` is unknown. Full suite: 468 passed, 8 skipped.
