### PR TITLE
fix: Tibber dynamic pricing only fetched today's prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## [1.0.0b2] - 2026-06-30
+## [1.0.0b3] - 2026-07-01
 
 ### Fixed
+- **Tibber dynamic pricing only returned today's prices** (#21): `tibber.get_prices` without an explicit `end` defaults to today only, so tomorrow's already-published slots (available after ~13:00) were never fetched. The service call now requests through the day after tomorrow. [`pricing/engine.py`](custom_components/omnibattery/pricing/engine.py).
 - **Backup Function switch had no effect (all models)**: `REGISTER_MAP` was missing the `backup_function` key, so toggling the switch always silently failed. Added register 41200 for v2, v3, vA and vD. [`const/registers_common.py`](custom_components/omnibattery/const/registers_common.py).
 - **Lost RS485 control after a full charge now recovers without an HA restart**: a v3 that drops forced mode at the BMS full-charge cutoff ACKs a re-enable write over the existing socket but ignores it — only a fresh TCP connection makes it stick, which is why a restart was the only fix. The non-delivery recovery now reads the RS485 register back and, if the re-assert didn't take, reconnects fresh (the restart-equivalent) instead of leaving the battery uncontrolled. [`__init__.py`](custom_components/omnibattery/__init__.py), [`drivers/marstek.py`](custom_components/omnibattery/drivers/marstek.py).
 - **Battery kept exporting to grid after it dropped RS485 control (#434)**: when a v3 silently slipped out of forced mode (ACK ok, ~0 W delivered) the non-responsive recovery toggled RS485 *off* → on — but the *off* step hands control to the battery's internal logic, which can export to grid, and the 5-minute pool exclusion then left it running free. Recovery now re-asserts RS485 without the off step and forces standby, and a battery commanded idle while still moving power is re-pinned (RS485 re-asserted + a real standby write) instead of trusting its matching set-points. [`__init__.py`](custom_components/omnibattery/__init__.py).

--- a/custom_components/omnibattery/pricing/engine.py
+++ b/custom_components/omnibattery/pricing/engine.py
@@ -147,10 +147,13 @@ class PricingManager:
     async def _maybe_refresh_tibber_prices(self, *, force: bool = False) -> None:
         """Poll ``tibber.get_prices`` and cache the slots when stale.
 
-        Tibber has no price sensor; the service returns today's slots and, after
-        ~13:00, tomorrow's. Refreshes when the cache is empty, older than
-        ``TIBBER_REFRESH_MINUTES``, or when ``force`` (before each evaluation).
-        No-op for every other integration type.
+        Tibber has no price sensor. Without an explicit ``end``, the service
+        defaults to today only (start of today to start of tomorrow); tomorrow's
+        already-published slots (available after ~13:00) are only returned if
+        ``end`` reaches past tomorrow midnight, so ``end`` is requested as the
+        start of the day after tomorrow. Refreshes when the cache is empty,
+        older than ``TIBBER_REFRESH_MINUTES``, or when ``force`` (before each
+        evaluation). No-op for every other integration type.
         """
         if self._controller.price_integration_type != PRICE_INTEGRATION_TIBBER:
             return
@@ -169,9 +172,16 @@ class PricingManager:
             _LOGGER.warning("Dynamic pricing: tibber.get_prices service not available")
             return
 
+        from homeassistant.util import dt as dt_util
+
+        end = dt_util.start_of_local_day() + timedelta(days=2)
         try:
             response = await self._hass.services.async_call(
-                "tibber", "get_prices", {}, blocking=True, return_response=True
+                "tibber",
+                "get_prices",
+                {"end": end.isoformat()},
+                blocking=True,
+                return_response=True,
             )
         except Exception as exc:
             _LOGGER.warning("Dynamic pricing: tibber.get_prices call failed: %s", exc)

--- a/tests/test_pricing_engine.py
+++ b/tests/test_pricing_engine.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 from custom_components.omnibattery.const import (
     PRICE_INTEGRATION_CKW,
     PRICE_INTEGRATION_NORDPOOL,
+    PRICE_INTEGRATION_TIBBER,
     PREDICTIVE_MODE_DYNAMIC_PRICING,
     PREDICTIVE_MODE_REALTIME_PRICE,
     PREDICTIVE_MODE_TIME_SLOT,
@@ -274,4 +275,41 @@ def test_dp_discharge_floor_unset_falls_back_to_charge_ceiling():
     ctrl = _dp_band_controller(discharge_price_threshold=None)
     _mgr_with_price(ctrl, 0.25).apply_price_discharge_block()
     assert ctrl._removed == ["price_discharge"]
+
+
+# ----------------------------------------------------------------------
+# _maybe_refresh_tibber_prices (#21: default call only returns today)
+# ----------------------------------------------------------------------
+
+class _FakeTibberServices:
+    """Records ``async_call`` args; ``get_prices`` always reports available."""
+
+    def __init__(self):
+        self.calls: list = []
+
+    def has_service(self, domain, service):
+        return domain == "tibber" and service == "get_prices"
+
+    async def async_call(self, domain, service, data, blocking=True, return_response=True):
+        self.calls.append(data)
+        return {"prices": {}}
+
+
+def test_tibber_refresh_requests_through_day_after_tomorrow():
+    import asyncio
+    from homeassistant.util import dt as dt_util
+
+    services = _FakeTibberServices()
+    hass = SimpleNamespace(services=services)
+    ctrl = _controller(
+        price_integration_type=PRICE_INTEGRATION_TIBBER,
+        _tibber_price_slots=[],
+        _tibber_prices_fetched_at=None,
+    )
+
+    asyncio.run(PricingManager(hass, ctrl)._maybe_refresh_tibber_prices(force=True))
+
+    assert len(services.calls) == 1
+    end = dt_util.parse_datetime(services.calls[0]["end"])
+    assert end == dt_util.start_of_local_day() + timedelta(days=2)
     assert ctrl._price_based_discharge_blocked is False


### PR DESCRIPTION
tibber.get_prices without an explicit end defaults to today only, so tomorrow's already-published slots (available after ~13:00) were never requested. Pass end = start of the day after tomorrow.

Fixes #21