### PR TITLE
Add diagnostics and system health platforms

### DIFF
--- a/custom_components/omnibattery/diagnostics.py
+++ b/custom_components/omnibattery/diagnostics.py
@@ -1,0 +1,89 @@
+"""Diagnostics for Omnibattery config entries.
+
+Home Assistant calls :func:`async_get_config_entry_diagnostics` when the user
+presses *Download diagnostics* on the integration. It returns a JSON-serialisable
+dump of connection health, driver traits and non-responsive-tracker state
+(everything that otherwise lives only in transient logs), with host/serial and
+sensor entity ids redacted.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+# Identifiers and user sensor references that could deanonymise the dump.
+# async_redact_data recurses into nested dicts/lists, so per-battery "host"
+# entries inside a batteries list are covered too.
+TO_REDACT = {
+    "host",
+    "serial",
+    "serial_port",
+    "ip_address",
+    "mac",
+    "consumption_sensor",
+    "grid_sensor",
+    "solar_forecast_sensor",
+    "average_price_sensor",
+}
+
+
+def _driver_info(coordinator) -> dict[str, Any]:
+    """Static driver traits (no host/serial, which are identifiers)."""
+    driver = coordinator.driver
+    caps = coordinator.capabilities
+    return {
+        "connected": driver.connected,
+        "model_label": driver.model_label,
+        "capabilities": asdict(caps) if is_dataclass(caps) else str(caps),
+    }
+
+
+def _tracker_info(controller, coordinator) -> dict[str, Any]:
+    """Non-responsive exclusion state for one battery (side-effect free)."""
+    tracker = getattr(controller, "_non_responsive", None)
+    if tracker is None:
+        return {}
+    info = tracker.batteries.get(coordinator, {})
+    return {
+        # excluded_names() reads without mutating; is_excluded() would reset the
+        # fail counter on cooldown expiry, which a read-only dump must not do.
+        "excluded": coordinator.name in tracker.excluded_names(),
+        "fail_count": info.get("fail_count", 0),
+        "reason": info.get("reason"),
+        "retry_attempted": info.get("retry_attempted", False),
+        "wake_used": info.get("wake_used", False),
+    }
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return a redacted health/driver/tracker dump for one config entry."""
+    data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    coordinators = data.get("coordinators") or []
+    controller = data.get("controller")
+
+    batteries = [
+        {
+            "health": coord.health_snapshot(),
+            "driver": _driver_info(coord),
+            "tracker": _tracker_info(controller, coord),
+        }
+        for coord in coordinators
+    ]
+
+    return {
+        "entry": {
+            "title": entry.title,
+            "version": entry.version,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": async_redact_data(dict(entry.options), TO_REDACT),
+        },
+        "batteries": batteries,
+    }

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -200,9 +200,18 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         self._max_failures_before_suspend = 5     # Suspend after 5 failed poll cycles
         self._is_connected = False
         self._suspension_reset_time = None         # When suspended, retry after this time
+        # Reason string of the most recent failed control write (set in the write
+        # path, surfaced by health_snapshot / diagnostics). Initialised here so a
+        # read before the first write returns None rather than raising.
+        self._last_write_failure_reason = None
 
         # Timestamp-based update tracking
         self._last_update_times = {}
+        # Last-written select values that override buggy register readbacks.
+        # Repopulated from persisted battery_config after construction; initialised
+        # here so get_shadow_select before that assignment returns None instead of
+        # raising AttributeError.
+        self._shadow_selects = {}
         self._entity_registry = None
         self.rs485_user_disabled = False  # Set by RS485 switch when user explicitly disables
         self._config_entry = None  # Set after creation to allow persisting rs485_user_disabled
@@ -446,6 +455,36 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
     def get_shadow_select(self, key: str) -> int | None:
         """Return the last-written value for a shadowed select, or None."""
         return self._shadow_selects.get(key)
