### PR TITLE
Temperature-based charge power limiting

### DIFF
--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -39,6 +39,16 @@ from .const import (
     CONF_ENABLE_CHARGE_DELAY,
     CONF_DELAY_SAFETY_MARGIN_MIN,
     DEFAULT_DELAY_SAFETY_MARGIN_MIN,
+    CONF_ENABLE_TEMP_CHARGE_LIMIT,
+    DEFAULT_ENABLE_TEMP_CHARGE_LIMIT,
+    CONF_TEMP_CHARGE_LIMIT_C,
+    DEFAULT_TEMP_CHARGE_LIMIT_C,
+    CONF_TEMP_CHARGE_LIMIT_BAND_C,
+    DEFAULT_TEMP_CHARGE_LIMIT_BAND_C,
+    CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT,
+    DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT,
+    CONF_TEMP_LIMIT_APPLY_DISCHARGE,
+    DEFAULT_TEMP_LIMIT_APPLY_DISCHARGE,
     CONF_CHARGE_DELAY_BALANCE_DEADBAND_KWH,
     DEFAULT_CHARGE_DELAY_BALANCE_DEADBAND_KWH,
     CONF_DELAY_SOC_SETPOINT_ENABLED,
@@ -141,6 +151,7 @@ from .tracking.non_responsive_tracker import NonResponsiveTracker
 from .control.weekly_full_charge import WeeklyFullChargeManager
 from .control.active_balance_mode import ActiveBalanceModeManager
 from .control.max_soc_charge import MaxSocChargeManager
+from .control.temperature_limit import TemperatureChargeLimitManager
 from .pricing import DynamicPricingSchedule, notifications
 from .pricing.engine import PricingManager
 
@@ -449,6 +460,7 @@ class ChargeDischargeController:
         self._normal_balance_recal_latched: dict[MarstekVenusDataUpdateCoordinator, bool] = {}
         self._active_balance_mgr = ActiveBalanceModeManager(hass, self)
         self._max_soc_mgr = MaxSocChargeManager(hass, self)
+        self._temp_limit_mgr = TemperatureChargeLimitManager(hass, self)
 
         # Calculate dynamic anti-windup limits based on total system capacity
         self.max_charge_capacity = self._effective_system_capacity(coordinators, is_charging=True)
@@ -640,6 +652,12 @@ class ChargeDischargeController:
         self._charge_delay_balance_deadband_kwh = config_entry.data.get(CONF_CHARGE_DELAY_BALANCE_DEADBAND_KWH, DEFAULT_CHARGE_DELAY_BALANCE_DEADBAND_KWH)
         self._delay_soc_setpoint_enabled = config_entry.data.get(CONF_DELAY_SOC_SETPOINT_ENABLED, DEFAULT_DELAY_SOC_SETPOINT_ENABLED)
         self._delay_soc_setpoint = config_entry.data.get(CONF_DELAY_SOC_SETPOINT, DEFAULT_DELAY_SOC_SETPOINT)
+        # Temperature-based charge derate
+        self.temp_charge_limit_enabled = config_entry.data.get(CONF_ENABLE_TEMP_CHARGE_LIMIT, DEFAULT_ENABLE_TEMP_CHARGE_LIMIT)
+        self._temp_charge_limit_c = config_entry.data.get(CONF_TEMP_CHARGE_LIMIT_C, DEFAULT_TEMP_CHARGE_LIMIT_C)
+        self._temp_charge_limit_band_c = config_entry.data.get(CONF_TEMP_CHARGE_LIMIT_BAND_C, DEFAULT_TEMP_CHARGE_LIMIT_BAND_C)
+        self._temp_charge_limit_floor_pct = config_entry.data.get(CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT, DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT)
+        self.temp_limit_apply_discharge = config_entry.data.get(CONF_TEMP_LIMIT_APPLY_DISCHARGE, DEFAULT_TEMP_LIMIT_APPLY_DISCHARGE)
         self._weekly_full_charge_skip_delay = config_entry.data.get(
             CONF_WEEKLY_FULL_CHARGE_SKIP_DELAY, DEFAULT_WEEKLY_FULL_CHARGE_SKIP_DELAY
         )
@@ -991,14 +1009,16 @@ class ChargeDischargeController:
     def _battery_power_limit(self, coordinator, is_charging: bool) -> int:
         """Return the effective per-battery power limit for the current cycle."""
         if not is_charging:
-            return self._apply_slot_power_ceiling(
-                coordinator, False, coordinator.max_discharge_power
+            limit = self._temp_limit_mgr.apply_discharge_limit(
+                coordinator, coordinator.max_discharge_power
             )
+            return self._apply_slot_power_ceiling(coordinator, False, limit)
 
         limit = coordinator.max_charge_power
         if coordinator.data is None:
             return self._apply_slot_power_ceiling(coordinator, True, limit)
         limit = self._max_soc_mgr.apply_charge_taper(coordinator, limit)
+        limit = self._temp_limit_mgr.apply_temperature_limit(coordinator, limit)
         return self._apply_slot_power_ceiling(coordinator, True, limit)
 
     def _apply_no_pd_overrides(self):
@@ -1076,6 +1096,12 @@ class ChargeDischargeController:
         self._charge_delay_balance_deadband_kwh = new_balance_deadband
         self._delay_soc_setpoint_enabled = self.config_entry.data.get(CONF_DELAY_SOC_SETPOINT_ENABLED, DEFAULT_DELAY_SOC_SETPOINT_ENABLED)
         self._delay_soc_setpoint = self.config_entry.data.get(CONF_DELAY_SOC_SETPOINT, DEFAULT_DELAY_SOC_SETPOINT)
+        # Temperature-based charge derate
+        self.temp_charge_limit_enabled = self.config_entry.data.get(CONF_ENABLE_TEMP_CHARGE_LIMIT, DEFAULT_ENABLE_TEMP_CHARGE_LIMIT)
+        self._temp_charge_limit_c = self.config_entry.data.get(CONF_TEMP_CHARGE_LIMIT_C, DEFAULT_TEMP_CHARGE_LIMIT_C)
+        self._temp_charge_limit_band_c = self.config_entry.data.get(CONF_TEMP_CHARGE_LIMIT_BAND_C, DEFAULT_TEMP_CHARGE_LIMIT_BAND_C)
+        self._temp_charge_limit_floor_pct = self.config_entry.data.get(CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT, DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT)
+        self.temp_limit_apply_discharge = self.config_entry.data.get(CONF_TEMP_LIMIT_APPLY_DISCHARGE, DEFAULT_TEMP_LIMIT_APPLY_DISCHARGE)
         self._weekly_full_charge_skip_delay = self.config_entry.data.get(
             CONF_WEEKLY_FULL_CHARGE_SKIP_DELAY, DEFAULT_WEEKLY_FULL_CHARGE_SKIP_DELAY
         )

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -50,6 +50,16 @@ from .const import (
     CONF_ENABLE_BALANCE_MONITOR,
     CONF_ENABLE_CHARGE_DELAY,
     CONF_DELAY_SAFETY_MARGIN_MIN,
+    CONF_ENABLE_TEMP_CHARGE_LIMIT,
+    DEFAULT_ENABLE_TEMP_CHARGE_LIMIT,
+    CONF_TEMP_CHARGE_LIMIT_C,
+    DEFAULT_TEMP_CHARGE_LIMIT_C,
+    CONF_TEMP_CHARGE_LIMIT_BAND_C,
+    DEFAULT_TEMP_CHARGE_LIMIT_BAND_C,
+    CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT,
+    DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT,
+    CONF_TEMP_LIMIT_APPLY_DISCHARGE,
+    DEFAULT_TEMP_LIMIT_APPLY_DISCHARGE,
     DEFAULT_DELAY_SAFETY_MARGIN_MIN,
     CONF_DELAY_SOC_SETPOINT_ENABLED,
     DEFAULT_DELAY_SOC_SETPOINT_ENABLED,
@@ -279,6 +289,39 @@ def _scoped_battery_config(scope: str, battery_configs: list[dict]) -> dict:
     if 0 <= idx < len(battery_configs):
         return battery_configs[idx]
     return {}
+
+
+def _temp_charge_limit_schema(existing: dict | None = None) -> dict:
+    """Voluptuous schema for the temperature charge-derate config step.
+
+    Shared by the initial config flow and the options flow; ``existing`` seeds
+    the slider defaults from the current config in the options flow.
+    """
+    existing = existing or {}
+    return {
+        vol.Optional(
+            "temp_charge_limit_c",
+            default=existing.get(CONF_TEMP_CHARGE_LIMIT_C, DEFAULT_TEMP_CHARGE_LIMIT_C),
+        ): NumberSelector(NumberSelectorConfig(
+            min=20, max=60, step=1, mode=NumberSelectorMode.SLIDER, unit_of_measurement="°C",
+        )),
+        vol.Optional(
+            "temp_charge_limit_band_c",
+            default=existing.get(CONF_TEMP_CHARGE_LIMIT_BAND_C, DEFAULT_TEMP_CHARGE_LIMIT_BAND_C),
+        ): NumberSelector(NumberSelectorConfig(
+            min=1, max=30, step=1, mode=NumberSelectorMode.SLIDER, unit_of_measurement="°C",
+        )),
+        vol.Optional(
+            "temp_charge_limit_floor_pct",
+            default=existing.get(CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT, DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT),
+        ): NumberSelector(NumberSelectorConfig(
+            min=0, max=100, step=5, mode=NumberSelectorMode.SLIDER, unit_of_measurement="%",
+        )),
+        vol.Optional(
+            "temp_limit_apply_discharge",
+            default=existing.get(CONF_TEMP_LIMIT_APPLY_DISCHARGE, DEFAULT_TEMP_LIMIT_APPLY_DISCHARGE),
+        ): bool,
+    }
 
 
 def _slot_target_indices(scope: str, num_batteries: int) -> list[int]:
@@ -1466,7 +1509,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 return await self.async_step_charge_delay_config()
             else:
                 self.config_data[CONF_ENABLE_CHARGE_DELAY] = False
-                return await self.async_step_capacity_protection()
+                return await self.async_step_temp_charge_limit()
 
         return self.async_show_form(
             step_id="charge_delay",
@@ -1508,7 +1551,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                         self.config_data[CONF_SOLAR_FORECAST_SENSOR] = forecast_sensor
 
             if not errors:
-                return await self.async_step_capacity_protection()
+                return await self.async_step_temp_charge_limit()
 
         has_forecast_sensor = bool(self.config_data.get(CONF_SOLAR_FORECAST_SENSOR))
         schema_dict = {
@@ -1539,6 +1582,50 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             step_id="charge_delay_config",
             data_schema=vol.Schema(schema_dict),
             errors=errors,
+        )
+
+    async def async_step_temp_charge_limit(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask whether to enable temperature-based charge power limiting."""
+        if user_input is not None:
+            if user_input.get("configure_temp_charge_limit", False):
+                return await self.async_step_temp_charge_limit_config()
+            self.config_data[CONF_ENABLE_TEMP_CHARGE_LIMIT] = False
+            return await self.async_step_capacity_protection()
+
+        return self.async_show_form(
+            step_id="temp_charge_limit",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("configure_temp_charge_limit", default=False): bool,
+                }
+            ),
+        )
+
+    async def async_step_temp_charge_limit_config(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure the temperature charge-derate thresholds."""
+        if user_input is not None:
+            self.config_data[CONF_ENABLE_TEMP_CHARGE_LIMIT] = True
+            self.config_data[CONF_TEMP_CHARGE_LIMIT_C] = int(
+                user_input.get("temp_charge_limit_c", DEFAULT_TEMP_CHARGE_LIMIT_C)
+            )
+            self.config_data[CONF_TEMP_CHARGE_LIMIT_BAND_C] = int(
+                user_input.get("temp_charge_limit_band_c", DEFAULT_TEMP_CHARGE_LIMIT_BAND_C)
+            )
+            self.config_data[CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT] = int(
+                user_input.get("temp_charge_limit_floor_pct", DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT)
+            )
+            self.config_data[CONF_TEMP_LIMIT_APPLY_DISCHARGE] = user_input.get(
+                "temp_limit_apply_discharge", DEFAULT_TEMP_LIMIT_APPLY_DISCHARGE
+            )
+            return await self.async_step_capacity_protection()
+
+        return self.async_show_form(
+            step_id="temp_charge_limit_config",
+            data_schema=vol.Schema(_temp_charge_limit_schema()),
         )
 
     async def async_step_capacity_protection(
@@ -2160,6 +2247,7 @@ class OptionsFlowHandler(OptionsFlow):
                 "predictive_charging",
                 "weekly_full_charge",
                 "charge_delay",
+                "temp_charge_limit",
                 "capacity_protection",
                 "hourly_balance",
                 "pd_advanced",
@@ -3296,6 +3384,53 @@ class OptionsFlowHandler(OptionsFlow):
             step_id="charge_delay_config",
             data_schema=vol.Schema(schema_dict),
             errors=errors,
+        )
+
+    async def async_step_temp_charge_limit(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask whether to enable temperature charge limiting in options flow."""
+        if user_input is not None:
+            if user_input.get("configure_temp_charge_limit", False):
+                return await self.async_step_temp_charge_limit_config()
+            self.config_data[CONF_ENABLE_TEMP_CHARGE_LIMIT] = False
+            return await self._save_and_finish()
+
+        is_enabled = self.config_entry.data.get(
+            CONF_ENABLE_TEMP_CHARGE_LIMIT, DEFAULT_ENABLE_TEMP_CHARGE_LIMIT
+        )
+        return self.async_show_form(
+            step_id="temp_charge_limit",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("configure_temp_charge_limit", default=is_enabled): bool,
+                }
+            ),
+        )
+
+    async def async_step_temp_charge_limit_config(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure the temperature charge-derate thresholds in options flow."""
+        if user_input is not None:
+            self.config_data[CONF_ENABLE_TEMP_CHARGE_LIMIT] = True
+            self.config_data[CONF_TEMP_CHARGE_LIMIT_C] = int(
+                user_input.get("temp_charge_limit_c", DEFAULT_TEMP_CHARGE_LIMIT_C)
+            )
+            self.config_data[CONF_TEMP_CHARGE_LIMIT_BAND_C] = int(
+                user_input.get("temp_charge_limit_band_c", DEFAULT_TEMP_CHARGE_LIMIT_BAND_C)
+            )
+            self.config_data[CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT] = int(
+                user_input.get("temp_charge_limit_floor_pct", DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT)
+            )
+            self.config_data[CONF_TEMP_LIMIT_APPLY_DISCHARGE] = user_input.get(
+                "temp_limit_apply_discharge", DEFAULT_TEMP_LIMIT_APPLY_DISCHARGE
+            )
+            return await self._save_and_finish()
+
+        return self.async_show_form(
+            step_id="temp_charge_limit_config",
+            data_schema=vol.Schema(_temp_charge_limit_schema(self.config_entry.data)),
         )
 
     async def async_step_capacity_protection(

--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -302,6 +302,24 @@ CONF_DELAY_SOC_SETPOINT = "delay_soc_setpoint"
 DEFAULT_DELAY_SOC_SETPOINT = 50  # % — default when the setpoint is enabled
 DELAY_SOC_SETPOINT_HYSTERESIS = 3  # % — SOC must drop this far below setpoint before recharging
 
+# Temperature-based charge power derate. When a battery runs hot, charge power is
+# proportionally reduced: full power at/below the limit, ramping linearly down to
+# a floor (% of the normal charge ceiling) as temperature rises across the band,
+# and back up as it cools. Charge-only; per-battery on internal_temperature.
+CONF_ENABLE_TEMP_CHARGE_LIMIT = "enable_temp_charge_limit"
+DEFAULT_ENABLE_TEMP_CHARGE_LIMIT = False
+CONF_TEMP_CHARGE_LIMIT_C = "temp_charge_limit_c"
+DEFAULT_TEMP_CHARGE_LIMIT_C = 40  # °C, derate starts at/above this temperature
+CONF_TEMP_CHARGE_LIMIT_BAND_C = "temp_charge_limit_band_c"
+DEFAULT_TEMP_CHARGE_LIMIT_BAND_C = 10  # °C, width over which power ramps to the floor
+CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT = "temp_charge_limit_floor_pct"
+DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT = 40  # % of normal charge power at limit+band (0 = full stop)
+# Optionally apply the SAME derate curve to discharge. Discharge tolerates heat
+# better than charge, so this shares one (charge-tuned) threshold as a deliberate
+# compromise; its main benefit is staying under the BMS hard over-temp cutoff.
+CONF_TEMP_LIMIT_APPLY_DISCHARGE = "temp_limit_apply_discharge"
+DEFAULT_TEMP_LIMIT_APPLY_DISCHARGE = False
+
 # Hourly Net Balance
 CONF_ENABLE_HOURLY_BALANCE = "enable_hourly_balance"
 CONF_HOURLY_BALANCE_TARGET_NET_WH = "hourly_balance_target_net_wh"

--- a/custom_components/omnibattery/control/temperature_limit.py
+++ b/custom_components/omnibattery/control/temperature_limit.py
@@ -1,0 +1,121 @@
+"""Temperature-based charge power derate (TemperatureChargeLimitManager).
+
+Optional, charge-only thermal protection. When a battery's internal temperature
+rises above a configured limit, the per-battery charge power is proportionally
+reduced: full power at/below the limit, ramping linearly down to a floor (a
+percentage of the normal charge ceiling) as the temperature climbs across the
+band, and back up as it cools. The ramp is continuous, so no cooldown latch or
+hysteresis is needed (it self-stabilises).
+
+This mirrors ``MaxSocChargeManager.apply_charge_taper``'s cap-and-return
+contract: it is called from ``_battery_power_limit`` with the current per-battery
+limit and returns a limit that is never higher than the one passed in. When the
+feature is disabled or the temperature is unavailable it returns the limit
+unchanged (fail-safe: a sensor gap never throttles charging).
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TemperatureChargeLimitManager:
+    """Proportional per-battery charge-power derate driven by internal temperature."""
+
+    def __init__(self, hass: "HomeAssistant", controller: Any) -> None:
+        self._hass = hass
+        self._controller = controller
+
+    def _derate_factor(self, temp: float) -> float:
+        """Return the charge-power scale (0..1) for a given temperature.
+
+        1.0 at/below the limit; ramps linearly to the floor across the band;
+        pinned at the floor at/above ``limit + band``.
+        """
+        c = self._controller
+        limit_c = c._temp_charge_limit_c
+        band_c = c._temp_charge_limit_band_c
+        floor = c._temp_charge_limit_floor_pct / 100.0
+
+        if temp <= limit_c:
+            return 1.0
+        if band_c <= 0 or temp >= limit_c + band_c:
+            return floor
+        frac = (temp - limit_c) / band_c  # 0..1 across the band
+        return 1.0 - frac * (1.0 - floor)
+
+    @staticmethod
+    def _min_power(coordinator, is_charging: bool) -> int:
+        """The battery's minimum reliable operating power (0 when it has none).
+
+        Read from the driver capabilities, which derive it from the
+        max_charge/discharge_power register floor (v2/v3 = 800 W, vA/vD/Zendure = 0).
+        """
+        caps = getattr(coordinator, "capabilities", None)
+        attr = "min_charge_power_w" if is_charging else "min_discharge_power_w"
+        return int(getattr(caps, attr, 0) or 0)
+
+    def _apply(self, coordinator, limit: int, is_charging: bool) -> int:
+        """Cap ``limit`` by the thermal derate factor (fail-safe passthrough)."""
+        temp = (coordinator.data or {}).get("internal_temperature")
+        if temp is None:
+            return limit
+        try:
+            temp_f = float(temp)
+        except (TypeError, ValueError):
+            return limit
+
+        factor = self._derate_factor(temp_f)
+        if factor >= 1.0:
+            return limit
+        derated = min(limit, int(round(limit * factor)))
+        # Hard floor: never command a non-zero power below the battery's minimum
+        # reliable operating power (v2/v3 = 800 W; vA/vD/Zendure = 0). Never raise
+        # above a limit that was already below that floor.
+        return max(derated, min(self._min_power(coordinator, is_charging), limit))
+
+    def apply_temperature_limit(self, coordinator, limit: int) -> int:
+        """Cap the per-battery charge limit by the thermal derate factor."""
+        if not self._controller.temp_charge_limit_enabled:
+            return limit
+        return self._apply(coordinator, limit, True)
+
+    def apply_discharge_limit(self, coordinator, limit: int) -> int:
+        """Cap the per-battery discharge limit, when opted in.
+
+        Uses the same (charge-tuned) curve; discharge tolerates heat better, so
+        this is a compromise whose main value is avoiding the BMS hard cutoff.
+        """
+        c = self._controller
+        if not (c.temp_charge_limit_enabled and c.temp_limit_apply_discharge):
+            return limit
+        return self._apply(coordinator, limit, False)
+
+    def get_status(self) -> dict:
+        """Return per-battery thermal-derate diagnostics for the status sensor."""
+        c = self._controller
+        status: dict = {}
+        for coordinator in c.coordinators:
+            data = coordinator.data or {}
+            temp = data.get("internal_temperature")
+            try:
+                temp_f = float(temp) if temp is not None else None
+            except (TypeError, ValueError):
+                temp_f = None
+            factor = self._derate_factor(temp_f) if temp_f is not None else 1.0
+            status[coordinator.name] = {
+                "enabled": c.temp_charge_limit_enabled,
+                "apply_discharge": c.temp_limit_apply_discharge,
+                "internal_temperature": temp,
+                "limit_c": c._temp_charge_limit_c,
+                "band_c": c._temp_charge_limit_band_c,
+                "floor_pct": c._temp_charge_limit_floor_pct,
+                "derate_factor": round(factor, 3),
+                "derating": c.temp_charge_limit_enabled and temp_f is not None and factor < 1.0,
+            }
+        return status

--- a/custom_components/omnibattery/drivers/base.py
+++ b/custom_components/omnibattery/drivers/base.py
@@ -98,6 +98,14 @@ class DriverCapabilities:
     # actuator can take seconds. Defaults to the fast (register) case.
     actuator_latency_s: float = 0.5
 
+    # Minimum reliable operating power (watts, per unit) below which the hardware
+    # will not sustain a non-zero charge/discharge. Marstek v2/v3 report 800 W (the
+    # max_charge/discharge_power register floor); vA/vD/Zendure have no such floor
+    # and report 0. The thermal derate clamps its non-zero output up to this value
+    # so it never dribbles an unreliable sub-minimum command. Defaults to 0 (no floor).
+    min_charge_power_w: int = 0
+    min_discharge_power_w: int = 0
+
 
 @dataclass(frozen=True)
 class SetpointResult:

--- a/custom_components/omnibattery/drivers/marstek.py
+++ b/custom_components/omnibattery/drivers/marstek.py
@@ -229,6 +229,10 @@ class MarstekModbusDriver(BatteryDriver):
         number_defs = {d.get("key"): d for d in self._definitions["number"]}
         hw_charge_ceiling = int(number_defs.get("max_charge_power", {}).get("max", max_charge_power_w))
         hw_discharge_ceiling = int(number_defs.get("max_discharge_power", {}).get("max", max_discharge_power_w))
+        # Register floor (v2/v3 = 800 W, vA/vD = 0): the minimum reliable operating
+        # power the thermal derate must not command below. 0 when absent.
+        hw_charge_floor = int(number_defs.get("max_charge_power", {}).get("min", 0))
+        hw_discharge_floor = int(number_defs.get("max_discharge_power", {}).get("min", 0))
 
         # Static capabilities, derived from the register map + the seeded entity
         # definitions so the control layer never branches on the version string.
@@ -241,6 +245,8 @@ class MarstekModbusDriver(BatteryDriver):
             push_telemetry=False,
             max_charge_power_w=hw_charge_ceiling,
             max_discharge_power_w=hw_discharge_ceiling,
+            min_charge_power_w=hw_charge_floor,
+            min_discharge_power_w=hw_discharge_floor,
             has_mppt_pv="mppt1_power" in self._telemetry_index,
             has_alarm_registers="alarm_status" in self._telemetry_index,
             has_rs485_control=REGISTER_MAP.get(version, {}).get("rs485_control") is not None,

--- a/custom_components/omnibattery/frontend/marstek-panel.js
+++ b/custom_components/omnibattery/frontend/marstek-panel.js
@@ -83,6 +83,7 @@ const I18N = {
     bcMaxCharge: "Max charge", bcMaxDischarge: "Max discharge",
     bcChargeToSoc: "Charge to SOC", bcChargeHysteresis: "Charge hysteresis", bcBackup: "Backup function", bcOffgridMode: "Off-grid mode",
     secManual: "Manual mode", itemEnable: "Enable",
+    secTempLimit: "Temperature charge limit", itemTempLimitC: "Temperature limit", itemTempLimitBand: "Ramp band", itemTempLimitFloor: "Minimum charge power", itemTempApplyDischarge: "Also throttle discharge",
     itemMaxContracted: "Max contracted power", itemSolarSafety: "Solar safety margin", itemGridChargeMargin: "Grid charge margin", itemMinSocFloorEnable: "SOC floor", itemMinSocFloor: "Guaranteed minimum SOC",
     itemSocThreshold: "SOC threshold", itemPeakLimit: "Peak limit",
     itemDelaySafety: "Safety margin", itemDelaySoc: "Delay target SOC", itemDelayDeadband: "Balance deadband",
@@ -147,6 +148,7 @@ const I18N = {
     bcMaxCharge: "Máx. carga", bcMaxDischarge: "Máx. descarga",
     bcChargeToSoc: "Cargar hasta SOC", bcChargeHysteresis: "Histéresis de carga", bcBackup: "Función de respaldo", bcOffgridMode: "Modo off-grid",
     secManual: "Modo manual", itemEnable: "Activar",
+    secTempLimit: "Límite de carga por temperatura", itemTempLimitC: "Límite de temperatura", itemTempLimitBand: "Banda de reducción", itemTempLimitFloor: "Potencia de carga mínima", itemTempApplyDischarge: "Reducir también la descarga",
     itemMaxContracted: "Potencia contratada máx.", itemSolarSafety: "Margen de seguridad solar", itemGridChargeMargin: "Margen de carga de red", itemMinSocFloorEnable: "Suelo de SOC", itemMinSocFloor: "SOC mínimo garantizado",
     itemSocThreshold: "Umbral de SOC", itemPeakLimit: "Límite de pico",
     itemDelaySafety: "Margen de seguridad", itemDelaySoc: "SOC objetivo de retardo", itemDelayDeadband: "Banda muerta de balance",
@@ -209,6 +211,7 @@ const I18N = {
     bcMaxCharge: "Màx. càrrega", bcMaxDischarge: "Màx. descàrrega",
     bcChargeToSoc: "Carregar fins a SOC", bcChargeHysteresis: "Histèresi de càrrega", bcBackup: "Funció de reserva", bcOffgridMode: "Mode fora de xarxa",
     secManual: "Mode manual", itemEnable: "Activar",
+    secTempLimit: "Límit de càrrega per temperatura", itemTempLimitC: "Límit de temperatura", itemTempLimitBand: "Banda de reducció", itemTempLimitFloor: "Potència de càrrega mínima", itemTempApplyDischarge: "Reduir també la descàrrega",
     itemMaxContracted: "Potència contractada màx.", itemSolarSafety: "Marge de seguretat solar", itemGridChargeMargin: "Marge de càrrega de xarxa", itemMinSocFloorEnable: "Terra de SOC", itemMinSocFloor: "SOC mínim garantit",
     itemSocThreshold: "Llindar de SOC", itemPeakLimit: "Límit de pic",
     itemDelaySafety: "Marge de seguretat", itemDelaySoc: "SOC objectiu de retard", itemDelayDeadband: "Banda morta de balanç",
@@ -271,6 +274,7 @@ const I18N = {
     bcMaxCharge: "Max. Ladeleistung", bcMaxDischarge: "Max. Entladeleistung",
     bcChargeToSoc: "Laden bis SOC", bcChargeHysteresis: "Ladehysterese", bcBackup: "Backup-Funktion", bcOffgridMode: "Inselnetz-Modus",
     secManual: "Manueller Modus", itemEnable: "Aktivieren",
+    secTempLimit: "Temperaturbasierte Ladebegrenzung", itemTempLimitC: "Temperaturgrenze", itemTempLimitBand: "Drosselbereich", itemTempLimitFloor: "Minimale Ladeleistung", itemTempApplyDischarge: "Auch Entladung drosseln",
     itemMaxContracted: "Max. Vertragsleistung", itemSolarSafety: "Sicherheitspuffer Solar", itemGridChargeMargin: "Netzladungs-Marge", itemMinSocFloorEnable: "SOC-Untergrenze", itemMinSocFloor: "Garantierter Mindest-SOC",
     itemSocThreshold: "SOC-Schwelle", itemPeakLimit: "Spitzenlimit",
     itemDelaySafety: "Sicherheitspuffer", itemDelaySoc: "Verzögerungs-Ziel-SOC", itemDelayDeadband: "Bilanz-Totband",
@@ -333,6 +337,7 @@ const I18N = {
     bcMaxCharge: "Charge max.", bcMaxDischarge: "Décharge max.",
     bcChargeToSoc: "Charger jusqu'à SOC", bcChargeHysteresis: "Hystérésis de charge", bcBackup: "Fonction de secours", bcOffgridMode: "Mode hors-réseau",
     secManual: "Mode manuel", itemEnable: "Activer",
+    secTempLimit: "Limite de charge par température", itemTempLimitC: "Limite de température", itemTempLimitBand: "Plage de réduction", itemTempLimitFloor: "Puissance de charge minimale", itemTempApplyDischarge: "Réduire aussi la décharge",
     itemMaxContracted: "Puissance contractuelle max.", itemSolarSafety: "Marge de sécurité solaire", itemGridChargeMargin: "Marge de charge réseau", itemMinSocFloorEnable: "Plancher SOC", itemMinSocFloor: "SOC minimum garanti",
     itemSocThreshold: "Seuil SOC", itemPeakLimit: "Limite de pointe",
     itemDelaySafety: "Marge de sécurité", itemDelaySoc: "SOC cible du délai", itemDelayDeadband: "Bande morte de bilan",
@@ -395,6 +400,7 @@ const I18N = {
     bcMaxCharge: "Max. laden", bcMaxDischarge: "Max. ontladen",
     bcChargeToSoc: "Laden tot SOC", bcChargeHysteresis: "Laadhysterese", bcBackup: "Back-upfunctie", bcOffgridMode: "Off-grid-modus",
     secManual: "Handmatige modus", itemEnable: "Inschakelen",
+    secTempLimit: "Temperatuurbegrenzing laden", itemTempLimitC: "Temperatuurlimiet", itemTempLimitBand: "Afbouwband", itemTempLimitFloor: "Minimaal laadvermogen", itemTempApplyDischarge: "Ook ontladen terugregelen",
     itemMaxContracted: "Max. gecontracteerd vermogen", itemSolarSafety: "Veiligheidsmarge zon", itemGridChargeMargin: "Netladingsmarge", itemMinSocFloorEnable: "SOC-vloer", itemMinSocFloor: "Gegarandeerde min. SOC",
     itemSocThreshold: "SOC-drempel", itemPeakLimit: "Pieklimiet",
     itemDelaySafety: "Veiligheidsmarge", itemDelaySoc: "Doel-SOC vertraging", itemDelayDeadband: "Balans dode band",
@@ -710,6 +716,17 @@ const SYS_SECTIONS = [
       { key: "capacity_protection_limit", lk: "itemPeakLimit", icon: "mdi:flash" },
     ],
   },
+  {
+    tk: "secTempLimit",
+    icon: "mdi:thermometer-alert",
+    items: [
+      { key: "temp_charge_limit", domain: "switch", lk: "itemEnable", icon: "mdi:thermometer-alert", gate: true },
+      { key: "temp_charge_limit_c", lk: "itemTempLimitC", icon: "mdi:thermometer-high" },
+      { key: "temp_charge_limit_band_c", lk: "itemTempLimitBand", icon: "mdi:thermometer-lines" },
+      { key: "temp_charge_limit_floor_pct", lk: "itemTempLimitFloor", icon: "mdi:battery-charging-low" },
+      { key: "temp_charge_limit_discharge", domain: "switch", lk: "itemTempApplyDischarge", icon: "mdi:battery-arrow-down" },
+    ],
+  },
 ];
 
 // Control tab layout, by section `tk`. Sections absent from the live registry
@@ -724,7 +741,7 @@ const SYS_LAYOUT = [
       ["secManual", "secWeeklyFull"],
       ["diagPredictive", "diagChargeDelay"],
       ["secHourly", "secSysLimits"],
-      ["diagPeak", null],
+      ["diagPeak", "secTempLimit"],
     ],
   },
   { col: ["secSlots"] },
@@ -790,6 +807,7 @@ const SYS_HELP = {
     delay_soc_setpoint: "The SOC the battery must reach before the solar delay kicks in. Minimum is 12 % — the Venus battery minimum discharge SOC.",
     capacity_protection_soc_threshold: "When average battery SOC drops below this value, capacity protection activates. The battery will stop discharging for normal consumption and only cover peaks above the limit.",
     capacity_protection_limit: "Grid import power threshold. When house consumption exceeds this value and protection is active, the battery discharges only the excess above this limit.",
+    secTempLimit: "When enabled, charge power is reduced when a battery gets hot: full power at or below the temperature limit, ramping down to the minimum over the band, and back up as it cools.",
   },
   es: {
     secManual: "Cuando está ACTIVADO, el control automático (PD, carga predictiva, franjas horarias, reducción de picos…) se pausa y todas las baterías se ponen a 0 W (en reposo). DESACTÍVALO para reanudar el control automático.",
@@ -833,6 +851,7 @@ const SYS_HELP = {
     delay_soc_setpoint: "SOC mínimo que debe alcanzar la batería antes de que el retraso solar entre en funcionamiento. El valor mínimo es el 12 % (SOC mínimo de descarga de las baterías Venus).",
     capacity_protection_soc_threshold: "Cuando el SOC medio de las baterías baje de este valor, se activa la reducción de picos. La batería dejará de descargar para consumo normal y solo cubrirá picos por encima del límite.",
     capacity_protection_limit: "Umbral de potencia de importación de red. Cuando el consumo de la casa supere este valor y la reducción de picos esté activa, la batería solo descargará el exceso por encima de este límite.",
+    secTempLimit: "Cuando está activado, la potencia de carga se reduce cuando una batería se calienta: plena potencia al límite de temperatura o por debajo, bajando hasta el mínimo a lo largo de la banda y subiendo de nuevo al enfriarse.",
   },
   ca: {
     secManual: "Quan està ACTIVAT, el control automàtic (PD, càrrega predictiva, franges horàries, reducció de pics…) es pausa i totes les bateries es posen a 0 W (en repòs). DESACTIVA'L per reprendre el control automàtic.",
@@ -875,6 +894,7 @@ const SYS_HELP = {
     delay_soc_setpoint: "SOC mínim que ha d'assolir la bateria abans que el retard solar entri en funcionament. El valor mínim és el 12 % (SOC mínim de descàrrega de les bateries Venus).",
     capacity_protection_soc_threshold: "Quan el SOC mitjà de les bateries baixi d'aquest valor, s'activa la reducció de pics. La bateria deixarà de descarregar per a consum normal i només cobrirà pics per sobre del límit.",
     capacity_protection_limit: "Llindar de potència d'importació de xarxa. Quan el consum de la casa superi aquest valor i la reducció de pics estigui activa, la bateria només descarregarà l'excés per sobre d'aquest límit.",
+    secTempLimit: "Quan està activat, la potència de càrrega es redueix quan una bateria s'escalfa: plena potència al límit de temperatura o per sota, baixant fins al mínim al llarg de la banda i pujant de nou en refredar-se.",
   },
   de: {
     secManual: "Wenn EIN, wird die automatische Regelung (PD, prädiktives Laden, Zeitfenster, Lastspitzenkappung…) pausiert und jede Batterie auf 0 W (Leerlauf) gesetzt. Schalte AUS, um die automatische Regelung fortzusetzen.",
@@ -917,6 +937,7 @@ const SYS_HELP = {
     delay_soc_setpoint: "Der SOC, den die Batterie erreichen muss, bevor die Solarverzögerung greift. Minimum ist 12 % — der minimale Entlade-SOC der Venus-Batterie.",
     capacity_protection_soc_threshold: "Wenn der durchschnittliche Batterie-SOC unter diesen Wert fällt, wird die Kapazitätsschutzfunktion aktiviert. Die Batterie entlädt nicht mehr für den normalen Verbrauch und deckt nur Spitzen über dem Limit ab.",
     capacity_protection_limit: "Netzimport-Leistungsschwelle. Wenn der Hausverbrauch diesen Wert überschreitet und der Schutz aktiv ist, entlädt die Batterie nur den Überschuss über diesem Limit.",
+    secTempLimit: "Wenn aktiviert, wird die Ladeleistung reduziert, wenn eine Batterie heiß wird: volle Leistung an oder unter der Temperaturgrenze, absinkend bis zum Minimum über den Bereich und wieder ansteigend beim Abkühlen.",
   },
   fr: {
     secManual: "Quand ACTIVÉ, le contrôle automatique (PD, charge prédictive, plages horaires, écrêtage des pics…) est mis en pause et chaque batterie est réglée à 0 W (repos). DÉSACTIVE-le pour reprendre le contrôle automatique.",
@@ -959,6 +980,7 @@ const SYS_HELP = {
     delay_soc_setpoint: "Le SOC que la batterie doit atteindre avant que le délai solaire ne s'active. Le minimum est 12 % — le SOC de décharge minimal de la batterie Venus.",
     capacity_protection_soc_threshold: "Quand le SOC moyen des batteries descend sous cette valeur, l'écrêtage des pics s'active. La batterie cesse de décharger pour la consommation normale et ne couvre que les pics au-dessus de la limite.",
     capacity_protection_limit: "Seuil de puissance d'import réseau. Quand la consommation de la maison dépasse cette valeur et que la protection est active, la batterie ne décharge que l'excédent au-dessus de cette limite.",
+    secTempLimit: "Lorsque activé, la puissance de charge est réduite quand une batterie chauffe : pleine puissance à la limite de température ou en dessous, diminuant jusqu'au minimum sur la plage, puis remontant au refroidissement.",
   },
   nl: {
     secManual: "Wanneer AAN, wordt de automatische regeling (PD, voorspellend laden, tijdvensters, piekafvlakking…) gepauzeerd en wordt elke batterij op 0 W (rust) gezet. Zet UIT om de automatische regeling te hervatten.",
@@ -1001,6 +1023,7 @@ const SYS_HELP = {
     delay_soc_setpoint: "De SOC die de batterij moet bereiken voordat de zonnevertraging ingaat. Minimum is 12 % — de minimale ontlaad-SOC van de Venus-batterij.",
     capacity_protection_soc_threshold: "Wanneer de gemiddelde batterij-SOC onder deze waarde zakt, wordt capaciteitsbescherming geactiveerd. De batterij stopt met ontladen voor normaal verbruik en dekt alleen pieken boven de limiet.",
     capacity_protection_limit: "Netimport-vermogensdrempel. Wanneer het huisverbruik deze waarde overschrijdt en de bescherming actief is, ontlaadt de batterij alleen het overschot boven deze limiet.",
+    secTempLimit: "Indien ingeschakeld wordt het laadvermogen verlaagd als een batterij warm wordt: vol vermogen op of onder de temperatuurlimiet, aflopend tot het minimum over de band en weer oplopend bij afkoelen.",
   },
 };
 

--- a/custom_components/omnibattery/number.py
+++ b/custom_components/omnibattery/number.py
@@ -18,6 +18,13 @@ from .const import (
     CONF_SYSTEM_MAX_DISCHARGE_POWER,
     CONF_MAX_PRICE_THRESHOLD,
     CONF_DISCHARGE_PRICE_THRESHOLD,
+    CONF_ENABLE_TEMP_CHARGE_LIMIT,
+    CONF_TEMP_CHARGE_LIMIT_C,
+    DEFAULT_TEMP_CHARGE_LIMIT_C,
+    CONF_TEMP_CHARGE_LIMIT_BAND_C,
+    DEFAULT_TEMP_CHARGE_LIMIT_BAND_C,
+    CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT,
+    DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT,
     CONF_PREDICTIVE_CHARGING_MODE,
     CONF_PRICE_INTEGRATION_TYPE,
     PREDICTIVE_MODE_DYNAMIC_PRICING,
@@ -99,6 +106,11 @@ async def async_setup_entry(
     ):
         entities.append(MarstekPriceThresholdNumber(hass, entry, "charge"))
         entities.append(MarstekPriceThresholdNumber(hass, entry, "discharge"))
+
+    # Temperature charge limit sliders (system-level, when the feature is configured)
+    if CONF_ENABLE_TEMP_CHARGE_LIMIT in entry.data:
+        for kind in ("limit", "band", "floor"):
+            entities.append(TempChargeLimitNumber(hass, entry, kind))
 
     # Per-excluded-device "exclusion %" sliders (runtime adjustable). EV
     # no-telemetry devices have no numeric power sensor, so the slider would do
@@ -337,6 +349,77 @@ class MarstekPriceThresholdNumber(NumberEntity):
         new_data[self._conf_key] = value
         self.hass.config_entries.async_update_entry(self.entry, data=new_data)
         _LOGGER.info("Dynamic pricing %s price threshold updated to %s", self._kind, value)
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        """Return device information for the system."""
+        return {
+            "identifiers": {(DOMAIN, "marstek_venus_system")},
+            "name": "Omnibattery System",
+            "manufacturer": "Omnibattery",
+            "model": "Multi-Battery System",
+        }
+
+
+class TempChargeLimitNumber(NumberEntity):
+    """Live-editable temperature charge-derate parameter (limit / band / floor).
+
+    Mirrors the value into ``config_entry.data``; the controller re-reads all
+    three on every entry update (``update_pd_parameters``), so a change takes
+    effect on the next control cycle.
+    """
+
+    _attr_has_entity_name = True
+    _attr_mode = NumberMode.SLIDER
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_should_poll = False
+
+    # kind -> (translation_key/entity slug, conf_key, default, unit, min, max, step, icon)
+    _SPEC = {
+        "limit": ("temp_charge_limit_c", CONF_TEMP_CHARGE_LIMIT_C, DEFAULT_TEMP_CHARGE_LIMIT_C,
+                  "°C", 20, 60, 1, "mdi:thermometer-high"),
+        "band": ("temp_charge_limit_band_c", CONF_TEMP_CHARGE_LIMIT_BAND_C, DEFAULT_TEMP_CHARGE_LIMIT_BAND_C,
+                 "°C", 1, 30, 1, "mdi:thermometer-lines"),
+        "floor": ("temp_charge_limit_floor_pct", CONF_TEMP_CHARGE_LIMIT_FLOOR_PCT, DEFAULT_TEMP_CHARGE_LIMIT_FLOOR_PCT,
+                  "%", 0, 100, 5, "mdi:battery-charging-low"),
+    }
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, kind: str) -> None:
+        """kind = 'limit' (°C), 'band' (°C) or 'floor' (% of normal charge power)."""
+        self.hass = hass
+        self.entry = entry
+        self._kind = kind
+        key, conf_key, default, unit, lo, hi, step, icon = self._SPEC[kind]
+        self._conf_key = conf_key
+        self._default = default
+        self._attr_translation_key = key
+        self._attr_unique_id = f"{SYSTEM_UNIQUE_ID_PREFIX}{key}"
+        self.entity_id = system_entity_id("number", key)
+        self._attr_native_unit_of_measurement = unit
+        self._attr_native_min_value = lo
+        self._attr_native_max_value = hi
+        self._attr_native_step = step
+        self._attr_icon = icon
+
+    async def async_added_to_hass(self) -> None:
+        """Refresh state when config_entry.data changes (options flow / sibling write)."""
+        self.async_on_remove(self.entry.add_update_listener(self._handle_entry_update))
+
+    async def _handle_entry_update(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> float:
+        """Current value from config_entry.data (default when unset)."""
+        return self.entry.data.get(self._conf_key, self._default)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Persist the new value to config_entry.data."""
+        new_data = dict(self.entry.data)
+        new_data[self._conf_key] = int(value)
+        self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+        _LOGGER.info("Temperature charge limit %s updated to %s", self._kind, int(value))
         self.async_write_ha_state()
 
     @property

--- a/custom_components/omnibattery/sensor.py
+++ b/custom_components/omnibattery/sensor.py
@@ -1185,6 +1185,10 @@ class IntegrationStatusSensor(SensorEntity):
             if status["charge_block_reason"]:
                 attrs["hourly_balance_charge_block_reason"] = status["charge_block_reason"]
 
+        temp_mgr = getattr(c, "_temp_limit_mgr", None)
+        if temp_mgr is not None and c.temp_charge_limit_enabled:
+            attrs["temperature_charge_limit"] = temp_mgr.get_status()
+
         balance_hold_batteries = self._balance_hold_batteries()
         if balance_hold_batteries:
             attrs["balance_hold_batteries"] = balance_hold_batteries

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -325,6 +325,29 @@
           "solar_forecast_sensor": "Sensor providing solar production forecast in kWh (e.g., Solcast). Not required if you already configured this sensor in the initial setup step — it will be used automatically."
         }
       },
+      "temp_charge_limit": {
+        "title": "Temperature charge limit",
+        "description": "Reduce charge power when a battery gets hot? Above a temperature limit charging is throttled proportionally and restored as the battery cools.",
+        "data": {
+          "configure_temp_charge_limit": "Configure temperature charge limit"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Temperature charge limit configuration",
+        "description": "Set the temperature at which charging starts to throttle, the band over which it ramps down, and the minimum charge power (as a percentage of normal).",
+        "data": {
+          "temp_charge_limit_c": "Temperature limit (°C)",
+          "temp_charge_limit_band_c": "Ramp band (°C)",
+          "temp_charge_limit_floor_pct": "Minimum charge power (%)",
+          "temp_limit_apply_discharge": "Also throttle discharge"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "Charging runs at full power at or below this temperature; above it the derate begins.",
+          "temp_charge_limit_band_c": "Temperature range above the limit over which charge power ramps down to the minimum.",
+          "temp_charge_limit_floor_pct": "Charge power at the limit plus the band, as a percentage of the normal charge ceiling. 0% stops charging entirely when very hot.",
+          "temp_limit_apply_discharge": "Apply the same temperature derate to discharge power. Discharge tolerates heat better, so this shares the charge threshold as a compromise; mainly it keeps discharge under the BMS hard cutoff."
+        }
+      },
       "capacity_protection": {
         "title": "Peak Shaving Mode",
         "description": "When enabled, if battery SOC drops below a threshold, the system conserves energy by only discharging to offset consumption above a peak limit.",
@@ -480,6 +503,7 @@
           "predictive_charging": "Predictive charging",
           "weekly_full_charge": "Weekly full charge",
           "charge_delay": "Solar charge delay",
+          "temp_charge_limit": "Temperature charge limit",
           "capacity_protection": "Capacity protection",
           "hourly_balance": "Hourly net balance",
           "pd_advanced": "PD controller (advanced)"
@@ -805,6 +829,29 @@
           "solar_forecast_sensor": "Sensor providing solar production forecast in kWh (e.g., Solcast). Not required if you already configured this sensor in the initial setup step — it will be used automatically."
         }
       },
+      "temp_charge_limit": {
+        "title": "Temperature charge limit",
+        "description": "Reduce charge power when a battery gets hot? Above a temperature limit charging is throttled proportionally and restored as the battery cools.",
+        "data": {
+          "configure_temp_charge_limit": "Configure temperature charge limit"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Temperature charge limit configuration",
+        "description": "Set the temperature at which charging starts to throttle, the band over which it ramps down, and the minimum charge power (as a percentage of normal).",
+        "data": {
+          "temp_charge_limit_c": "Temperature limit (°C)",
+          "temp_charge_limit_band_c": "Ramp band (°C)",
+          "temp_charge_limit_floor_pct": "Minimum charge power (%)",
+          "temp_limit_apply_discharge": "Also throttle discharge"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "Charging runs at full power at or below this temperature; above it the derate begins.",
+          "temp_charge_limit_band_c": "Temperature range above the limit over which charge power ramps down to the minimum.",
+          "temp_charge_limit_floor_pct": "Charge power at the limit plus the band, as a percentage of the normal charge ceiling. 0% stops charging entirely when very hot.",
+          "temp_limit_apply_discharge": "Apply the same temperature derate to discharge power. Discharge tolerates heat better, so this shares the charge threshold as a compromise; mainly it keeps discharge under the BMS hard cutoff."
+        }
+      },
       "capacity_protection": {
         "title": "Capacity Protection Mode",
         "description": "When enabled, if battery SOC drops below a threshold, the system conserves energy by only discharging to offset consumption above a peak limit.",
@@ -959,6 +1006,12 @@
       },
       "charge_delay": {
         "name": "Charge Delay"
+      },
+      "temp_charge_limit": {
+        "name": "Temperature Charge Limit"
+      },
+      "temp_charge_limit_discharge": {
+        "name": "Temperature Discharge Limit"
       },
       "weekly_full_charge_delay": {
         "name": "Delay Weekly Full Charge"
@@ -1449,6 +1502,15 @@
       },
       "delay_soc_setpoint": {
         "name": "Charge Delay SOC Setpoint"
+      },
+      "temp_charge_limit_c": {
+        "name": "Temperature Charge Limit"
+      },
+      "temp_charge_limit_band_c": {
+        "name": "Temperature Charge Limit Band"
+      },
+      "temp_charge_limit_floor_pct": {
+        "name": "Temperature Charge Limit Floor"
       },
       "capacity_protection_limit": {
         "name": "Peak Shaving Limit"

--- a/custom_components/omnibattery/switch.py
+++ b/custom_components/omnibattery/switch.py
@@ -17,6 +17,8 @@ from .const import (
     CONF_ACTIVE_BALANCE_MODE_ENABLED,
     CONF_CAPACITY_PROTECTION_ENABLED,
     CONF_ENABLE_CHARGE_DELAY,
+    CONF_ENABLE_TEMP_CHARGE_LIMIT,
+    CONF_TEMP_LIMIT_APPLY_DISCHARGE,
     CONF_ENABLE_HOURLY_BALANCE,
     CONF_ENABLE_SYSTEM_POWER_LIMITS,
     CONF_ENABLE_WEEKLY_FULL_CHARGE_DELAY,
@@ -84,6 +86,11 @@ async def async_setup_entry(
     # both weekly full charge and the charge delay are configured.
     if controller and controller.weekly_full_charge_enabled and has_charge_delay_config:
         entities.append(WeeklyFullChargeDelaySwitch(hass, entry, controller))
+
+    # Add temperature charge limit switch (system-level, when configured)
+    if controller and CONF_ENABLE_TEMP_CHARGE_LIMIT in entry.data:
+        entities.append(TempChargeLimitSwitch(hass, entry, controller))
+        entities.append(TempChargeLimitDischargeSwitch(hass, entry, controller))
 
     # Add hourly balance switch (system-level, when hourly balance is configured)
     if controller and CONF_ENABLE_HOURLY_BALANCE in entry.data:
@@ -628,6 +635,106 @@ class ChargeDelaySwitch(SwitchEntity):
         new_data[CONF_ENABLE_CHARGE_DELAY] = False
         self.hass.config_entries.async_update_entry(self.entry, data=new_data)
         _LOGGER.info("Charge Delay DISABLED")
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        """Return device information for the system."""
+        return {
+            "identifiers": {(DOMAIN, "marstek_venus_system")},
+            "name": "Omnibattery System",
+            "manufacturer": "Omnibattery",
+            "model": "Multi-Battery System",
+        }
+
+
+class TempChargeLimitSwitch(SwitchEntity):
+    """Switch to enable/disable temperature-based charge power limiting."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, controller) -> None:
+        """Initialize the temperature charge limit switch."""
+        self.hass = hass
+        self.entry = entry
+        self.controller = controller
+
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "temp_charge_limit"
+        self._attr_unique_id = f"{SYSTEM_UNIQUE_ID_PREFIX}temp_charge_limit"
+        self.entity_id = system_entity_id("switch", "temp_charge_limit")
+        self._attr_icon = "mdi:thermometer-alert"
+        self._attr_should_poll = False
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if temperature charge limiting is enabled."""
+        return self.controller.temp_charge_limit_enabled
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable temperature charge limiting."""
+        self.controller.temp_charge_limit_enabled = True
+        new_data = dict(self.entry.data)
+        new_data[CONF_ENABLE_TEMP_CHARGE_LIMIT] = True
+        self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+        _LOGGER.info("Temperature Charge Limit ENABLED")
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable temperature charge limiting."""
+        self.controller.temp_charge_limit_enabled = False
+        new_data = dict(self.entry.data)
+        new_data[CONF_ENABLE_TEMP_CHARGE_LIMIT] = False
+        self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+        _LOGGER.info("Temperature Charge Limit DISABLED")
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        """Return device information for the system."""
+        return {
+            "identifiers": {(DOMAIN, "marstek_venus_system")},
+            "name": "Omnibattery System",
+            "manufacturer": "Omnibattery",
+            "model": "Multi-Battery System",
+        }
+
+
+class TempChargeLimitDischargeSwitch(SwitchEntity):
+    """Sub-toggle: also apply the thermal derate to discharge power."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, controller) -> None:
+        """Initialize the discharge sub-toggle."""
+        self.hass = hass
+        self.entry = entry
+        self.controller = controller
+
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "temp_charge_limit_discharge"
+        self._attr_unique_id = f"{SYSTEM_UNIQUE_ID_PREFIX}temp_charge_limit_discharge"
+        self.entity_id = system_entity_id("switch", "temp_charge_limit_discharge")
+        self._attr_icon = "mdi:battery-arrow-down"
+        self._attr_should_poll = False
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the derate also applies to discharge."""
+        return self.controller.temp_limit_apply_discharge
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Apply the derate to discharge as well."""
+        self.controller.temp_limit_apply_discharge = True
+        new_data = dict(self.entry.data)
+        new_data[CONF_TEMP_LIMIT_APPLY_DISCHARGE] = True
+        self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+        _LOGGER.info("Temperature Charge Limit: discharge derate ENABLED")
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Limit the derate to charge only."""
+        self.controller.temp_limit_apply_discharge = False
+        new_data = dict(self.entry.data)
+        new_data[CONF_TEMP_LIMIT_APPLY_DISCHARGE] = False
+        self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+        _LOGGER.info("Temperature Charge Limit: discharge derate DISABLED")
         self.async_write_ha_state()
 
     @property

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -333,6 +333,29 @@
           "solar_forecast_sensor": "Sensor que proporciona la predicció de producció solar en kWh (ex: Solcast). No cal si ja has configurat aquest sensor al pas inicial: s'utilitzarà automàticament."
         }
       },
+      "temp_charge_limit": {
+        "title": "Límit de càrrega per temperatura",
+        "description": "Voleu reduir la potència de càrrega quan una bateria s'escalfa? Per damunt d'un límit de temperatura la càrrega es redueix progressivament i es restableix quan la bateria es refreda.",
+        "data": {
+          "configure_temp_charge_limit": "Configurar el límit de càrrega per temperatura"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Configuració del límit de càrrega per temperatura",
+        "description": "Definiu la temperatura a què la càrrega comença a reduir-se, la banda en què disminueix i la potència de càrrega mínima (com a percentatge de la normal).",
+        "data": {
+          "temp_charge_limit_c": "Límit de temperatura (°C)",
+          "temp_charge_limit_band_c": "Banda de reducció (°C)",
+          "temp_charge_limit_floor_pct": "Potència de càrrega mínima (%)",
+          "temp_limit_apply_discharge": "Reduir també la descàrrega"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "La càrrega funciona a plena potència a aquesta temperatura o per sota; per damunt comença la reducció.",
+          "temp_charge_limit_band_c": "Rang de temperatura per damunt del límit en què la potència de càrrega baixa fins al mínim.",
+          "temp_charge_limit_floor_pct": "Potència de càrrega al límit més la banda, com a percentatge del màxim de càrrega normal. 0% atura la càrrega completament quan fa molta calor.",
+          "temp_limit_apply_discharge": "Aplica la mateixa reducció per temperatura a la potència de descàrrega. La descàrrega tolera millor la calor, així que comparteix el llindar de càrrega com a compromís; sobretot manté la descàrrega per sota del tall dur del BMS."
+        }
+      },
       "capacity_protection": {
         "title": "Mode de reducció de pics",
         "description": "Si s'activa, quan el SOC de la bateria baixi d'un llindar, el sistema conservarà energia descarregant només per cobrir consum que superi un límit pic.",
@@ -489,6 +512,7 @@
           "predictive_charging": "Càrrega predictiva",
           "weekly_full_charge": "Càrrega completa setmanal",
           "charge_delay": "Retard de càrrega solar",
+          "temp_charge_limit": "Límit de càrrega per temperatura",
           "capacity_protection": "Protecció de capacitat",
           "hourly_balance": "Balanç net horari",
           "pd_advanced": "Controlador PD (avançat)"
@@ -822,6 +846,29 @@
           "solar_forecast_sensor": "Sensor que proporciona la predicció de producció solar en kWh (ex: Solcast). No cal si ja has configurat aquest sensor al pas inicial: s'utilitzarà automàticament."
         }
       },
+      "temp_charge_limit": {
+        "title": "Límit de càrrega per temperatura",
+        "description": "Voleu reduir la potència de càrrega quan una bateria s'escalfa? Per damunt d'un límit de temperatura la càrrega es redueix progressivament i es restableix quan la bateria es refreda.",
+        "data": {
+          "configure_temp_charge_limit": "Configurar el límit de càrrega per temperatura"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Configuració del límit de càrrega per temperatura",
+        "description": "Definiu la temperatura a què la càrrega comença a reduir-se, la banda en què disminueix i la potència de càrrega mínima (com a percentatge de la normal).",
+        "data": {
+          "temp_charge_limit_c": "Límit de temperatura (°C)",
+          "temp_charge_limit_band_c": "Banda de reducció (°C)",
+          "temp_charge_limit_floor_pct": "Potència de càrrega mínima (%)",
+          "temp_limit_apply_discharge": "Reduir també la descàrrega"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "La càrrega funciona a plena potència a aquesta temperatura o per sota; per damunt comença la reducció.",
+          "temp_charge_limit_band_c": "Rang de temperatura per damunt del límit en què la potència de càrrega baixa fins al mínim.",
+          "temp_charge_limit_floor_pct": "Potència de càrrega al límit més la banda, com a percentatge del màxim de càrrega normal. 0% atura la càrrega completament quan fa molta calor.",
+          "temp_limit_apply_discharge": "Aplica la mateixa reducció per temperatura a la potència de descàrrega. La descàrrega tolera millor la calor, així que comparteix el llindar de càrrega com a compromís; sobretot manté la descàrrega per sota del tall dur del BMS."
+        }
+      },
       "capacity_protection": {
         "title": "Mode de reducció de pics",
         "description": "Si s'activa, quan el SOC de la bateria baixi d'un llindar, el sistema conservarà energia descarregant només per cobrir consum que superi un límit pic.",
@@ -977,6 +1024,12 @@
       },
       "charge_delay": {
         "name": "Retard de Càrrega"
+      },
+      "temp_charge_limit": {
+        "name": "Límit de càrrega per temperatura"
+      },
+      "temp_charge_limit_discharge": {
+        "name": "Límit de descàrrega per temperatura"
       },
       "weekly_full_charge_delay": {
         "name": "Retardar Càrrega Setmanal Completa"
@@ -1467,6 +1520,15 @@
       },
       "delay_soc_setpoint": {
         "name": "Retard de Càrrega – SOC Setpoint"
+      },
+      "temp_charge_limit_c": {
+        "name": "Límit de càrrega per temperatura"
+      },
+      "temp_charge_limit_band_c": {
+        "name": "Banda de càrrega per temperatura"
+      },
+      "temp_charge_limit_floor_pct": {
+        "name": "Potència mínima de càrrega"
       },
       "capacity_protection_limit": {
         "name": "Reducció de Pics – Límit"

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -333,6 +333,29 @@
           "solar_forecast_sensor": "Sensor, der die Solarproduktionsprognose in kWh liefert (z.B. Solcast). Nicht erforderlich, wenn dieser Sensor bereits im ersten Schritt konfiguriert wurde — er wird automatisch verwendet."
         }
       },
+      "temp_charge_limit": {
+        "title": "Temperaturbasierte Ladebegrenzung",
+        "description": "Ladeleistung reduzieren, wenn eine Batterie heiß wird? Oberhalb einer Temperaturgrenze wird das Laden proportional gedrosselt und beim Abkühlen wiederhergestellt.",
+        "data": {
+          "configure_temp_charge_limit": "Temperaturbasierte Ladebegrenzung konfigurieren"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Konfiguration der temperaturbasierten Ladebegrenzung",
+        "description": "Legen Sie die Temperatur fest, ab der das Laden gedrosselt wird, den Bereich, über den es abnimmt, und die minimale Ladeleistung (als Prozentsatz der normalen).",
+        "data": {
+          "temp_charge_limit_c": "Temperaturgrenze (°C)",
+          "temp_charge_limit_band_c": "Drosselbereich (°C)",
+          "temp_charge_limit_floor_pct": "Minimale Ladeleistung (%)",
+          "temp_limit_apply_discharge": "Auch Entladung drosseln"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "Bei oder unter dieser Temperatur lädt die Batterie mit voller Leistung; darüber beginnt die Drosselung.",
+          "temp_charge_limit_band_c": "Temperaturbereich oberhalb der Grenze, über den die Ladeleistung auf das Minimum absinkt.",
+          "temp_charge_limit_floor_pct": "Ladeleistung bei Grenze plus Bereich, als Prozentsatz der normalen Ladeobergrenze. 0% stoppt das Laden vollständig, wenn es sehr heiß ist.",
+          "temp_limit_apply_discharge": "Wendet dieselbe temperaturbasierte Drosselung auf die Entladeleistung an. Entladen verträgt Hitze besser, daher teilt es sich die Ladeschwelle als Kompromiss; vor allem hält es die Entladung unter der harten BMS-Abschaltung."
+        }
+      },
       "capacity_protection": {
         "title": "Spitzenlastkappung",
         "description": "Wenn aktiviert, wird das System bei niedrigem Batterie-SOC Energie sparen und nur entladen, um Verbrauch über einem Spitzenlimit auszugleichen.",
@@ -489,6 +512,7 @@
           "predictive_charging": "Prädiktive Ladung",
           "weekly_full_charge": "Wöchentliche Vollladung",
           "charge_delay": "Solarladungsverzögerung",
+          "temp_charge_limit": "Temperaturbasierte Ladebegrenzung",
           "capacity_protection": "Kapazitätsschutz",
           "pd_advanced": "PD-Regler (erweitert)",
           "hourly_balance": "Stündliche Netzbalance"
@@ -822,6 +846,29 @@
           "solar_forecast_sensor": "Sensor, der die Solarproduktionsprognose in kWh liefert (z.B. Solcast). Nicht erforderlich, wenn dieser Sensor bereits im ersten Schritt konfiguriert wurde — er wird automatisch verwendet."
         }
       },
+      "temp_charge_limit": {
+        "title": "Temperaturbasierte Ladebegrenzung",
+        "description": "Ladeleistung reduzieren, wenn eine Batterie heiß wird? Oberhalb einer Temperaturgrenze wird das Laden proportional gedrosselt und beim Abkühlen wiederhergestellt.",
+        "data": {
+          "configure_temp_charge_limit": "Temperaturbasierte Ladebegrenzung konfigurieren"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Konfiguration der temperaturbasierten Ladebegrenzung",
+        "description": "Legen Sie die Temperatur fest, ab der das Laden gedrosselt wird, den Bereich, über den es abnimmt, und die minimale Ladeleistung (als Prozentsatz der normalen).",
+        "data": {
+          "temp_charge_limit_c": "Temperaturgrenze (°C)",
+          "temp_charge_limit_band_c": "Drosselbereich (°C)",
+          "temp_charge_limit_floor_pct": "Minimale Ladeleistung (%)",
+          "temp_limit_apply_discharge": "Auch Entladung drosseln"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "Bei oder unter dieser Temperatur lädt die Batterie mit voller Leistung; darüber beginnt die Drosselung.",
+          "temp_charge_limit_band_c": "Temperaturbereich oberhalb der Grenze, über den die Ladeleistung auf das Minimum absinkt.",
+          "temp_charge_limit_floor_pct": "Ladeleistung bei Grenze plus Bereich, als Prozentsatz der normalen Ladeobergrenze. 0% stoppt das Laden vollständig, wenn es sehr heiß ist.",
+          "temp_limit_apply_discharge": "Wendet dieselbe temperaturbasierte Drosselung auf die Entladeleistung an. Entladen verträgt Hitze besser, daher teilt es sich die Ladeschwelle als Kompromiss; vor allem hält es die Entladung unter der harten BMS-Abschaltung."
+        }
+      },
       "capacity_protection": {
         "title": "Spitzenlastkappung",
         "description": "Wenn aktiviert, wird das System bei niedrigem Batterie-SOC Energie sparen und nur entladen, um Verbrauch über einem Spitzenlimit auszugleichen.",
@@ -977,6 +1024,12 @@
       },
       "charge_delay": {
         "name": "Ladeverzögerung"
+      },
+      "temp_charge_limit": {
+        "name": "Temperaturbasierte Ladebegrenzung"
+      },
+      "temp_charge_limit_discharge": {
+        "name": "Temperatur-Entladegrenze"
       },
       "weekly_full_charge_delay": {
         "name": "Wöchentliche Vollladung verzögern"
@@ -1467,6 +1520,15 @@
       },
       "delay_soc_setpoint": {
         "name": "Ladungsverzögerung – SOC-Schwellwert"
+      },
+      "temp_charge_limit_c": {
+        "name": "Temperatur-Ladegrenze"
+      },
+      "temp_charge_limit_band_c": {
+        "name": "Temperatur-Ladebereich"
+      },
+      "temp_charge_limit_floor_pct": {
+        "name": "Minimale Ladeleistung"
       },
       "capacity_protection_limit": {
         "name": "Spitzenlastkappung Limit"

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -327,6 +327,29 @@
           "solar_forecast_sensor": "Sensor providing solar production forecast in kWh (e.g., Solcast). Not required if you already configured this sensor in the initial setup step — it will be used automatically."
         }
       },
+      "temp_charge_limit": {
+        "title": "Temperature charge limit",
+        "description": "Reduce charge power when a battery gets hot? Above a temperature limit charging is throttled proportionally and restored as the battery cools.",
+        "data": {
+          "configure_temp_charge_limit": "Configure temperature charge limit"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Temperature charge limit configuration",
+        "description": "Set the temperature at which charging starts to throttle, the band over which it ramps down, and the minimum charge power (as a percentage of normal).",
+        "data": {
+          "temp_charge_limit_c": "Temperature limit (°C)",
+          "temp_charge_limit_band_c": "Ramp band (°C)",
+          "temp_charge_limit_floor_pct": "Minimum charge power (%)",
+          "temp_limit_apply_discharge": "Also throttle discharge"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "Charging runs at full power at or below this temperature; above it the derate begins.",
+          "temp_charge_limit_band_c": "Temperature range above the limit over which charge power ramps down to the minimum.",
+          "temp_charge_limit_floor_pct": "Charge power at the limit plus the band, as a percentage of the normal charge ceiling. 0% stops charging entirely when very hot.",
+          "temp_limit_apply_discharge": "Apply the same temperature derate to discharge power. Discharge tolerates heat better, so this shares the charge threshold as a compromise; mainly it keeps discharge under the BMS hard cutoff."
+        }
+      },
       "capacity_protection": {
         "title": "Peak Shaving Mode",
         "description": "When enabled, if battery SOC drops below a threshold, the system conserves energy by only discharging to offset consumption above a peak limit.",
@@ -483,6 +506,7 @@
           "predictive_charging": "Predictive charging",
           "weekly_full_charge": "Weekly full charge",
           "charge_delay": "Solar charge delay",
+          "temp_charge_limit": "Temperature charge limit",
           "capacity_protection": "Capacity protection",
           "hourly_balance": "Hourly net balance",
           "pd_advanced": "PD controller (advanced)"
@@ -810,6 +834,29 @@
           "solar_forecast_sensor": "Sensor providing solar production forecast in kWh (e.g., Solcast). Not required if you already configured this sensor in the initial setup step — it will be used automatically."
         }
       },
+      "temp_charge_limit": {
+        "title": "Temperature charge limit",
+        "description": "Reduce charge power when a battery gets hot? Above a temperature limit charging is throttled proportionally and restored as the battery cools.",
+        "data": {
+          "configure_temp_charge_limit": "Configure temperature charge limit"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Temperature charge limit configuration",
+        "description": "Set the temperature at which charging starts to throttle, the band over which it ramps down, and the minimum charge power (as a percentage of normal).",
+        "data": {
+          "temp_charge_limit_c": "Temperature limit (°C)",
+          "temp_charge_limit_band_c": "Ramp band (°C)",
+          "temp_charge_limit_floor_pct": "Minimum charge power (%)",
+          "temp_limit_apply_discharge": "Also throttle discharge"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "Charging runs at full power at or below this temperature; above it the derate begins.",
+          "temp_charge_limit_band_c": "Temperature range above the limit over which charge power ramps down to the minimum.",
+          "temp_charge_limit_floor_pct": "Charge power at the limit plus the band, as a percentage of the normal charge ceiling. 0% stops charging entirely when very hot.",
+          "temp_limit_apply_discharge": "Apply the same temperature derate to discharge power. Discharge tolerates heat better, so this shares the charge threshold as a compromise; mainly it keeps discharge under the BMS hard cutoff."
+        }
+      },
       "capacity_protection": {
         "title": "Capacity Protection Mode",
         "description": "When enabled, if battery SOC drops below a threshold, the system conserves energy by only discharging to offset consumption above a peak limit.",
@@ -968,6 +1015,12 @@
       },
       "charge_delay": {
         "name": "Charge Delay"
+      },
+      "temp_charge_limit": {
+        "name": "Temperature Charge Limit"
+      },
+      "temp_charge_limit_discharge": {
+        "name": "Temperature Discharge Limit"
       },
       "weekly_full_charge_delay": {
         "name": "Delay Weekly Full Charge"
@@ -1455,6 +1508,15 @@
       },
       "delay_soc_setpoint": {
         "name": "Charge Delay SOC Setpoint"
+      },
+      "temp_charge_limit_c": {
+        "name": "Temperature Charge Limit"
+      },
+      "temp_charge_limit_band_c": {
+        "name": "Temperature Charge Limit Band"
+      },
+      "temp_charge_limit_floor_pct": {
+        "name": "Temperature Charge Limit Floor"
       },
       "capacity_protection_limit": {
         "name": "Peak Shaving Limit"

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -333,6 +333,29 @@
           "solar_forecast_sensor": "Sensor que proporciona la predicción de producción solar en kWh (ej: Solcast). No es necesario si ya configuraste este sensor en el paso inicial: se usará automáticamente."
         }
       },
+      "temp_charge_limit": {
+        "title": "Límite de carga por temperatura",
+        "description": "¿Reducir la potencia de carga cuando una batería se calienta? Por encima de un límite de temperatura la carga se reduce progresivamente y se restablece cuando la batería se enfría.",
+        "data": {
+          "configure_temp_charge_limit": "Configurar límite de carga por temperatura"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Configuración del límite de carga por temperatura",
+        "description": "Define la temperatura a la que la carga empieza a reducirse, la banda en la que disminuye y la potencia de carga mínima (como porcentaje de la normal).",
+        "data": {
+          "temp_charge_limit_c": "Límite de temperatura (°C)",
+          "temp_charge_limit_band_c": "Banda de reducción (°C)",
+          "temp_charge_limit_floor_pct": "Potencia de carga mínima (%)",
+          "temp_limit_apply_discharge": "Reducir también la descarga"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "La carga funciona a plena potencia a esta temperatura o por debajo; por encima comienza la reducción.",
+          "temp_charge_limit_band_c": "Rango de temperatura por encima del límite en el que la potencia de carga baja hasta el mínimo.",
+          "temp_charge_limit_floor_pct": "Potencia de carga en el límite más la banda, como porcentaje del máximo de carga normal. 0% detiene la carga por completo cuando hace mucho calor.",
+          "temp_limit_apply_discharge": "Aplica la misma reducción por temperatura a la potencia de descarga. La descarga tolera mejor el calor, por lo que comparte el umbral de carga como compromiso; sobre todo mantiene la descarga por debajo del corte duro del BMS."
+        }
+      },
       "capacity_protection": {
         "title": "Modo de reducción de picos",
         "description": "Si se activa, cuando el SOC de la batería baje de un umbral, el sistema conservará energía descargando solo para cubrir consumo que supere un límite pico.",
@@ -489,6 +512,7 @@
           "predictive_charging": "Carga predictiva",
           "weekly_full_charge": "Carga completa semanal",
           "charge_delay": "Retraso de carga solar",
+          "temp_charge_limit": "Límite de carga por temperatura",
           "capacity_protection": "Protección de capacidad",
           "hourly_balance": "Balance neto horario",
           "pd_advanced": "Controlador PD (avanzado)"
@@ -822,6 +846,29 @@
           "solar_forecast_sensor": "Sensor que proporciona la predicción de producción solar en kWh (ej: Solcast). No es necesario si ya configuraste este sensor en el paso inicial: se usará automáticamente."
         }
       },
+      "temp_charge_limit": {
+        "title": "Límite de carga por temperatura",
+        "description": "¿Reducir la potencia de carga cuando una batería se calienta? Por encima de un límite de temperatura la carga se reduce progresivamente y se restablece cuando la batería se enfría.",
+        "data": {
+          "configure_temp_charge_limit": "Configurar límite de carga por temperatura"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Configuración del límite de carga por temperatura",
+        "description": "Define la temperatura a la que la carga empieza a reducirse, la banda en la que disminuye y la potencia de carga mínima (como porcentaje de la normal).",
+        "data": {
+          "temp_charge_limit_c": "Límite de temperatura (°C)",
+          "temp_charge_limit_band_c": "Banda de reducción (°C)",
+          "temp_charge_limit_floor_pct": "Potencia de carga mínima (%)",
+          "temp_limit_apply_discharge": "Reducir también la descarga"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "La carga funciona a plena potencia a esta temperatura o por debajo; por encima comienza la reducción.",
+          "temp_charge_limit_band_c": "Rango de temperatura por encima del límite en el que la potencia de carga baja hasta el mínimo.",
+          "temp_charge_limit_floor_pct": "Potencia de carga en el límite más la banda, como porcentaje del máximo de carga normal. 0% detiene la carga por completo cuando hace mucho calor.",
+          "temp_limit_apply_discharge": "Aplica la misma reducción por temperatura a la potencia de descarga. La descarga tolera mejor el calor, por lo que comparte el umbral de carga como compromiso; sobre todo mantiene la descarga por debajo del corte duro del BMS."
+        }
+      },
       "capacity_protection": {
         "title": "Modo de reducción de picos",
         "description": "Si se activa, cuando el SOC de la batería baje de un umbral, el sistema conservará energía descargando solo para cubrir consumo que supere un límite pico.",
@@ -980,6 +1027,12 @@
       },
       "charge_delay": {
         "name": "Retraso de Carga"
+      },
+      "temp_charge_limit": {
+        "name": "Límite de carga por temperatura"
+      },
+      "temp_charge_limit_discharge": {
+        "name": "Límite de descarga por temperatura"
       },
       "weekly_full_charge_delay": {
         "name": "Retrasar Carga Semanal Completa"
@@ -1467,6 +1520,15 @@
       },
       "delay_soc_setpoint": {
         "name": "Retraso de Carga – SOC Setpoint"
+      },
+      "temp_charge_limit_c": {
+        "name": "Límite de carga por temperatura"
+      },
+      "temp_charge_limit_band_c": {
+        "name": "Banda de carga por temperatura"
+      },
+      "temp_charge_limit_floor_pct": {
+        "name": "Potencia mínima de carga"
       },
       "capacity_protection_limit": {
         "name": "Reducción de Picos – Límite"

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -333,6 +333,29 @@
           "solar_forecast_sensor": "Capteur fournissant la prévision de production solaire en kWh (ex : Solcast). Non requis si ce capteur a déjà été configuré à l'étape initiale — il sera utilisé automatiquement."
         }
       },
+      "temp_charge_limit": {
+        "title": "Limite de charge par température",
+        "description": "Réduire la puissance de charge quand une batterie chauffe ? Au-dessus d'une limite de température, la charge est réduite progressivement puis rétablie au refroidissement.",
+        "data": {
+          "configure_temp_charge_limit": "Configurer la limite de charge par température"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Configuration de la limite de charge par température",
+        "description": "Définissez la température à laquelle la charge commence à être réduite, la plage sur laquelle elle diminue et la puissance de charge minimale (en pourcentage de la normale).",
+        "data": {
+          "temp_charge_limit_c": "Limite de température (°C)",
+          "temp_charge_limit_band_c": "Plage de réduction (°C)",
+          "temp_charge_limit_floor_pct": "Puissance de charge minimale (%)",
+          "temp_limit_apply_discharge": "Réduire aussi la décharge"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "La charge fonctionne à pleine puissance à cette température ou en dessous ; au-dessus, la réduction commence.",
+          "temp_charge_limit_band_c": "Plage de température au-dessus de la limite sur laquelle la puissance de charge descend jusqu'au minimum.",
+          "temp_charge_limit_floor_pct": "Puissance de charge à la limite plus la plage, en pourcentage du plafond de charge normal. 0 % arrête complètement la charge en cas de forte chaleur.",
+          "temp_limit_apply_discharge": "Applique la même réduction par température à la puissance de décharge. La décharge tolère mieux la chaleur, elle partage donc le seuil de charge en compromis ; surtout, elle maintient la décharge sous la coupure dure du BMS."
+        }
+      },
       "capacity_protection": {
         "title": "Mode écrêtement de pointe",
         "description": "Si activé, lorsque le SOC de la batterie descend en dessous d'un seuil, le système économise l'énergie en ne déchargeant que pour compenser la consommation dépassant une limite de pointe.",
@@ -489,6 +512,7 @@
           "predictive_charging": "Charge prédictive",
           "weekly_full_charge": "Charge complète hebdomadaire",
           "charge_delay": "Retard de charge solaire",
+          "temp_charge_limit": "Limite de charge par température",
           "capacity_protection": "Protection de capacité",
           "pd_advanced": "Contrôleur PD (avancé)",
           "hourly_balance": "Bilan horaire net"
@@ -822,6 +846,29 @@
           "solar_forecast_sensor": "Capteur fournissant la prévision de production solaire en kWh (ex : Solcast). Non requis si ce capteur a déjà été configuré à l'étape initiale — il sera utilisé automatiquement."
         }
       },
+      "temp_charge_limit": {
+        "title": "Limite de charge par température",
+        "description": "Réduire la puissance de charge quand une batterie chauffe ? Au-dessus d'une limite de température, la charge est réduite progressivement puis rétablie au refroidissement.",
+        "data": {
+          "configure_temp_charge_limit": "Configurer la limite de charge par température"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Configuration de la limite de charge par température",
+        "description": "Définissez la température à laquelle la charge commence à être réduite, la plage sur laquelle elle diminue et la puissance de charge minimale (en pourcentage de la normale).",
+        "data": {
+          "temp_charge_limit_c": "Limite de température (°C)",
+          "temp_charge_limit_band_c": "Plage de réduction (°C)",
+          "temp_charge_limit_floor_pct": "Puissance de charge minimale (%)",
+          "temp_limit_apply_discharge": "Réduire aussi la décharge"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "La charge fonctionne à pleine puissance à cette température ou en dessous ; au-dessus, la réduction commence.",
+          "temp_charge_limit_band_c": "Plage de température au-dessus de la limite sur laquelle la puissance de charge descend jusqu'au minimum.",
+          "temp_charge_limit_floor_pct": "Puissance de charge à la limite plus la plage, en pourcentage du plafond de charge normal. 0 % arrête complètement la charge en cas de forte chaleur.",
+          "temp_limit_apply_discharge": "Applique la même réduction par température à la puissance de décharge. La décharge tolère mieux la chaleur, elle partage donc le seuil de charge en compromis ; surtout, elle maintient la décharge sous la coupure dure du BMS."
+        }
+      },
       "capacity_protection": {
         "title": "Mode écrêtement de pointe",
         "description": "Si activé, lorsque le SOC de la batterie descend en dessous d'un seuil, le système économise l'énergie en ne déchargeant que pour compenser la consommation dépassant une limite de pointe.",
@@ -977,6 +1024,12 @@
       },
       "charge_delay": {
         "name": "Délai de Charge"
+      },
+      "temp_charge_limit": {
+        "name": "Limite de charge par température"
+      },
+      "temp_charge_limit_discharge": {
+        "name": "Limite de décharge par température"
       },
       "weekly_full_charge_delay": {
         "name": "Retarder la Charge Complète Hebdomadaire"
@@ -1467,6 +1520,15 @@
       },
       "delay_soc_setpoint": {
         "name": "Retard de Charge – SOC Seuil"
+      },
+      "temp_charge_limit_c": {
+        "name": "Limite de charge par température"
+      },
+      "temp_charge_limit_band_c": {
+        "name": "Plage de charge par température"
+      },
+      "temp_charge_limit_floor_pct": {
+        "name": "Puissance de charge minimale"
       },
       "capacity_protection_limit": {
         "name": "Écrêtement de Pointe – Limite"

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -333,6 +333,29 @@
           "solar_forecast_sensor": "Sensor die de zonneproductievoorspelling in kWh levert (bijv. Solcast). Niet vereist als u deze sensor al in de eerste stap heeft geconfigureerd — hij wordt automatisch gebruikt."
         }
       },
+      "temp_charge_limit": {
+        "title": "Temperatuurbegrenzing laden",
+        "description": "Laadvermogen verlagen als een batterij te warm wordt? Boven een temperatuurlimiet wordt het laden geleidelijk teruggeregeld en weer hersteld als de batterij afkoelt.",
+        "data": {
+          "configure_temp_charge_limit": "Temperatuurbegrenzing laden instellen"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Instellingen temperatuurbegrenzing laden",
+        "description": "Stel de temperatuur in waarbij het laden gaat terugregelen, de band waarover dit afbouwt, en het minimale laadvermogen (als percentage van normaal).",
+        "data": {
+          "temp_charge_limit_c": "Temperatuurlimiet (°C)",
+          "temp_charge_limit_band_c": "Afbouwband (°C)",
+          "temp_charge_limit_floor_pct": "Minimaal laadvermogen (%)",
+          "temp_limit_apply_discharge": "Ook ontladen terugregelen"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "Onder of op deze temperatuur laadt de batterij op vol vermogen; daarboven begint het terugregelen.",
+          "temp_charge_limit_band_c": "Temperatuurbereik boven de limiet waarover het laadvermogen afbouwt naar het minimum.",
+          "temp_charge_limit_floor_pct": "Laadvermogen bij limiet plus band, als percentage van het normale laadmaximum. 0% stopt het laden volledig als het zeer warm is.",
+          "temp_limit_apply_discharge": "Pas dezelfde temperatuurterugregeling toe op het ontlaadvermogen. Ontladen verdraagt warmte beter, dus dit deelt de laaddrempel als compromis; vooral houdt het het ontladen onder de harde BMS-uitschakeling."
+        }
+      },
       "capacity_protection": {
         "title": "Piekbegrenzing",
         "description": "Indien ingeschakeld, als de batterij-SOC onder een drempel daalt, spaart het systeem energie door alleen te ontladen om verbruik boven een pieklimiet te compenseren.",
@@ -489,6 +512,7 @@
           "predictive_charging": "Voorspellend laden",
           "weekly_full_charge": "Wekelijkse volledige lading",
           "charge_delay": "Zonne-oplaadvertraging",
+          "temp_charge_limit": "Temperatuurbegrenzing laden",
           "capacity_protection": "Capaciteitsbescherming",
           "pd_advanced": "PD-regelaar (geavanceerd)",
           "hourly_balance": "Uurlijks netsaldo"
@@ -822,6 +846,29 @@
           "solar_forecast_sensor": "Sensor die de zonneproductievoorspelling in kWh levert (bijv. Solcast). Niet vereist als u deze sensor al in de eerste stap heeft geconfigureerd — hij wordt automatisch gebruikt."
         }
       },
+      "temp_charge_limit": {
+        "title": "Temperatuurbegrenzing laden",
+        "description": "Laadvermogen verlagen als een batterij te warm wordt? Boven een temperatuurlimiet wordt het laden geleidelijk teruggeregeld en weer hersteld als de batterij afkoelt.",
+        "data": {
+          "configure_temp_charge_limit": "Temperatuurbegrenzing laden instellen"
+        }
+      },
+      "temp_charge_limit_config": {
+        "title": "Instellingen temperatuurbegrenzing laden",
+        "description": "Stel de temperatuur in waarbij het laden gaat terugregelen, de band waarover dit afbouwt, en het minimale laadvermogen (als percentage van normaal).",
+        "data": {
+          "temp_charge_limit_c": "Temperatuurlimiet (°C)",
+          "temp_charge_limit_band_c": "Afbouwband (°C)",
+          "temp_charge_limit_floor_pct": "Minimaal laadvermogen (%)",
+          "temp_limit_apply_discharge": "Ook ontladen terugregelen"
+        },
+        "data_description": {
+          "temp_charge_limit_c": "Onder of op deze temperatuur laadt de batterij op vol vermogen; daarboven begint het terugregelen.",
+          "temp_charge_limit_band_c": "Temperatuurbereik boven de limiet waarover het laadvermogen afbouwt naar het minimum.",
+          "temp_charge_limit_floor_pct": "Laadvermogen bij limiet plus band, als percentage van het normale laadmaximum. 0% stopt het laden volledig als het zeer warm is.",
+          "temp_limit_apply_discharge": "Pas dezelfde temperatuurterugregeling toe op het ontlaadvermogen. Ontladen verdraagt warmte beter, dus dit deelt de laaddrempel als compromis; vooral houdt het het ontladen onder de harde BMS-uitschakeling."
+        }
+      },
       "capacity_protection": {
         "title": "Piekbegrenzing",
         "description": "Indien ingeschakeld, als de batterij-SOC onder een drempel daalt, spaart het systeem energie door alleen te ontladen om verbruik boven een pieklimiet te compenseren.",
@@ -977,6 +1024,12 @@
       },
       "charge_delay": {
         "name": "Laadvertraging"
+      },
+      "temp_charge_limit": {
+        "name": "Temperatuurbegrenzing laden"
+      },
+      "temp_charge_limit_discharge": {
+        "name": "Temperatuurbegrenzing ontladen"
       },
       "weekly_full_charge_delay": {
         "name": "Wekelijkse Volledige Lading Vertragen"
@@ -1467,6 +1520,15 @@
       },
       "delay_soc_setpoint": {
         "name": "Laadvertraging – SOC-drempel"
+      },
+      "temp_charge_limit_c": {
+        "name": "Temperatuurlimiet laden"
+      },
+      "temp_charge_limit_band_c": {
+        "name": "Temperatuurband laden"
+      },
+      "temp_charge_limit_floor_pct": {
+        "name": "Minimaal laadvermogen"
       },
       "capacity_protection_limit": {
         "name": "Piekbegrenzing Limiet"

--- a/tests/test_temperature_limit.py
+++ b/tests/test_temperature_limit.py
@@ -1,0 +1,245 @@
+"""Unit tests for TemperatureChargeLimitManager (thermal charge derate).
+
+No hardware, no Home Assistant: the manager only stores ``hass``/``controller``
+references and reads plain attributes off the controller stub, so it is built
+directly. ``apply_temperature_limit`` mirrors ``apply_charge_taper``'s
+cap-and-return contract, so the assertions are on the returned integer limit.
+
+The derate enforces a hard floor equal to the battery's minimum operating power,
+read from ``coordinator.capabilities`` (v2/v3 = 800 W, vA/vD/Zendure = 0). Most
+cases use a realistic 2500 W ceiling with an 800 W floor so the ramp stays above it.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.omnibattery.control.temperature_limit import (
+    TemperatureChargeLimitManager,
+)
+
+CEIL = 2500  # realistic per-battery charge ceiling
+FLOOR_W = 800  # v3/vA minimum operating power
+
+
+class _Coord:
+    """Coordinator stand-in with a ``data`` dict and driver ``capabilities``.
+
+    ``min_power`` models the hardware floor: 800 for v2/v3, 0 for vA/vD/Zendure.
+    """
+
+    def __init__(self, name="bat", *, data=None, min_power=FLOOR_W):
+        self.name = name
+        self.data = {} if data is None else data
+        self.capabilities = SimpleNamespace(
+            min_charge_power_w=min_power,
+            min_discharge_power_w=min_power,
+        )
+
+
+def _mgr(
+    *,
+    enabled=True,
+    limit_c=40,
+    band_c=10,
+    floor_pct=40,
+    apply_discharge=False,
+    coords=None,
+):
+    ctrl = SimpleNamespace(
+        temp_charge_limit_enabled=enabled,
+        temp_limit_apply_discharge=apply_discharge,
+        _temp_charge_limit_c=limit_c,
+        _temp_charge_limit_band_c=band_c,
+        _temp_charge_limit_floor_pct=floor_pct,
+        coordinators=coords or [],
+    )
+    return TemperatureChargeLimitManager(hass=None, controller=ctrl)
+
+
+def _cap(temp, limit=CEIL, *, min_power=FLOOR_W, **kw):
+    mgr = _mgr(**kw)
+    coord = _Coord(data={"internal_temperature": temp}, min_power=min_power)
+    return mgr.apply_temperature_limit(coord, limit)
+
+
+# ----------------------------------------------------------------------
+# Derate curve (2500 W ceiling: ramp stays above the 800 W floor)
+# ----------------------------------------------------------------------
+
+def test_below_limit_full_power():
+    assert _cap(35) == 2500
+    assert _cap(40) == 2500  # exactly at the limit is still full power
+
+
+def test_midband_is_linear():
+    # limit 40, band 10, floor 40%: at 45 C -> halfway -> factor 0.7 -> 1750 W
+    assert _cap(45) == 1750
+
+
+def test_at_and_above_band_pins_to_floor():
+    assert _cap(50) == 1000  # limit + band -> 40% of 2500
+    assert _cap(60) == 1000  # beyond the band stays at the floor
+
+
+def test_zero_band_steps_to_floor_above_limit():
+    assert _cap(40, band_c=0) == 2500  # at the limit: unchanged
+    assert _cap(41, band_c=0) == 1000  # any excess -> 40% floor
+
+
+def test_never_exceeds_incoming_limit():
+    # A cool battery returns the limit untouched (min-cap contract).
+    assert _cap(30, limit=500) == 500
+
+
+@pytest.mark.parametrize("temp,expected", [(40, 2500), (42.5, 2125), (47.5, 1375), (50, 1000)])
+def test_curve_points(temp, expected):
+    assert _cap(temp) == expected
+
+
+# ----------------------------------------------------------------------
+# Hard floor from the battery's minimum operating power (capabilities)
+# ----------------------------------------------------------------------
+
+def test_clamps_up_to_floor_when_derate_would_go_lower():
+    # 20% of 2500 = 500 W, below the 800 W minimum -> clamped up to 800.
+    assert _cap(50, floor_pct=20) == FLOOR_W
+
+
+def test_floor_zero_clamps_to_hw_floor_when_present():
+    # floor 0 would ask for 0 W over the band; the 800 W hw floor makes it 800 W.
+    assert _cap(55, floor_pct=0) == FLOOR_W
+    # ...but mid-band it is still above the floor and rides the ramp.
+    assert _cap(45, floor_pct=0) == 1250  # 2500 * 0.5
+
+
+def test_vd_has_no_floor_so_floor_zero_stops():
+    # vD/Zendure report min_power 0: the derate can reach a full stop.
+    assert _cap(55, floor_pct=0, min_power=0) == 0
+    assert _cap(50, floor_pct=20, min_power=0) == 500  # no clamp-up
+
+
+def test_never_raises_a_limit_already_below_floor():
+    # A 500 W ceiling stays 500 W even when hot; the clamp must not raise it.
+    assert _cap(55, limit=500) == 500
+    assert _cap(50, limit=700, floor_pct=0) == 700
+
+
+# ----------------------------------------------------------------------
+# Fail-safe / gating
+# ----------------------------------------------------------------------
+
+def test_disabled_passes_through():
+    assert _cap(55, enabled=False) == 2500
+
+
+def test_missing_temperature_passes_through():
+    mgr = _mgr()
+    assert mgr.apply_temperature_limit(_Coord(data={}), CEIL) == 2500
+    assert mgr.apply_temperature_limit(_Coord(data=None), CEIL) == 2500
+
+
+def test_non_numeric_temperature_passes_through():
+    assert _cap("n/a") == 2500
+
+
+# ----------------------------------------------------------------------
+# Discharge sub-toggle
+# ----------------------------------------------------------------------
+
+def _dcap(temp, limit=CEIL, *, min_power=FLOOR_W, **kw):
+    mgr = _mgr(**kw)
+    coord = _Coord(data={"internal_temperature": temp}, min_power=min_power)
+    return mgr.apply_discharge_limit(coord, limit)
+
+
+def test_discharge_off_by_default():
+    # Feature enabled but discharge sub-toggle off: discharge untouched.
+    assert _dcap(45) == 2500
+
+
+def test_discharge_on_applies_same_curve_and_floor():
+    assert _dcap(45, apply_discharge=True) == 1750
+    assert _dcap(50, apply_discharge=True, floor_pct=20) == FLOOR_W
+
+
+def test_discharge_requires_feature_enabled():
+    # Sub-toggle on but whole feature off: still a passthrough.
+    assert _dcap(45, enabled=False, apply_discharge=True) == 2500
+
+
+# ----------------------------------------------------------------------
+# Status
+# ----------------------------------------------------------------------
+
+def test_get_status_reports_per_battery():
+    c1 = _Coord("hot", data={"internal_temperature": 45})
+    c2 = _Coord("cool", data={"internal_temperature": 30})
+    status = _mgr(coords=[c1, c2]).get_status()
+    assert status["hot"]["derating"] is True
+    assert status["hot"]["derate_factor"] == 0.7
+    assert status["cool"]["derating"] is False
+    assert status["cool"]["derate_factor"] == 1.0
+
+
+# ----------------------------------------------------------------------
+# Integration: the real ChargeDischargeController._battery_power_limit hook
+#
+# Drives the actual production method (not the manager in isolation) with a
+# duck-typed ``self``, so the wiring is exercised: charge goes taper -> temp
+# derate -> slot ceiling; discharge goes temp derate -> slot ceiling. The
+# real TemperatureChargeLimitManager reads its mirrors off this same ``self``.
+# ----------------------------------------------------------------------
+
+from custom_components.omnibattery import ChargeDischargeController  # noqa: E402
+
+
+def _ctrl_self(*, enabled=True, apply_discharge=False, limit_c=40, band_c=10, floor_pct=40):
+    ns = SimpleNamespace(
+        temp_charge_limit_enabled=enabled,
+        temp_limit_apply_discharge=apply_discharge,
+        _temp_charge_limit_c=limit_c,
+        _temp_charge_limit_band_c=band_c,
+        _temp_charge_limit_floor_pct=floor_pct,
+        # max-SOC taper is a no-op here (identity), so the temp derate is isolated.
+        _max_soc_mgr=SimpleNamespace(apply_charge_taper=lambda coord, limit: limit),
+        # slot ceiling: identity (no active slot override in the test).
+        _apply_slot_power_ceiling=lambda coord, is_charging, limit: limit,
+    )
+    ns._temp_limit_mgr = TemperatureChargeLimitManager(hass=None, controller=ns)
+    return ns
+
+
+def _limit(self_ns, coord, is_charging):
+    return ChargeDischargeController._battery_power_limit(self_ns, coord, is_charging)
+
+
+def test_hook_charge_derates_when_hot():
+    coord = _Coord(data={"internal_temperature": 45})
+    coord.max_charge_power = 2500
+    assert _limit(_ctrl_self(), coord, True) == 1750  # 2500 * 0.7
+
+
+def test_hook_charge_untouched_when_cool():
+    coord = _Coord(data={"internal_temperature": 30})
+    coord.max_charge_power = 2500
+    assert _limit(_ctrl_self(), coord, True) == 2500
+
+
+def test_hook_charge_no_data_passes_ceiling():
+    coord = _Coord(data=None)
+    coord.max_charge_power = 2500
+    assert _limit(_ctrl_self(), coord, True) == 2500
+
+
+def test_hook_discharge_off_by_default():
+    coord = _Coord(data={"internal_temperature": 45})
+    coord.max_discharge_power = 2500
+    assert _limit(_ctrl_self(), coord, False) == 2500
+
+
+def test_hook_discharge_derates_when_opted_in():
+    coord = _Coord(data={"internal_temperature": 45})
+    coord.max_discharge_power = 2500
+    assert _limit(_ctrl_self(apply_discharge=True), coord, False) == 1750


### PR DESCRIPTION
Optional feature (off by default) that lowers charge power when a battery gets hot and restores it as it cools.

Full power at or below the temperature limit, then a linear ramp down to a floor (% of normal charge power) across a band you set. Example: 40°C limit, 10°C band, 40% floor gives full power up to 40°C, 70% at 45°C, 40% from 50°C up. Smooth ramp, no hysteresis to tune. Per-battery on its own temperature. Missing sensor reading never blocks charging.

A hard floor stops the derate from commanding an unreliable low power: it clamps to each battery's minimum operating power from the driver (Marstek v2/v3 = 800 W, vA/vD/Zendure = 0), so v2/v3 floor at 800 W and the rest can derate to a stop.

Opt-in toggle applies the same curve to discharge, mainly to stay under the BMS hard over-temp cutoff.

Controls appear as normal entities (enable switch, discharge toggle, three sliders) plus a panel block, in all six languages.

Tested: 25 unit tests (incl. the real _battery_power_limit hook), full suite green (592 passed).
