### PR TITLE
fix: honest predictive-charging notification for floor-driven charge (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Predictive-charging notification quoted nonsense grid/solar numbers** (#46): on a floor-driven charge (SOC below the guaranteed-min-SOC target) the "STARTED" notification showed `Grid: 0.00 kWh` while claiming solar would charge a figure larger than the battery. It now reports the grid deficit needed to reach the floor, and `solar_surplus_kwh` is capped at battery headroom. [`__init__.py`](custom_components/omnibattery/__init__.py), [`pricing/notifications.py`](custom_components/omnibattery/pricing/notifications.py).
+
 ## [1.0.0b4] - 2026-07-02
 
 ### Added

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -2597,7 +2597,10 @@ class ChargeDischargeController:
         _max_soc_values = [c.max_soc for c in coordinators_with_data]
         _config_max_soc = min(_max_soc_values) if _max_soc_values else 95
         _gap_to_max_kwh = max(0.0, (_config_max_soc - avg_soc) / 100.0 * total_capacity_kwh)
-        solar_surplus_kwh = max(0.0, solar_forecast_kwh - avg_consumption_kwh)
+        # Cap at battery headroom: only this much solar can actually land in the
+        # battery, so the "solar will charge the remaining X" line can't quote a
+        # figure larger than the pack (e.g. 12.94 kWh into a 5.12 kWh battery).
+        solar_surplus_kwh = max(0.0, min(solar_forecast_kwh - avg_consumption_kwh, _gap_to_max_kwh))
         _grid_margin_factor = 1.0 + self._predictive_grid_charge_margin_pct / 100.0
         grid_charge_kwh = min(
             _gap_to_max_kwh,
@@ -2619,6 +2622,7 @@ class ChargeDischargeController:
             "days_in_history": days_in_history,
             "solar_surplus_kwh": solar_surplus_kwh,
             "grid_charge_kwh": grid_charge_kwh,
+            "floor_active": floor_active,
             "consumption_source": "derived (grid + battery AC + solar)",
             "reason": (
                 f"Guaranteed minimum SOC: charging {energy_deficit_kwh:.2f} kWh "

--- a/custom_components/omnibattery/pricing/notifications.py
+++ b/custom_components/omnibattery/pricing/notifications.py
@@ -90,8 +90,17 @@ def format_predictive_notification_message(
 
     grid_charge = decision_data.get("grid_charge_kwh")
     solar_surplus = decision_data.get("solar_surplus_kwh")
-    if grid_charge is not None and solar_surplus is not None:
-        # When charging triggers, solar_surplus ≤ gap_to_max, so solar will contribute exactly solar_surplus to battery
+    if decision_data.get("floor_active"):
+        # Charge is driven by the guaranteed-minimum-SOC floor, not the daily
+        # energy balance. The floor charge happens whenever SOC is low (often
+        # overnight, before solar ramps), so the day's solar surplus can't be
+        # credited against it — the whole deficit comes from the grid.
+        charge_split_line = (
+            f"🔌 Grid: {energy_deficit:.2f} kWh to reach guaranteed minimum SOC\n"
+        )
+    elif grid_charge is not None and solar_surplus is not None:
+        # solar_surplus is capped at battery headroom, so it's the amount solar
+        # can actually add; grid covers the rest of the gap.
         charge_split_line = (
             f"🔌 Grid: {grid_charge:.2f} kWh — solar will charge the remaining {solar_surplus:.2f} kWh\n"
         )

--- a/tests/test_pricing_notifications.py
+++ b/tests/test_pricing_notifications.py
@@ -84,6 +84,28 @@ def test_predictive_started():
     assert "ICP: 5000W, batteries: 3000W" in message
 
 
+def test_predictive_floor_charge_reports_grid_deficit_not_solar():
+    # Issue #46: floor-driven charge on a solar-positive day. grid_charge_kwh
+    # computes to 0 and solar_surplus is large, but the battery really charges
+    # energy_deficit from the grid to reach the floor. Notification must say so
+    # and must not claim solar covers it.
+    title, message = notifications.format_predictive_notification_message(
+        _decision(
+            should_charge=True,
+            solar_forecast_kwh=29.61,
+            avg_consumption_kwh=16.67,
+            energy_deficit_kwh=0.67,
+            grid_charge_kwh=0.0,
+            solar_surplus_kwh=3.74,
+            floor_active=True,
+        ),
+        **_CFG,
+    )
+    assert title == "Predictive Charging: STARTED"
+    assert "Grid: 0.67 kWh to reach guaranteed minimum SOC" in message
+    assert "solar will charge the remaining" not in message
+
+
 def test_predictive_daily_evaluation_expected():
     title, _ = notifications.format_predictive_notification_message(
         _decision(should_charge=True, energy_deficit_kwh=2.0), True, **_CFG


### PR DESCRIPTION
Fixes #46.

## Problem
On a floor-driven charge (SOC below the guaranteed-min-SOC target) the "STARTED" notification showed `Grid: 0.00 kWh` while claiming solar would charge a figure larger than the battery (12.94 kWh into a 5.12 kWh pack).

Root cause: the grid/solar split came from the **daily energy balance**, which credited the whole day's solar surplus even though the floor charge runs overnight from the grid. So `solar_surplus_kwh` was uncapped (`solar_forecast − consumption`) and `grid_charge_kwh` computed to 0, contradicting the actual overnight grid charge.

## Fix
- Cap `solar_surplus_kwh` at battery headroom (`gap_to_max`) so no quoted figure exceeds the pack. Display-only value; not read by decision logic.
- Expose `floor_active` in decision data; when set, report the grid deficit needed to reach the floor and drop the "solar covers it" claim.
- Regression test + CHANGELOG.

## Not in scope
The two `5` values in `daily_consumption_history` are the `DEFAULT_BASE_CONSUMPTION_KWH = 5.0` sentinel leaking into history for days with no real data — a separate bug tracked for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)