+
+    def health_snapshot(self) -> dict:
+        """Point-in-time connection-health state for diagnostics / system_health.
+
+        A read-only view of the failure ladder and poll bookkeeping, keyed by
+        plain serialisable values so the diagnostics platform can dump it without
+        reaching into driver internals. Consumed by both ``diagnostics.py`` and
+        ``system_health.py`` so the two never diverge.
+        """
+        def _iso(value):
+            return value.isoformat() if hasattr(value, "isoformat") else value
+
+        return {
+            "name": self.name,
+            "brand": self.brand,
+            "battery_version": self.battery_version,
+            "connected": self._is_connected,
+            "available": self.is_available,
+            "shutting_down": self._is_shutting_down,
+            "consecutive_failures": self._consecutive_failures,
+            "max_failures_before_reconnect": self._max_failures_before_reconnect,
+            "max_failures_before_suspend": self._max_failures_before_suspend,
+            "suspended": self._suspension_reset_time is not None,
+            "suspension_reset_time": _iso(self._suspension_reset_time),
+            "last_write_failure_reason": self._last_write_failure_reason,
+            "last_update_times": {
+                ",".join(keys): _iso(ts)
+                for keys, ts in self._last_update_times.items()
+            },
+        }
 
     async def _async_update_data(self) -> dict:
         """Update all sensors asynchronously with per-sensor interval skipping.

--- a/custom_components/omnibattery/system_health.py
+++ b/custom_components/omnibattery/system_health.py
@@ -1,0 +1,52 @@
+"""System-health summary for Omnibattery.
+
+Shown in Settings → System → Repairs (system health card). A compact
+at-a-glance counterpart to the full diagnostics dump: how many batteries are
+connected, how many are suspended by the failure ladder, and how many are
+currently excluded as non-responsive. Reuses each coordinator's
+``health_snapshot`` so it never diverges from the diagnostics view.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components import system_health
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
+
+
+def _entry_datas(hass: HomeAssistant):
+    """Yield the per-config-entry data dicts, skipping registration flags."""
+    for value in hass.data.get(DOMAIN, {}).values():
+        if isinstance(value, dict) and "coordinators" in value:
+            yield value
+
+
+@callback
+def async_register(
+    hass: HomeAssistant, register: system_health.SystemHealthRegistration
+) -> None:
+    """Register the system-health info callback."""
+    register.async_register_info(_async_system_health_info)
+
+
+async def _async_system_health_info(hass: HomeAssistant) -> dict[str, Any]:
+    """Return the summary counters shown on the system-health card."""
+    coordinators = [c for d in _entry_datas(hass) for c in (d.get("coordinators") or [])]
+
+    total = len(coordinators)
+    connected = sum(1 for c in coordinators if c.is_available)
+    suspended = sum(1 for c in coordinators if c.health_snapshot()["suspended"])
+
+    non_responsive: set[str] = set()
+    for data in _entry_datas(hass):
+        tracker = getattr(data.get("controller"), "_non_responsive", None)
+        if tracker is not None:
+            non_responsive.update(tracker.excluded_names())
+
+    return {
+        "batteries_connected": f"{connected}/{total}",
+        "suspended": suspended,
+        "non_responsive": len(non_responsive),
+    }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,154 @@
+"""Tests for the diagnostics platform and the coordinator health snapshot.
+
+Pure-unit: no ``hass`` fixture, no real Modbus. The coordinator's
+``health_snapshot`` is exercised by calling the unbound method against a
+duck-typed stub (it only reads attributes), and the diagnostics assembly is
+driven with stub coordinators plus a real NonResponsiveTracker.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.omnibattery import diagnostics
+from custom_components.omnibattery.const import DOMAIN
+from custom_components.omnibattery.drivers import DriverCapabilities
+from custom_components.omnibattery.infra.coordinator import (
+    MarstekVenusDataUpdateCoordinator,
+)
+from custom_components.omnibattery.tracking.non_responsive_tracker import (
+    NonResponsiveTracker,
+)
+
+
+class _FakeDatetime:
+    def __init__(self, iso: str) -> None:
+        self._iso = iso
+
+    def isoformat(self) -> str:
+        return self._iso
+
+
+def _make_caps() -> DriverCapabilities:
+    return DriverCapabilities(
+        hardware_soc_cutoff=False,
+        has_force_mode=True,
+        push_telemetry=False,
+        max_charge_power_w=2500,
+        max_discharge_power_w=2500,
+        has_mppt_pv=False,
+        has_alarm_registers=True,
+        has_rs485_control=True,
+    )
+
+
+def test_health_snapshot_serialises_ladder_fields():
+    fake = SimpleNamespace(
+        name="Battery 1",
+        brand="marstek",
+        battery_version="v3",
+        _is_connected=True,
+        is_available=True,
+        _is_shutting_down=False,
+        _consecutive_failures=2,
+        _max_failures_before_reconnect=3,
+        _max_failures_before_suspend=5,
+        _suspension_reset_time=_FakeDatetime("2026-07-02T22:00:00+00:00"),
+        _last_write_failure_reason="driver_exception",
+        _last_update_times={("battery_soc", "battery_power"): _FakeDatetime("2026-07-02T21:59:00+00:00")},
+    )
+
+    snap = MarstekVenusDataUpdateCoordinator.health_snapshot(fake)
+
+    assert snap["name"] == "Battery 1"
+    assert snap["consecutive_failures"] == 2
+    assert snap["suspended"] is True
+    assert snap["suspension_reset_time"] == "2026-07-02T22:00:00+00:00"
+    assert snap["last_write_failure_reason"] == "driver_exception"
+    # tuple group key is joined into a single serialisable string
+    assert snap["last_update_times"] == {
+        "battery_soc,battery_power": "2026-07-02T21:59:00+00:00"
+    }
+
+
+def test_health_snapshot_not_suspended_when_no_reset_time():
+    fake = SimpleNamespace(
+        name="B", brand="zendure", battery_version="v2",
+        _is_connected=False, is_available=False, _is_shutting_down=False,
+        _consecutive_failures=0, _max_failures_before_reconnect=3,
+        _max_failures_before_suspend=5, _suspension_reset_time=None,
+        _last_write_failure_reason=None, _last_update_times={},
+    )
+    snap = MarstekVenusDataUpdateCoordinator.health_snapshot(fake)
+    assert snap["suspended"] is False
+    assert snap["suspension_reset_time"] is None
+
+
+class _StubCoordinator:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.driver = SimpleNamespace(connected=True, model_label="Venus v3")
+        self.capabilities = _make_caps()
+
+    def health_snapshot(self) -> dict:
+        return {"name": self.name, "connected": True, "suspended": False}
+
+
+async def test_diagnostics_dump_structure_and_redaction():
+    coord = _StubCoordinator("Battery 1")
+    tracker = NonResponsiveTracker(fail_threshold=3)
+    # Drive it to exclusion (comm failures take no wake-grace round).
+    for _ in range(3):
+        tracker.record_comm_failure(coord, "feedback_timeout")
+    controller = SimpleNamespace(_non_responsive=tracker)
+
+    entry = SimpleNamespace(
+        entry_id="abc",
+        title="Omnibattery",
+        version=9,
+        data={"host": "192.168.1.50", "consumption_sensor": "sensor.grid", "brand": "marstek"},
+        options={},
+    )
+    hass = SimpleNamespace(
+        data={DOMAIN: {"abc": {"coordinators": [coord], "controller": controller}}}
+    )
+
+    result = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["entry"]["data"]["host"] == "**REDACTED**"
+    assert result["entry"]["data"]["consumption_sensor"] == "**REDACTED**"
+    assert result["entry"]["data"]["brand"] == "marstek"  # non-sensitive kept
+
+    battery = result["batteries"][0]
+    assert battery["health"]["name"] == "Battery 1"
+    assert battery["driver"]["model_label"] == "Venus v3"
+    assert battery["driver"]["capabilities"]["max_charge_power_w"] == 2500
+    assert battery["tracker"]["excluded"] is True
+    assert battery["tracker"]["reason"] == "feedback_timeout"
+
+
+async def test_diagnostics_read_is_side_effect_free():
+    """The dump must not reset tracker state (no is_excluded call)."""
+    coord = _StubCoordinator("Battery 1")
+    tracker = NonResponsiveTracker(fail_threshold=3)
+    for _ in range(3):
+        tracker.record_comm_failure(coord, "feedback_timeout")
+    controller = SimpleNamespace(_non_responsive=tracker)
+    entry = SimpleNamespace(entry_id="abc", title="t", version=9, data={}, options={})
+    hass = SimpleNamespace(
+        data={DOMAIN: {"abc": {"coordinators": [coord], "controller": controller}}}
+    )
+
+    await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    # fail_count untouched, still excluded
+    assert tracker.batteries[coord]["fail_count"] == 3
+    assert coord.name in tracker.excluded_names()
+
+
+async def test_diagnostics_handles_missing_entry_data():
+    entry = SimpleNamespace(entry_id="missing", title="t", version=9, data={}, options={})
+    hass = SimpleNamespace(data={DOMAIN: {}})
+    result = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+    assert result["batteries"] == []


### PR DESCRIPTION
Two read-only platforms to see why a battery misbehaves without digging through logs.

**Diagnostics** (per entry, per battery): connection-health ladder (failures, reconnect/suspend thresholds, suspension state, last write-failure reason, poll times), driver capabilities, non-responsive tracker state. Host/serial/sensor-ids redacted.

**System health card**: batteries connected, suspended count, non-responsive count.

Both read one new `coordinator.health_snapshot()`, so they cannot drift.

Drive-by: init `_shadow_selects` (was set via external `setattr`, so an early `get_shadow_select()` raised `AttributeError`) and `_last_write_failure_reason` (written but never read) in `__init__`.

No manifest change (auto-discovered). Diagnostics read is side-effect free. Tests: new `test_diagnostics.py` (5), full suite 537 passed / 10 skipped, no regressions.