### PR TITLE
fix: keep non-operating days out of consumption history (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **Consumption average skewed by non-operating days** (#46): days the battery doesn't run (e.g. weekends outside the charging window) were seeded with the 5.0 kWh default and averaged into the 7-day consumption forecast, dragging it down (e.g. 16.7 vs ~21 kWh real). History now only holds operating days; stale weekend defaults are purged on startup. [`tracking/consumption_tracker.py`](custom_components/omnibattery/tracking/consumption_tracker.py).
+- **Consumption average skewed by non-operating days** (#46): days the battery doesn't run (e.g. weekends outside the charging window) were seeded with the 5.0 kWh default and averaged into the consumption forecast, dragging it down (e.g. 16.7 vs ~21 kWh real). The history window is now **7 operating days**, reaching back across weekends into the previous week rather than counting non-operating days; stale weekend defaults are purged on startup. [`tracking/consumption_tracker.py`](custom_components/omnibattery/tracking/consumption_tracker.py).
 
 ## [1.0.0b4] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Consumption average skewed by non-operating days** (#46): days the battery doesn't run (e.g. weekends outside the charging window) were seeded with the 5.0 kWh default and averaged into the 7-day consumption forecast, dragging it down (e.g. 16.7 vs ~21 kWh real). History now only holds operating days; stale weekend defaults are purged on startup. [`tracking/consumption_tracker.py`](custom_components/omnibattery/tracking/consumption_tracker.py).
+
 ## [1.0.0b4] - 2026-07-02
 
 ### Added

--- a/custom_components/omnibattery/tracking/consumption_tracker.py
+++ b/custom_components/omnibattery/tracking/consumption_tracker.py
@@ -498,24 +498,27 @@ class ConsumptionTracker:
         # OPPORTUNISTIC BACKFILL: Replace default entries with real data from HA history
         # This recovers real data after restarts or when defaults were pre-populated.
         # Window = the 7 most recent operating days (skips non-operating days).
+        # Gate on <7 real entries so a permanently unfillable day (no recorder
+        # data) isn't re-queried on every predictive evaluation.
         real_data_dates = {
             d for d, c in ctrl._daily_consumption_history if c != DEFAULT_BASE_CONSUMPTION_KWH
         }
-        for past_date in self._recent_operating_days(7):
-            if past_date not in real_data_dates:
-                value = await self.backfill_home_from_history(past_date)
-                if value is not None and value >= 1.5:
-                    replaced = False
-                    for i, (d, c) in enumerate(ctrl._daily_consumption_history):
-                        if d == past_date:
-                            ctrl._daily_consumption_history[i] = (past_date, value)
-                            replaced = True
-                            break
-                    if not replaced:
-                        ctrl._daily_consumption_history.append((past_date, value))
-                    ctrl._daily_consumption_history.sort(key=lambda x: x[0])
-                    ctrl._daily_consumption_history = ctrl._daily_consumption_history[-7:]
-                await asyncio.sleep(0.1)  # Small delay between history queries
+        if len(real_data_dates) < 7:
+            for past_date in self._recent_operating_days(7):
+                if past_date not in real_data_dates:
+                    value = await self.backfill_home_from_history(past_date)
+                    if value is not None and value >= 1.5:
+                        replaced = False
+                        for i, (d, c) in enumerate(ctrl._daily_consumption_history):
+                            if d == past_date:
+                                ctrl._daily_consumption_history[i] = (past_date, value)
+                                replaced = True
+                                break
+                        if not replaced:
+                            ctrl._daily_consumption_history.append((past_date, value))
+                        ctrl._daily_consumption_history.sort(key=lambda x: x[0])
+                        ctrl._daily_consumption_history = ctrl._daily_consumption_history[-7:]
+                    await asyncio.sleep(0.1)  # Small delay between history queries
 
         # Calculate average from history
         if len(ctrl._daily_consumption_history) == 0:

--- a/custom_components/omnibattery/tracking/consumption_tracker.py
+++ b/custom_components/omnibattery/tracking/consumption_tracker.py
@@ -494,30 +494,28 @@ class ConsumptionTracker:
         the Home Consumption sensor's recorder history.
         """
         ctrl = self._controller
-        today = date.today()
 
         # OPPORTUNISTIC BACKFILL: Replace default entries with real data from HA history
-        # This recovers real data after restarts or when defaults were pre-populated
+        # This recovers real data after restarts or when defaults were pre-populated.
+        # Window = the 7 most recent operating days (skips non-operating days).
         real_data_dates = {
             d for d, c in ctrl._daily_consumption_history if c != DEFAULT_BASE_CONSUMPTION_KWH
         }
-        if len(real_data_dates) < 7:
-            for days_ago in range(1, 8):  # Look back 7 days (excluding today)
-                past_date = today - timedelta(days=days_ago)
-                if past_date not in real_data_dates:
-                    value = await self.backfill_home_from_history(past_date)
-                    if value is not None and value >= 1.5:
-                        replaced = False
-                        for i, (d, c) in enumerate(ctrl._daily_consumption_history):
-                            if d == past_date:
-                                ctrl._daily_consumption_history[i] = (past_date, value)
-                                replaced = True
-                                break
-                        if not replaced:
-                            ctrl._daily_consumption_history.append((past_date, value))
-                        ctrl._daily_consumption_history.sort(key=lambda x: x[0])
-                        ctrl._daily_consumption_history = ctrl._daily_consumption_history[-7:]
-                    await asyncio.sleep(0.1)  # Small delay between history queries
+        for past_date in self._recent_operating_days(7):
+            if past_date not in real_data_dates:
+                value = await self.backfill_home_from_history(past_date)
+                if value is not None and value >= 1.5:
+                    replaced = False
+                    for i, (d, c) in enumerate(ctrl._daily_consumption_history):
+                        if d == past_date:
+                            ctrl._daily_consumption_history[i] = (past_date, value)
+                            replaced = True
+                            break
+                    if not replaced:
+                        ctrl._daily_consumption_history.append((past_date, value))
+                    ctrl._daily_consumption_history.sort(key=lambda x: x[0])
+                    ctrl._daily_consumption_history = ctrl._daily_consumption_history[-7:]
+                await asyncio.sleep(0.1)  # Small delay between history queries
 
         # Calculate average from history
         if len(ctrl._daily_consumption_history) == 0:
@@ -564,6 +562,25 @@ class ConsumptionTracker:
             return True
         day_name = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"][d.weekday()]
         return any(day_name in s.get("days", []) for s in slots)
+
+    def _recent_operating_days(self, n: int = 7, *, before: Optional[date] = None) -> list[date]:
+        """The ``n`` most recent operating dates strictly before ``before`` (default today).
+
+        Walks the calendar backwards skipping non-operating days, so the history
+        window always spans ``n`` days the battery actually ran — reaching past
+        weekends into the previous week rather than shrinking. Bounded so an
+        unusual slot config (few operating days per week) can't loop unboundedly;
+        returns fewer than ``n`` only if the bound is hit.
+        """
+        before = before or date.today()
+        limit = before - timedelta(days=n * 7 + 7)  # worst case ~1 operating day/week
+        days: list[date] = []
+        d = before - timedelta(days=1)
+        while len(days) < n and d > limit:
+            if self._is_operating_day(d):
+                days.append(d)
+            d -= timedelta(days=1)
+        return days
 
     def _home_consumption_entity_id(self) -> Optional[str]:
         """Resolve the aggregate Home Consumption power sensor's entity_id.
@@ -752,8 +769,6 @@ class ConsumptionTracker:
         if not ctrl.predictive_charging_enabled:
             return
 
-        today = date.today()
-
         # Drop stale synthetic entries for non-operating days (e.g. weekends
         # outside the charging window) left by an earlier default-seeding run.
         # These are never measured, so a 5.0 kWh default only skews the average.
@@ -772,13 +787,14 @@ class ConsumptionTracker:
             sum(1 for _, c in ctrl._daily_consumption_history if c != DEFAULT_BASE_CONSUMPTION_KWH),
         )
 
-        # Try to backfill past days from recorder history
+        # Try to backfill past days from recorder history.
+        # Window = the 7 most recent operating days (skips non-operating days).
+        target_days = self._recent_operating_days(7)
         real_data_dates = {
             d for d, c in ctrl._daily_consumption_history if c != DEFAULT_BASE_CONSUMPTION_KWH
         }
         backfill_count = 0
-        for days_ago in range(1, 8):
-            past_date = today - timedelta(days=days_ago)
+        for past_date in target_days:
             if past_date not in real_data_dates:
                 value = await self.backfill_home_from_history(past_date)
                 if value is not None and value >= 1.5:
@@ -795,7 +811,7 @@ class ConsumptionTracker:
                 await asyncio.sleep(0.1)
                 backfill_count += 1
 
-        # Fill any remaining gaps in the 7-day window so we always have 7 entries.
+        # Fill any remaining gaps in the window so we always have 7 operating days.
         # Use the average of real entries as the gap value; fall back to
         # DEFAULT_BASE_CONSUMPTION_KWH only if there are no real entries at all.
         real_values = [
@@ -806,9 +822,8 @@ class ConsumptionTracker:
             else DEFAULT_BASE_CONSUMPTION_KWH
         )
         existing_dates = {d for d, _ in ctrl._daily_consumption_history}
-        for days_ago in range(1, 8):
-            past_date = today - timedelta(days=days_ago)
-            if past_date not in existing_dates and self._is_operating_day(past_date):
+        for past_date in target_days:
+            if past_date not in existing_dates:
                 ctrl._daily_consumption_history.append((past_date, gap_value))
                 _LOGGER.info(
                     "Startup backfill: no data found for %s, inserted %.2f kWh (%s)",
@@ -847,15 +862,10 @@ class ConsumptionTracker:
             DEFAULT_BASE_CONSUMPTION_KWH,
         )
 
-        today = date.today()
-
-        # Pre-populate the past 7 days with fallback values, but only for days the
-        # battery actually operates: non-operating days (e.g. weekends outside the
-        # charging window) are never measured, so seeding them would skew the avg.
-        for days_ago in range(6, -1, -1):
-            past_date = today - timedelta(days=days_ago)
-            if not self._is_operating_day(past_date):
-                continue
+        # Pre-populate the 7 most recent operating days with fallback values.
+        # Non-operating days (e.g. weekends outside the charging window) are never
+        # measured, so the window skips them and reaches further back instead.
+        for past_date in self._recent_operating_days(7):
             ctrl._daily_consumption_history.append((past_date, DEFAULT_BASE_CONSUMPTION_KWH))
 
         _LOGGER.info(

--- a/custom_components/omnibattery/tracking/consumption_tracker.py
+++ b/custom_components/omnibattery/tracking/consumption_tracker.py
@@ -550,6 +550,21 @@ class ConsumptionTracker:
 
         return average
 
+    def _is_operating_day(self, d: date) -> bool:
+        """True if the battery operates on ``d`` (a charging window covers that weekday).
+
+        No ``charging_time_slots`` configured = the battery runs every day. Days not
+        covered by any window are non-operating: home consumption is only measured
+        inside the solar+battery window (see ``accumulate_household_consumption``),
+        so history must never hold synthetic entries for them — a default like
+        5.0 kWh would only skew the 7-day average.
+        """
+        slots = self._controller.charging_time_slots
+        if not slots:
+            return True
+        day_name = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"][d.weekday()]
+        return any(day_name in s.get("days", []) for s in slots)
+
     def _home_consumption_entity_id(self) -> Optional[str]:
         """Resolve the aggregate Home Consumption power sensor's entity_id.
 
@@ -581,10 +596,9 @@ class ConsumptionTracker:
         day_names = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
         day_name = day_names[target_date.weekday()]
         # Skip days not covered by any charging window (battery doesn't operate those days)
-        if ctrl.charging_time_slots:
-            if not any(day_name in s.get("days", []) for s in ctrl.charging_time_slots):
-                _LOGGER.debug("Household backfill: skipping %s (not a slot day)", target_date)
-                return None
+        if not self._is_operating_day(target_date):
+            _LOGGER.debug("Household backfill: skipping %s (not a slot day)", target_date)
+            return None
 
         try:
             from homeassistant.components.recorder import history, get_instance
@@ -740,6 +754,17 @@ class ConsumptionTracker:
 
         today = date.today()
 
+        # Drop stale synthetic entries for non-operating days (e.g. weekends
+        # outside the charging window) left by an earlier default-seeding run.
+        # These are never measured, so a 5.0 kWh default only skews the average.
+        before = len(ctrl._daily_consumption_history)
+        ctrl._daily_consumption_history = [
+            (d, c) for d, c in ctrl._daily_consumption_history if self._is_operating_day(d)
+        ]
+        purged = before - len(ctrl._daily_consumption_history)
+        if purged:
+            _LOGGER.info("Startup backfill: dropped %d non-operating-day entries", purged)
+
         _LOGGER.info(
             "Startup backfill: attempting to replace defaults with real data "
             "(current history: %d entries, %d real)",
@@ -783,7 +808,7 @@ class ConsumptionTracker:
         existing_dates = {d for d, _ in ctrl._daily_consumption_history}
         for days_ago in range(1, 8):
             past_date = today - timedelta(days=days_ago)
-            if past_date not in existing_dates:
+            if past_date not in existing_dates and self._is_operating_day(past_date):
                 ctrl._daily_consumption_history.append((past_date, gap_value))
                 _LOGGER.info(
                     "Startup backfill: no data found for %s, inserted %.2f kWh (%s)",
@@ -824,9 +849,13 @@ class ConsumptionTracker:
 
         today = date.today()
 
-        # Pre-populate with 7 days of fallback values (6 days ago through today)
+        # Pre-populate the past 7 days with fallback values, but only for days the
+        # battery actually operates: non-operating days (e.g. weekends outside the
+        # charging window) are never measured, so seeding them would skew the avg.
         for days_ago in range(6, -1, -1):
             past_date = today - timedelta(days=days_ago)
+            if not self._is_operating_day(past_date):
+                continue
             ctrl._daily_consumption_history.append((past_date, DEFAULT_BASE_CONSUMPTION_KWH))
 
         _LOGGER.info(

--- a/tests/test_consumption_tracker.py
+++ b/tests/test_consumption_tracker.py
@@ -8,7 +8,7 @@ helpers are called directly, and the one instance test uses the in-process
 from __future__ import annotations
 
 import math
-from datetime import date
+from datetime import date, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -131,16 +131,39 @@ def test_is_operating_day_true_when_no_slots():
     assert tracker._is_operating_day(date(2026, 6, 27))  # a Saturday
 
 
-def test_initialize_defaults_skips_non_operating_days():
+def test_recent_operating_days_reaches_across_weekend():
+    # The window is 7 OPERATING days, not 7 calendar days: on a Friday it reaches
+    # back over the weekend into the previous week. (Issue #46 clarification.)
     tracker = _make_history_tracker([], _MON_FRI)
-    # Anchor "today" so the 7-day window is deterministic: 2026-07-03 is a Friday,
-    # so the past-7 window spans Sat 06-27 and Sun 06-28.
+    days = tracker._recent_operating_days(7, before=date(2026, 7, 3))  # a Friday
+    assert days == [
+        date(2026, 7, 2),   # Thu (yesterday)
+        date(2026, 7, 1),   # Wed
+        date(2026, 6, 30),  # Tue
+        date(2026, 6, 29),  # Mon
+        date(2026, 6, 26),  # Fri  (skipped Sun 28 + Sat 27)
+        date(2026, 6, 25),  # Thu
+        date(2026, 6, 24),  # Wed
+    ]
+    # No weekend day ever appears.
+    assert all(tracker._is_operating_day(d) for d in days)
+
+
+def test_recent_operating_days_all_when_no_slots():
+    # 24/7 config → 7 consecutive calendar days before `before`.
+    tracker = _make_history_tracker([], [])
+    days = tracker._recent_operating_days(7, before=date(2026, 7, 3))
+    assert days == [date(2026, 7, 3) - timedelta(days=i) for i in range(1, 8)]
+
+
+def test_initialize_defaults_seeds_seven_operating_days():
+    tracker = _make_history_tracker([], _MON_FRI)
     import custom_components.omnibattery.tracking.consumption_tracker as ct
 
     class _FrozenDate(date):
         @classmethod
         def today(cls):
-            return date(2026, 7, 3)
+            return date(2026, 7, 3)  # Friday
 
     orig = ct.date
     ct.date = _FrozenDate
@@ -150,10 +173,9 @@ def test_initialize_defaults_skips_non_operating_days():
         ct.date = orig
 
     seeded = {d for d, _ in tracker._controller._daily_consumption_history}
-    assert date(2026, 6, 27) not in seeded  # Saturday
-    assert date(2026, 6, 28) not in seeded  # Sunday
-    assert date(2026, 7, 3) in seeded        # Friday
-    # Every seeded day is an operating weekday.
+    assert len(seeded) == 7                    # always 7 operating days
+    assert date(2026, 6, 27) not in seeded     # Saturday
+    assert date(2026, 6, 28) not in seeded     # Sunday
     assert all(tracker._is_operating_day(d) for d in seeded)
 
 

--- a/tests/test_consumption_tracker.py
+++ b/tests/test_consumption_tracker.py
@@ -98,6 +98,66 @@ def test_avg_daily_consumption_single_day():
 
 
 # ----------------------------------------------------------------------
+# Operating-day gating of the consumption history (#46 follow-up):
+# non-operating days (weekends outside the charging window) must never enter
+# history with a synthetic default, or they drag the 7-day average down.
+# ----------------------------------------------------------------------
+
+def _make_history_tracker(history, charging_time_slots):
+    tracker = ConsumptionTracker.__new__(ConsumptionTracker)
+    tracker._controller = SimpleNamespace(
+        _daily_consumption_history=history,
+        charging_time_slots=charging_time_slots,
+        predictive_charging_enabled=True,
+    )
+    return tracker
+
+
+_MON_FRI = [{"days": ["mon", "tue", "wed", "thu", "fri"],
+             "start_time": "00:00", "end_time": "08:00"}]
+
+
+def test_is_operating_day_respects_slot_days():
+    tracker = _make_history_tracker([], _MON_FRI)
+    assert tracker._is_operating_day(date(2026, 6, 26))   # Friday
+    assert not tracker._is_operating_day(date(2026, 6, 27))  # Saturday
+    assert not tracker._is_operating_day(date(2026, 6, 28))  # Sunday
+    assert tracker._is_operating_day(date(2026, 6, 29))   # Monday
+
+
+def test_is_operating_day_true_when_no_slots():
+    # No charging window configured = battery runs 24/7 = every day counts.
+    tracker = _make_history_tracker([], [])
+    assert tracker._is_operating_day(date(2026, 6, 27))  # a Saturday
+
+
+def test_initialize_defaults_skips_non_operating_days():
+    tracker = _make_history_tracker([], _MON_FRI)
+    # Anchor "today" so the 7-day window is deterministic: 2026-07-03 is a Friday,
+    # so the past-7 window spans Sat 06-27 and Sun 06-28.
+    import custom_components.omnibattery.tracking.consumption_tracker as ct
+
+    class _FrozenDate(date):
+        @classmethod
+        def today(cls):
+            return date(2026, 7, 3)
+
+    orig = ct.date
+    ct.date = _FrozenDate
+    try:
+        tracker.initialize_history_with_defaults()
+    finally:
+        ct.date = orig
+
+    seeded = {d for d, _ in tracker._controller._daily_consumption_history}
+    assert date(2026, 6, 27) not in seeded  # Saturday
+    assert date(2026, 6, 28) not in seeded  # Sunday
+    assert date(2026, 7, 3) in seeded        # Friday
+    # Every seeded day is an operating weekday.
+    assert all(tracker._is_operating_day(d) for d in seeded)
+
+
+# ----------------------------------------------------------------------
 # Total solar power: external sensor + Venus DC-coupled PV (MPPT on vA/vD).
 # Pins the #354 fix — daily solar must count the battery's own MPPT panels,
 # not only the configured external sensor, and survive the external being gone.


### PR DESCRIPTION
Follow-up to #46 (the spurious `5` kWh values in `daily_consumption_history`).

## Root cause
The two `5` values fall exactly on **Saturday 06-27 and Sunday 06-28** — days outside the reporter's `mon-fri` charging window. Default-seeding pre-populated **every** day with `DEFAULT_BASE_CONSUMPTION_KWH = 5.0` without checking slot days, while `backfill_home_from_history` deliberately **skips** non-operating days. So weekend entries stayed at 5.0 forever and got averaged into the forecast — 16.7 kWh vs the ~21 kWh of the real weekdays.

## Fix
The history window is now **7 operating days**, not 7 calendar days. Non-operating days (weekends) are skipped and the window reaches back into the previous week so it always holds 7 days the battery actually ran.

Example on a Friday: `Wed, Thu, Fri, Mon, Tue, Wed, Thu` (yesterday) — the weekend is stepped over.

- `_is_operating_day()` — mirrors the check `backfill` already did.
- `_recent_operating_days(n)` — walks the calendar backwards skipping non-operating days until `n` are collected (bounded).
- All seeding/backfill loops (initialize, startup backfill, gap-fill, opportunistic backfill) iterate that window instead of `range(1, 8)`.
- Stale non-operating-day entries are purged on startup so existing histories self-correct immediately.
- Tests pin the exact window (the Friday example) + the 24/7 no-slot case.

The `5.0` default still exists for genuine cold-start (fresh install, or an operating day with no recorder data) — it just no longer pollutes non-operating days.

Full suite: 537 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)