### PR TITLE
feat(charge-delay): score price-aware release over the whole charge window

### DIFF
--- a/custom_components/omnibattery/control/charge_delay.py
+++ b/custom_components/omnibattery/control/charge_delay.py
@@ -543,7 +543,10 @@ class ChargeDelayManager:
         # (teruglever) revenue. SOC target stays fully protected: the window never
         # extends past the edge, and the hard energy/time unlocks above remain the
         # floor. Degrades to legacy edge-release when no price data is available.
-        release_h = self._price_optimal_release_h(now_h, est_unlock_h)
+        # charge_time_h is passed so the scorer weights the WHOLE charge window, not
+        # just the starting slot (a cheap start followed by pricey hours can cost
+        # more export than a slightly dearer start sitting in a sustained trough).
+        release_h = self._price_optimal_release_h(now_h, est_unlock_h, charge_time_h)
         if release_h is not None:
             if now_h + 1e-6 < release_h:
                 # A cheaper feasible hour lies ahead, keep holding for it.
@@ -562,14 +565,24 @@ class ChargeDelayManager:
         status["state"] = f"Delayed ({status['estimated_unlock_time']} est.)"
         return True
 
-    def _price_optimal_release_h(self, now_h: float, edge_h: float) -> float | None:
-        """Cheapest export hour to begin charging within [now_h, edge_h].
+    def _price_optimal_release_h(
+        self, now_h: float, edge_h: float, charge_h: float | None = None
+    ) -> float | None:
+        """Cheapest hour to begin charging within [now_h, edge_h].
 
-        Returns the start hour (float, today) of the lowest-priced price slot whose
-        start lies in the still-feasible window. Returns ``now_h`` when the current
-        slot is itself the cheapest (within a small epsilon, so we never hold for a
-        negligible gain). Returns ``None`` when no usable price data exists, in
-        which case the caller keeps the legacy edge-release behaviour.
+        Returns the start hour (float, today) of the lowest-priced feasible start.
+        Returns ``now_h`` when the current moment is itself the cheapest (within a
+        small epsilon, so we never hold for a negligible gain). Returns ``None``
+        when no usable price data exists, in which case the caller keeps the legacy
+        edge-release behaviour.
+
+        When ``charge_h`` is given (> 0) each candidate start is scored by the
+        duration-weighted AVERAGE price over the whole charge window
+        ``[start, start+charge_h]``, so the charge lands in the cheapest *sustained*
+        block rather than merely starting in the cheapest single slot. A start whose
+        window runs past the available price data is skipped (an incomplete tail
+        must not score as artificially cheap). Without ``charge_h`` the score is the
+        single slot price (legacy behaviour).
 
         This only ever moves the release EARLIER than the feasibility edge; it never
         defers past it, so the SOC-target safety margin enforced upstream is intact.
@@ -588,23 +601,65 @@ class ChargeDelayManager:
         if not slots:
             return None
 
-        candidates = []  # (start_hour, price)
-        cur_price = None
+        def _score(start_h):
+            """Window-average price for a charge starting at ``start_h`` (or the
+            single covering-slot price when no charge length is known)."""
+            if charge_h and charge_h > 0:
+                return self._window_avg_price(start_h, charge_h, slots)
+            for s in slots:
+                s_h = s.start.hour + s.start.minute / 60.0
+                s_end = s_h + (s.end - s.start).total_seconds() / 3600.0
+                if s_h - 1e-9 <= start_h < s_end:
+                    return s.price
+            return None
+
+        candidates = []  # (start_hour, score)
+        has_current = False
         for s in slots:
             s_h = s.start.hour + s.start.minute / 60.0
             if s_h > edge_h + 1e-6:  # slot starts after the feasibility edge
                 continue
-            candidates.append((s_h, s.price))
-            if s_h <= now_h + 1e-9:  # slot covering the current moment
-                cur_price = s.price
+            score = _score(s_h)
+            if score is None:  # window runs past available price data — unscorable
+                continue
+            candidates.append((s_h, score))
+            if s_h <= now_h + 1e-9:  # a slot covers the current moment
+                has_current = True
         if not candidates:
             return None
 
         eps = 0.005  # EUR/kWh: ignore sub-cent differences, prefer releasing sooner
         best_h, best_p = min(candidates, key=lambda c: (c[1], c[0]))
-        if cur_price is not None and cur_price <= best_p + eps:
-            return now_h
+        if has_current:
+            cur_score = _score(now_h)  # window starting at the current moment
+            if cur_score is not None and cur_score <= best_p + eps:
+                return now_h
         return best_h
