### PR TITLE
fix: move Modbus retries into pymodbus so late replies match their transaction id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **pymodbus "transaction_id mismatch, Skipping" errors + discarded late replies**: retries now run inside pymodbus (which re-sends the same transaction id since 3.8) instead of the wrapper loop (new id per attempt), so a battery that stalls and answers late gets its reply consumed instead of logged as an error and thrown away. Requires pymodbus>=3.8.0. [`infra/modbus_client.py`](custom_components/omnibattery/infra/modbus_client.py).
 - **Consumption average skewed by non-operating days** (#46): days the battery doesn't run (e.g. weekends outside the charging window) were seeded with the 5.0 kWh default and averaged into the consumption forecast, dragging it down (e.g. 16.7 vs ~21 kWh real). The history window is now **7 operating days**, reaching back across weekends into the previous week rather than counting non-operating days; stale weekend defaults are purged on startup. [`tracking/consumption_tracker.py`](custom_components/omnibattery/tracking/consumption_tracker.py).
 - **Predictive-charging notification quoted nonsense grid/solar numbers** (#46): on a floor-driven charge (SOC below the guaranteed-min-SOC target) the "STARTED" notification showed `Grid: 0.00 kWh` while claiming solar would charge a figure larger than the battery. It now reports the grid deficit needed to reach the floor, and `solar_surplus_kwh` is capped at battery headroom. [`__init__.py`](custom_components/omnibattery/__init__.py), [`pricing/notifications.py`](custom_components/omnibattery/pricing/notifications.py).
 

--- a/custom_components/omnibattery/const/registers_common.py
+++ b/custom_components/omnibattery/const/registers_common.py
@@ -73,12 +73,13 @@ MESSAGE_WAIT_MS = {
     "vD": 150,
 }
 
-# Version-specific per-read timeout (seconds).
-# The v3 weak MCU answers in well under a second at the 150ms cadence. A long
-# timeout lets a request that already timed out get answered late, leaving a
-# stale frame in the socket buffer that poisons the next read (pymodbus
-# "transaction_id mismatch", issue #361). Fail fast on v3 so a slow reply is
-# discarded promptly instead of cascading.
+# Version-specific per-attempt timeout (seconds), passed to pymodbus.
+# The v3 weak MCU answers in well under a second at the 150ms cadence, but
+# occasionally stalls for several seconds and then flushes queued replies in a
+# burst. Each pymodbus-internal retry re-sends the SAME transaction_id (>=3.8),
+# so a reply arriving after a per-attempt timeout still matches the retry and
+# is consumed (issue #361 history in infra/modbus_client.py). Keep v3 attempts
+# short so the retries land inside the stall window.
 READ_TIMEOUT_S = {
     "v2": 10,
     "v3": 3,

--- a/custom_components/omnibattery/infra/modbus_client.py
+++ b/custom_components/omnibattery/infra/modbus_client.py
@@ -17,6 +17,14 @@ from ..const import DEBUG_RAW_MODBUS_READS, SERIAL_BAUDRATE
 
 _LOGGER = logging.getLogger(__name__)
 
+# pymodbus-internal retries per request. Since the pymodbus 3.8 transaction
+# manager rewrite, internal retries re-send the SAME transaction_id, so a late
+# answer from a stalled battery (the v3 MCU queues requests and flushes the
+# replies in a burst) matches the retry and is consumed as valid. Wrapper-level
+# retries minted a new tid per attempt, which guaranteed every flushed reply
+# was discarded with a "transaction_id mismatch, Skipping" error.
+_PYMODBUS_RETRIES = 2
+
 
 def _backoff_jitter(delay: float) -> float:
     """Return a symmetric +/-10% jitter for a retry backoff delay.
@@ -146,6 +154,11 @@ class MarstekModbusClient:
         self._host = host
         self._port = port
         self._timeout = timeout
+        # Outer safety-net timeout for one request: must cover all pymodbus
+        # internal attempts ((retries+1) x per-attempt timeout) plus margin.
+        # Cancelling pymodbus mid-transaction orphans an already-sent request,
+        # which recreates the stale-reply mismatch this design avoids.
+        self._request_timeout = timeout * (_PYMODBUS_RETRIES + 1) + 2
         self._is_v3 = is_v3
         self._serial_port = serial_port
         # pymodbus has no inter-message delay for TCP (message_wait_milliseconds
@@ -169,10 +182,14 @@ class MarstekModbusClient:
 
         Auto-reconnect is disabled: we manage reconnection ourselves by creating
         fresh client instances, which avoids pymodbus's internal reconnect_delay
-        growing up to 300s. retries=0 because our _read_raw loop already owns
-        retries+backoff; pymodbus's default 3 internal retries each fire a NEW
-        transaction_id, which surfaces as the "transaction_id mismatch" cascade on
-        the weak v3 MCU (issue #361).
+        growing up to 300s. Retries live INSIDE pymodbus (not in our loop):
+        since pymodbus 3.8 internal retries re-send the same transaction_id, so
+        a reply that arrives after the per-attempt timeout still matches the
+        retry and is consumed. The old note here ("internal retries each fire a
+        NEW transaction_id", issue #361) described pre-3.8 behaviour and is why
+        retries used to be 0 with the loop in _read_raw owning them — that
+        combination is what produced the "transaction_id mismatch, Skipping"
+        log spam whenever a v3 battery stalled and answered late.
 
         Serial uses RTU framing at a fixed 115200 8N1 — the rate Marstek's RS485
         link runs at (discussion #350); these are hardware-fixed, not tunable.
@@ -185,13 +202,13 @@ class MarstekModbusClient:
                 parity="N",
                 stopbits=1,
                 timeout=self._timeout,
-                retries=0,
+                retries=_PYMODBUS_RETRIES,
             )
         return AsyncModbusTcpClient(
             host=self._host,
             port=self._port,
             timeout=self._timeout,
-            retries=0,
+            retries=_PYMODBUS_RETRIES,
             reconnect_delay=0,
             reconnect_delay_max=0,
         )
@@ -298,15 +315,21 @@ class MarstekModbusClient:
         self,
         register: int,
         count: int,
-        max_retries: int = 3,
+        max_retries: int = 1,
         retry_delay: float = 0.1,
         sensor_key: Optional[str] = None,
     ) -> Optional[list]:
-        """Read ``count`` holding registers with retries, returning raw words.
+        """Read ``count`` holding registers, returning raw words.
 
-        Shared read+retry machinery for both single-register reads and block
-        reads. Returns the list of register words (length ``count``) or None on
+        Shared read machinery for both single-register reads and block reads.
+        Returns the list of register words (length ``count``) or None on
         failure. Callers decode the words with :func:`decode_registers`.
+
+        Default is a single attempt: retries are pymodbus-internal
+        (_PYMODBUS_RETRIES, same transaction_id per re-send) so late replies
+        from a stalled battery match and are consumed. Looping here would mint
+        a new tid per attempt and turn every late reply into a discarded
+        "transaction_id mismatch".
         """
         if not (0 <= register <= 0xFFFF):
             _LOGGER.error(
@@ -334,7 +357,7 @@ class MarstekModbusClient:
                 try:
                     result = await asyncio.wait_for(
                         self.client.read_holding_registers(address=register, count=count, **{self._slave_kwarg: self.unit_id}),
-                        timeout=self._timeout,
+                        timeout=self._request_timeout,
                     )
                 finally:
                     # Inter-message spacing: v3 firmware needs time between
@@ -412,7 +435,7 @@ class MarstekModbusClient:
         count: Optional[int] = None,
         bit_index: Optional[int] = None,
         sensor_key: Optional[str] = None,
-        max_retries: int = 3,
+        max_retries: int = 1,
         retry_delay: float = 0.1,
     ):
         """
@@ -448,7 +471,7 @@ class MarstekModbusClient:
         self,
         start: int,
         count: int,
-        max_retries: int = 3,
+        max_retries: int = 1,
         retry_delay: float = 0.1,
         block_key: Optional[str] = None,
     ) -> Optional[list]:
@@ -467,9 +490,13 @@ class MarstekModbusClient:
             sensor_key=block_key,
         )
 
-    async def async_write_register(self, register: int, value: int, max_retries: int = 3, retry_delay: float = 0.1) -> bool:
+    async def async_write_register(self, register: int, value: int, max_retries: int = 1, retry_delay: float = 0.1) -> bool:
         """
         Write a single value to a Modbus holding register asynchronously.
+
+        Default is a single attempt; retries are pymodbus-internal with the
+        same transaction_id (see ``_read_raw``). Re-sending a single-register
+        write is idempotent, so a duplicate delivery is harmless.
 
         Args:
             register (int): Register address to write to.
@@ -491,7 +518,7 @@ class MarstekModbusClient:
                 try:
                     result = await asyncio.wait_for(
                         self.client.write_register(address=register, value=value, **{self._slave_kwarg: self.unit_id}),
-                        timeout=self._timeout,
+                        timeout=self._request_timeout,
                     )
                 finally:
                     # Inter-message spacing (see async_read_register).

--- a/custom_components/omnibattery/manifest.json
+++ b/custom_components/omnibattery/manifest.json
@@ -18,7 +18,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ffunes/omnibattery/issues",
   "requirements": [
-    "pymodbus>=3.5.0",
+    "pymodbus>=3.8.0",
     "pyserial>=3.5"
   ],
   "version": "1.0.0b4",

--- a/tests/test_modbus_client_retry.py
+++ b/tests/test_modbus_client_retry.py
@@ -1,10 +1,14 @@
 """Retry/backoff and no-self-reconnect behaviour of the Modbus read/write loops.
 
 Exercises ``_read_raw`` and ``async_write_register`` against a scripted fake
-pymodbus client (no hardware, no HA). These pin two deliberate properties that
-had no coverage: the same-connection retry loop, and that a connection error
-does NOT trigger a reconnect from inside the loop (the coordinator owns
-reconnection; reconnecting here would storm the v3 single TCP slot, issue #361).
+pymodbus client (no hardware, no HA). These pin three deliberate properties:
+the default is a SINGLE wrapper attempt (retries are pymodbus-internal so they
+re-send the same transaction_id and a late reply still matches — wrapper
+retries minted a new tid per attempt, turning every late reply into a
+"transaction_id mismatch, Skipping" error), the same-connection retry loop
+still works for callers that opt in, and a connection error does NOT trigger
+a reconnect from inside the loop (the coordinator owns reconnection;
+reconnecting here would storm the v3 single TCP slot, issue #361).
 
 ``retry_delay=0`` keeps the backoff sleeps at zero so the tests run instantly.
 """
@@ -81,10 +85,20 @@ def test_read_success_returns_registers():
     assert fake.read_calls == 1
 
 
+def test_read_default_is_single_attempt():
+    """Default = one wrapper attempt: retries are pymodbus-internal (same tid),
+    a wrapper-level retry would mint a new tid and discard the late reply."""
+    fake = _FakeClient(read_results=[asyncio.TimeoutError(), _Result([5])])
+    c = _client_with_fake(fake)
+    regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
+    assert regs is None
+    assert fake.read_calls == 1
+
+
 def test_read_retries_on_connection_error_then_succeeds():
     fake = _FakeClient(read_results=[ConnectionException("boom"), _Result([5])])
     c = _client_with_fake(fake)
-    regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
+    regs = asyncio.run(c._read_raw(0x0010, 1, max_retries=2, retry_delay=0))
     assert regs == [5]
     assert fake.read_calls == 2
 
@@ -92,7 +106,7 @@ def test_read_retries_on_connection_error_then_succeeds():
 def test_read_timeout_is_retried():
     fake = _FakeClient(read_results=[asyncio.TimeoutError(), _Result([9])])
     c = _client_with_fake(fake)
-    regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
+    regs = asyncio.run(c._read_raw(0x0010, 1, max_retries=2, retry_delay=0))
     assert regs == [9]
     assert fake.read_calls == 2
 
@@ -100,7 +114,7 @@ def test_read_timeout_is_retried():
 def test_read_error_result_is_retried():
     fake = _FakeClient(read_results=[_Result(error=True), _Result([7])])
     c = _client_with_fake(fake)
-    regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
+    regs = asyncio.run(c._read_raw(0x0010, 1, max_retries=2, retry_delay=0))
     assert regs == [7]
     assert fake.read_calls == 2
 
@@ -135,7 +149,7 @@ def test_read_stops_immediately_when_shutting_down():
     fake = _FakeClient(read_results=[ConnectionException(), _Result([1])])
     c = _client_with_fake(fake)
     c._is_shutting_down = True
-    regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
+    regs = asyncio.run(c._read_raw(0x0010, 1, max_retries=3, retry_delay=0))
     assert regs is None
     assert fake.read_calls == 1  # no retry once shutting down
 
@@ -162,10 +176,18 @@ def test_write_success_returns_true():
     assert fake.write_calls == 1
 
 
+def test_write_default_is_single_attempt():
+    """Same property as the read path: pymodbus owns the retries."""
+    fake = _FakeClient(write_results=[asyncio.TimeoutError(), _Result(error=False)])
+    c = _client_with_fake(fake)
+    assert asyncio.run(c.async_write_register(0x2000, 1, retry_delay=0)) is False
+    assert fake.write_calls == 1
+
+
 def test_write_retries_on_connection_error_then_succeeds():
     fake = _FakeClient(write_results=[ConnectionException(), _Result(error=False)])
     c = _client_with_fake(fake)
-    assert asyncio.run(c.async_write_register(0x2000, 1, retry_delay=0)) is True
+    assert asyncio.run(c.async_write_register(0x2000, 1, max_retries=2, retry_delay=0)) is True
     assert fake.write_calls == 2
 
 


### PR DESCRIPTION
## Problem

Users see repeated `pymodbus` errors:

```
ERROR: request ask for transaction_id=737 but got id=733, Skipping.
```

The v3 MCU occasionally stalls for a few seconds, **queues** the requests it received, then flushes all the replies in a burst (visible in the log dumps: every queued tid gets answered). Our wrapper-level retry loop minted a **new transaction_id per attempt**, so by the time the flush arrived, every reply was stale → pymodbus discarded them all with the ERROR above, and the read/write failed anyway despite the data being right there.

## Fix

Since the pymodbus 3.8 transaction-manager rewrite, **internal retries re-send the same transaction_id** (verified in 3.8.0 / 3.11.2 / 3.13.0 source). Moving the retries inside pymodbus means a late reply matches the retry and is **consumed as a valid result** — less noise *and* faster recovery.

- `retries=2` in the pymodbus client; wrapper `_read_raw` / `async_write_register` default to a single attempt (loop machinery kept for explicit callers)
- outer `asyncio.wait_for` widened to `timeout×3+2` so it can't cancel pymodbus mid-transaction (that orphans an already-sent request and recreates the mismatch)
- `manifest.json`: `pymodbus>=3.8.0` — guarantees tid-reuse semantics; the "Skipping" message itself only exists from 3.8, so anyone seeing this error already runs a compatible version
- The stale #361 comment ("internal retries each fire a NEW transaction_id") described pre-3.8 behaviour and was the reason retries lived in the wrapper; comments updated

Bonus for the v3 single TCP slot: pymodbus's internal self-disconnect (`count_until_disconnect = retries+3`) now needs 5 fully-failed requests instead of 3 before it closes the connection on its own.

## Residual

If the battery queued both the original send and a re-send of the same tid, the duplicate reply logs at most a WARNING ("pdu without a corresponding request, IGNORING") — much rarer than today, where every late reply was a guaranteed mismatch. The firmware stall itself is not fixable from our side.

## Tests

569 passed. `test_modbus_client_retry.py` now pins the new deliberate property (default = single wrapper attempt) plus the existing loop/no-self-reconnect behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)