### PR TITLE
Fix modbus backoff jitter clock source, add retry tests

### DIFF
--- a/custom_components/omnibattery/infra/modbus_client.py
+++ b/custom_components/omnibattery/infra/modbus_client.py
@@ -8,6 +8,7 @@ from pymodbus.client import AsyncModbusTcpClient, AsyncModbusSerialClient
 from pymodbus.exceptions import ConnectionException, ModbusIOException
 import asyncio
 import inspect
+import time
 from typing import Optional
 
 import logging
@@ -15,6 +16,17 @@ import logging
 from ..const import DEBUG_RAW_MODBUS_READS, SERIAL_BAUDRATE
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _backoff_jitter(delay: float) -> float:
+    """Return a symmetric +/-10% jitter for a retry backoff delay.
+
+    Entropy comes from time.monotonic() rather than
+    asyncio.get_event_loop().time(); the latter reaches into loop internals and
+    is a deprecated access pattern. Precision is irrelevant: the jitter only
+    de-syncs concurrent retriers so they don't all wake on the same tick.
+    """
+    return delay * 0.1 * (0.5 - time.monotonic() % 1)
 
 
 def _marstek_v3_packet_correction(sending: bool, data: bytes) -> bytes:
@@ -218,8 +230,8 @@ class MarstekModbusClient:
                     result = self.client.close()
                     if asyncio.iscoroutine(result):
                         await result
-                except Exception:
-                    pass
+                except Exception as e:
+                    _LOGGER.debug("Error closing stale Modbus client before reconnect: %s", e)
 
                 # v3 firmware exposes a single TCP slot and does not free it
                 # instantly on close. Reopening immediately gets refused, so the
@@ -382,8 +394,7 @@ class MarstekModbusClient:
             attempt += 1
             if attempt < max_retries:
                 # Exponential backoff with jitter