+
+    @staticmethod
+    def _window_avg_price(start_h: float, charge_h: float, slots: list) -> float | None:
+        """Duration-weighted average slot price over [start_h, start_h+charge_h].
+
+        Returns ``None`` when the window is not fully covered by the available
+        slots (an incomplete forecast tail, or a window crossing midnight past the
+        today-only slot set), so the caller skips that start rather than scoring a
+        partial — and therefore artificially cheap — window.
+        """
+        if charge_h <= 0:
+            return None
+        end_h = start_h + charge_h
+        cost = 0.0
+        covered = 0.0
+        for s in slots:
+            s_h = s.start.hour + s.start.minute / 60.0
+            s_end = s_h + (s.end - s.start).total_seconds() / 3600.0
+            overlap = min(end_h, s_end) - max(start_h, s_h)
+            if overlap > 0:
+                cost += s.price * overlap
+                covered += overlap
+        if covered < charge_h - 1e-6:
+            return None
+        return cost / charge_h
 
     def _low_forecast_price_release(self, now_h: float) -> bool:
         """Hold a genuine grid-deficit day until its cheapest import hour.

--- a/tests/test_charge_delay.py
+++ b/tests/test_charge_delay.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from datetime import date
 from types import SimpleNamespace
 
+import pytest
+
 from custom_components.omnibattery.control.charge_delay import (
     ChargeDelayManager,
     _TRANSIENT_UNLOCK_REASONS,
@@ -569,3 +571,59 @@ def test_price_release_counts_current_partial_hour():
     slots = [_slot(11, 0.14), _slot(12, 0.20)]
     mgr = _make_mgr(_price_ctrl(slots))
     assert mgr._price_optimal_release_h(11.5, 16.0) == 11.5
+
+
+# ----------------------------------------------------------------------
+# _price_optimal_release_h with charge_h: window-average (sustained-trough) scoring
+# ----------------------------------------------------------------------
+
+
+def test_window_avg_price_basic():
+    # Two-hour charge from 11:00 averages the 11:00 and 12:00 slots.
+    slots = [_slot(11, 0.10), _slot(12, 0.20)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._window_avg_price(11.0, 2.0, slots) == pytest.approx(0.15)
+
+
+def test_window_avg_price_partial_overlap():
+    # A 1h charge starting mid-slot (11:30) spans half of 11:00 and half of 12:00.
+    slots = [_slot(11, 0.10), _slot(12, 0.30)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._window_avg_price(11.5, 1.0, slots) == pytest.approx(0.20)
+
+
+def test_window_avg_price_none_on_incomplete_tail():
+    # The window runs past the last slot → unscorable (must not look cheap).
+    slots = [_slot(11, 0.10), _slot(12, 0.20)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._window_avg_price(11.0, 3.0, slots) is None
+
+
+def test_window_release_prefers_sustained_trough_over_cheap_start():
+    # Single-slot scoring would pick 11:00 (the lone cheapest slot), but the
+    # following hour is dear; the sustained trough at 13:00-15:00 is cheaper across
+    # the whole 2h charge, so the window scorer holds for 13:00.
+    slots = [
+        _slot(11, 0.10), _slot(12, 0.30), _slot(13, 0.16),
+        _slot(14, 0.16), _slot(15, 0.30),
+    ]
+    mgr = _make_mgr(_price_ctrl(slots))
+    # Legacy single-slot behaviour (no charge_h) still picks the lone cheap start.
+    assert mgr._price_optimal_release_h(11.0, 16.0) == 11.0
+    # Window-aware (2h charge) holds for the sustained trough.
+    assert mgr._price_optimal_release_h(11.0, 16.0, 2.0) == 13.0
+
+
+def test_window_release_skips_start_whose_window_exceeds_data():
+    # start=13 would need price data to 15:00 but the tail stops at 14:00, so 13 is
+    # skipped; the cheapest fully-scorable 2h window (12:00) wins.
+    slots = [_slot(11, 0.20), _slot(12, 0.10), _slot(13, 0.10)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 16.0, 2.0) == 12.0
+
+
+def test_window_release_now_when_current_window_cheapest():
+    # The charge starting now is the cheapest 2h window → release immediately.
+    slots = [_slot(11, 0.10), _slot(12, 0.10), _slot(13, 0.30), _slot(14, 0.30)]
+    mgr = _make_mgr(_price_ctrl(slots))
+    assert mgr._price_optimal_release_h(11.0, 16.0, 2.0) == 11.0


### PR DESCRIPTION
`_price_optimal_release_h` picks the single cheapest slot to start in. But the charge runs `charge_time_h` across several slots, so a cheap slot followed by expensive ones can lose more export than starting later in a flatter, actually cheaper stretch. 
Cheapest start != cheapest charge.

Fix: score each candidate start by the duration-weighted average over `[start, start+charge_h]`, so the whole charge lands in the cheapest sustained block. `charge_time_h` is already computed at the call site, just passed in.

## Notes for review:

- `_window_avg_price` does the overlap-weighted average. Window running off the  end of the slots returns `None` and skips that start (else a short incomplete tail looks fake-cheap and wins).
- `charge_h` is optional. The grid-deficit path (`_low_forecast_price_release`) has no defined charge duration, so it calls without it: old single-slot behaviour there is unchanged.
- SOC safety untouched: starts still can't pass the feasibility edge, hard energy/time unlocks stay the floor, release only moves earlier.

## Tests

Existing characterization tests pass unchanged. Added 6 covering `_window_avg_price` and the window-aware release. 477 passed, 8 skipped.