-                jitter = current_retry_delay * 0.1 * (0.5 - asyncio.get_event_loop().time() % 1)
-                await asyncio.sleep(current_retry_delay + jitter)
+                await asyncio.sleep(current_retry_delay + _backoff_jitter(current_retry_delay))
                 current_retry_delay = min(current_retry_delay * 2, 5.0)  # Cap at 5 seconds
 
         _LOGGER.debug(
@@ -508,8 +519,7 @@ class MarstekModbusClient:
             attempt += 1
             if attempt < max_retries:
                 # Exponential backoff with jitter
-                jitter = current_retry_delay * 0.1 * (0.5 - asyncio.get_event_loop().time() % 1)
-                await asyncio.sleep(current_retry_delay + jitter)
+                await asyncio.sleep(current_retry_delay + _backoff_jitter(current_retry_delay))
                 current_retry_delay = min(current_retry_delay * 2, 5.0)  # Cap at 5 seconds
 
         _LOGGER.debug(

--- a/tests/test_alarm_notifier.py
+++ b/tests/test_alarm_notifier.py
@@ -1,0 +1,75 @@
+"""Tests for AlarmNotifier: notify on new bits, dismiss on all-clear, severity.
+
+First coverage for this module. A fake hass captures persistent_notification
+service calls; no HA runtime needed.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from custom_components.omnibattery.infra.alarm_notifier import AlarmNotifier
+
+
+class _FakeServices:
+    def __init__(self):
+        self.calls = []
+
+    async def async_call(self, domain, service, data):
+        self.calls.append((domain, service, data))
+
+
+class _FakeHass:
+    def __init__(self):
+        self.services = _FakeServices()
+
+
+def _notifier():
+    hass = _FakeHass()
+    return hass, AlarmNotifier(hass, "Battery 1")
+
+
+def test_new_fault_bit_creates_notification():
+    hass, n = _notifier()
+    asyncio.run(n.check(alarm_status=0, fault_status=0b1))
+    assert len(hass.services.calls) == 1
+    domain, service, data = hass.services.calls[0]
+    assert (domain, service) == ("persistent_notification", "create")
+    assert "Fault" in data["title"]
+
+
+def test_new_alarm_bit_only_is_a_warning():
+    hass, n = _notifier()
+    asyncio.run(n.check(alarm_status=0b1, fault_status=0))
+    domain, service, data = hass.services.calls[0]
+    assert (domain, service) == ("persistent_notification", "create")
+    assert "Warning" in data["title"]
+
+
+def test_unchanged_bits_do_not_renotify():
+    hass, n = _notifier()
+    asyncio.run(n.check(0, 0b1))
+    asyncio.run(n.check(0, 0b1))  # same bit still set -> no new bits
+    assert len(hass.services.calls) == 1
+
+
+def test_all_clear_dismisses_notification():
+    hass, n = _notifier()
+    asyncio.run(n.check(0, 0b1))          # raise
+    asyncio.run(n.check(0, 0))            # clear
+    assert len(hass.services.calls) == 2
+    domain, service, data = hass.services.calls[1]
+    assert (domain, service) == ("persistent_notification", "dismiss")
+
+
+def test_no_bits_ever_set_is_silent():
+    hass, n = _notifier()
+    asyncio.run(n.check(0, 0))
+    assert hass.services.calls == []
+
+
+def test_additional_new_bit_renotifies():
+    hass, n = _notifier()
+    asyncio.run(n.check(0, 0b01))         # first fault
+    asyncio.run(n.check(0, 0b11))         # a second fault bit appears
+    assert len(hass.services.calls) == 2
+    assert hass.services.calls[1][1] == "create"

--- a/tests/test_modbus_client_retry.py
+++ b/tests/test_modbus_client_retry.py
@@ -1,0 +1,196 @@
+"""Retry/backoff and no-self-reconnect behaviour of the Modbus read/write loops.
+
+Exercises ``_read_raw`` and ``async_write_register`` against a scripted fake
+pymodbus client (no hardware, no HA). These pin two deliberate properties that
+had no coverage: the same-connection retry loop, and that a connection error
+does NOT trigger a reconnect from inside the loop (the coordinator owns
+reconnection; reconnecting here would storm the v3 single TCP slot, issue #361).
+
+``retry_delay=0`` keeps the backoff sleeps at zero so the tests run instantly.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pymodbus.exceptions import ConnectionException
+
+from custom_components.omnibattery.infra.modbus_client import (
+    MarstekModbusClient,
+    _backoff_jitter,
+)
+
+
+class _Result:
+    def __init__(self, registers=None, error=False):
+        self.registers = registers
+        self._error = error
+
+    def isError(self):
+        return self._error
+
+
+class _FakeClient:
+    """Scripted pymodbus stand-in: pops a queued result/exception per call."""
+
+    def __init__(self, read_results=None, write_results=None):
+        self._reads = list(read_results or [])
+        self._writes = list(write_results or [])
+        self.read_calls = 0
+        self.write_calls = 0
+        self.connect_calls = 0
+        self.close_calls = 0
+
+    async def read_holding_registers(self, address, count, **kwargs):
+        self.read_calls += 1
+        item = self._reads.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def write_register(self, address, value, **kwargs):
+        self.write_calls += 1
+        item = self._writes.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def connect(self):
+        self.connect_calls += 1
+        return True
+
+    def close(self):
+        self.close_calls += 1
+
+
+def _client_with_fake(fake: _FakeClient, **kwargs) -> MarstekModbusClient:
+    async def _build():
+        c = MarstekModbusClient(host="192.168.1.50", port=502, message_wait_ms=0, **kwargs)
+        c.client = fake
+        c._message_wait_sec = 0.0
+        return c
+    return asyncio.run(_build())
+
+
+# ---------------------------------------------------------------- read path
+def test_read_success_returns_registers():
+    fake = _FakeClient(read_results=[_Result([1, 2])])
+    c = _client_with_fake(fake)
+    regs = asyncio.run(c._read_raw(0x0000, 2, retry_delay=0))
+    assert regs == [1, 2]
+    assert fake.read_calls == 1
+
+
+def test_read_retries_on_connection_error_then_succeeds():
+    fake = _FakeClient(read_results=[ConnectionException("boom"), _Result([5])])
+    c = _client_with_fake(fake)
+    regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
+    assert regs == [5]
+    assert fake.read_calls == 2
+
+
+def test_read_timeout_is_retried():
+    fake = _FakeClient(read_results=[asyncio.TimeoutError(), _Result([9])])
+    c = _client_with_fake(fake)
+    regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
+    assert regs == [9]
+    assert fake.read_calls == 2
+
+
+def test_read_error_result_is_retried():
+    fake = _FakeClient(read_results=[_Result(error=True), _Result([7])])
+    c = _client_with_fake(fake)
+    regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
+    assert regs == [7]
+    assert fake.read_calls == 2
+
+
+def test_read_short_read_is_rejected_and_retried():
+    # Every attempt returns one word for a two-word read -> incomplete, never accepted.
+    fake = _FakeClient(read_results=[_Result([1]), _Result([1]), _Result([1])])
+    c = _client_with_fake(fake)
+    regs = asyncio.run(c._read_raw(0x0010, 2, max_retries=3, retry_delay=0))
+    assert regs is None
+    assert fake.read_calls == 3
+
+
+def test_read_all_attempts_fail_returns_none():
+    fake = _FakeClient(read_results=[ConnectionException()] * 3)
+    c = _client_with_fake(fake)
+    regs = asyncio.run(c._read_raw(0x0010, 1, max_retries=3, retry_delay=0))
+    assert regs is None
+    assert fake.read_calls == 3
+
+
+def test_read_does_not_self_reconnect_on_failure():
+    """A failed read must not tear down / rebuild the connection (issue #361)."""
+    fake = _FakeClient(read_results=[ConnectionException()] * 3)
+    c = _client_with_fake(fake)
+    asyncio.run(c._read_raw(0x0010, 1, max_retries=3, retry_delay=0))
+    assert fake.connect_calls == 0
+    assert fake.close_calls == 0
+
+
+def test_read_stops_immediately_when_shutting_down():
+    fake = _FakeClient(read_results=[ConnectionException(), _Result([1])])
+    c = _client_with_fake(fake)
+    c._is_shutting_down = True
+    regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
+    assert regs is None
+    assert fake.read_calls == 1  # no retry once shutting down
+
+
+def test_read_invalid_register_returns_none_without_io():
+    fake = _FakeClient()
+    c = _client_with_fake(fake)
+    assert asyncio.run(c._read_raw(0x1_0000, 1, retry_delay=0)) is None
+    assert fake.read_calls == 0
+
+
+def test_read_invalid_count_returns_none_without_io():
+    fake = _FakeClient()
+    c = _client_with_fake(fake)
+    assert asyncio.run(c._read_raw(0x0000, 200, retry_delay=0)) is None
+    assert fake.read_calls == 0
+
+
+# --------------------------------------------------------------- write path
+def test_write_success_returns_true():
+    fake = _FakeClient(write_results=[_Result(error=False)])
+    c = _client_with_fake(fake)
+    assert asyncio.run(c.async_write_register(0x2000, 1, retry_delay=0)) is True
+    assert fake.write_calls == 1
+
+
+def test_write_retries_on_connection_error_then_succeeds():
+    fake = _FakeClient(write_results=[ConnectionException(), _Result(error=False)])
+    c = _client_with_fake(fake)
+    assert asyncio.run(c.async_write_register(0x2000, 1, retry_delay=0)) is True
+    assert fake.write_calls == 2
+
+
+def test_write_error_result_returns_false_without_retry():
+    # A protocol-level error result is a definitive answer, not a comms failure.
+    fake = _FakeClient(write_results=[_Result(error=True)])
+    c = _client_with_fake(fake)
+    assert asyncio.run(c.async_write_register(0x2000, 1, max_retries=3, retry_delay=0)) is False
+    assert fake.write_calls == 1
+
+
+def test_write_all_attempts_fail_returns_false_no_reconnect():
+    fake = _FakeClient(write_results=[ConnectionException()] * 3)
+    c = _client_with_fake(fake)
+    assert asyncio.run(c.async_write_register(0x2000, 1, max_retries=3, retry_delay=0)) is False
+    assert fake.write_calls == 3
+    assert fake.connect_calls == 0
+    assert fake.close_calls == 0
+
+
+# ------------------------------------------------------------------- jitter
+@pytest.mark.parametrize("delay", [0.1, 0.5, 1.0, 5.0])
+def test_backoff_jitter_bounded_to_five_percent(delay):
+    # Symmetric +/-10% * 0.5 amplitude -> magnitude never exceeds 5% of the delay,
+    # so delay + jitter stays strictly positive.
+    j = _backoff_jitter(delay)
+    assert abs(j) <= 0.05 * delay
+    assert delay + j > 0


### PR DESCRIPTION
The retry backoff jitter read `asyncio.get_event_loop().time()`, a deprecated loop-internals access pattern, in both the read and write loops. Extracted a single `_backoff_jitter()` helper seeded from `time.monotonic()` and called from both sites. Same `+/-5%-of-delay` formula, no behaviour change.

Also replaced the bare `except Exception: pass` around the pre-reconnect client close with a debug log, so a close failure is no longer completely invisible.

First coverage for two paths that had none:

- `test_modbus_client_retry.py`: `_read_raw` and `async_write_register` retry/backoff, timeout and error-result retry, short-read rejection, invalid-arg guards, shutdown fast-exit, and that a connection error does not self-reconnect from inside the loop (coordinator owns reconnection, issue #361).
- `test_alarm_notifier.py`: notify on new bits, dismiss on all-clear, no re-notify on unchanged bits, fault-vs-warning severity.

Full suite: 556 passed / 10 skipped.