### PR TITLE
feat: ESPHome driver for Marstek batteries behind a LilyGo RS485 bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [1.0.0b5] - 2026-07-04
+## [Unreleased]
+
+### Added
+- **LilyGo RS485 / ESPHome driver**: support for Marstek batteries bridged by the [marstek-lilygo-rs485](https://github.com/whyisthisbroken/marstek-lilygo-rs485) firmware — telemetry and control go through the ESPHome device's HA entities (the battery's RS485 port is occupied by the ESP32). New brand in the config flow; same register semantics as the direct Modbus driver. [`drivers/esphome.py`](custom_components/omnibattery/drivers/esphome.py).
+
+## [1.0.0b5] - 2026-07-03
 
 ### Added
 - **Diagnostics and system health platforms**: per-entry, per-battery diagnostics (connection-health ladder, driver capabilities, non-responsive tracker state) and a system health card (connected/suspended/non-responsive counts), both read from a single `coordinator.health_snapshot()` so they can't drift. Thanks to @syphernl for the contribution. [`diagnostics.py`](custom_components/omnibattery/diagnostics.py), [`system_health.py`](custom_components/omnibattery/system_health.py).

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -5249,6 +5249,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             brand=battery_config.get("brand", "marstek"),
             zendure_model=battery_config.get("zendure_model", "2400ac_pro"),
             serial_port=battery_config.get(CONF_SERIAL_PORT) or None,
+            esphome_device_id=battery_config.get("esphome_device_id"),
         )
 
         # Restore persisted RS485 user preference and store entry reference for future persistence

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -16,6 +16,8 @@ from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
+    DeviceSelector,
+    DeviceSelectorConfig,
     EntitySelector,
     EntitySelectorConfig,
     TimeSelector,
@@ -137,6 +139,7 @@ from .const import (
     DEFAULT_SLOT_SOC_MAX_CEILING,
     MAX_TIME_SLOTS,
 )
+from .drivers.esphome import EsphomeEntityDriver
 from .drivers.marstek import MarstekModbusDriver
 from .drivers.zendure import ZendureLocalDriver, detect_model as _detect_zendure_model
 
@@ -716,6 +719,8 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             self._current_battery_data = {"brand": brand}
             if brand == "zendure":
                 return await self.async_step_battery_connection_zendure()
+            if brand == "esphome":
+                return await self.async_step_battery_connection_esphome()
             return await self.async_step_battery_connection()
 
         return self.async_show_form(
@@ -727,6 +732,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                             options=[
                                 {"value": "marstek", "label": "Marstek Venus"},
                                 {"value": "zendure", "label": "Zendure SolarFlow"},
+                                {"value": "esphome", "label": "Marstek via LilyGo RS485 (ESPHome)"},
                             ],
                             mode=SelectSelectorMode.DROPDOWN,
                         )),
@@ -843,6 +849,44 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             ),
             errors=errors,
             description_placeholders={"battery_num": str(battery_num)},
+        )
+
+    async def async_step_battery_connection_esphome(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 3b (ESPHome): pick the LilyGo/ESPHome device bridging the battery."""
+        errors = {}
+        placeholders: dict[str, str] = {"battery_num": str(self.battery_index + 1)}
+
+        if user_input is not None:
+            device_id = user_input["esphome_device"]
+            _, missing = EsphomeEntityDriver.resolve(self.hass, device_id)
+            if missing:
+                errors["base"] = "esphome_entities_missing"
+                placeholders["missing"] = ", ".join(missing)
+            else:
+                self._current_battery_data.update({
+                    CONF_NAME: user_input[CONF_NAME],
+                    # The registry device id doubles as the battery identity
+                    # (device_key, persistence matching); there is no IP:port.
+                    CONF_HOST: device_id,
+                    CONF_PORT: 0,
+                    "brand": "esphome",
+                    "esphome_device_id": device_id,
+                })
+                return await self.async_step_battery_limits()
+
+        return self.async_show_form(
+            step_id="battery_connection_esphome",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default=f"Marstek Venus {self.battery_index + 1}"): str,
+                    vol.Required("esphome_device"):
+                        DeviceSelector(DeviceSelectorConfig(integration="esphome")),
+                }
+            ),
+            errors=errors,
+            description_placeholders=placeholders,
         )
 
     async def async_step_battery_limits(
@@ -1996,6 +2040,8 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
 
         if current.get("brand", "marstek") == "zendure":
             return await self.async_step_reconfigure_battery_zendure(user_input)
+        if current.get("brand", "marstek") == "esphome":
+            return await self.async_step_reconfigure_battery_esphome(user_input)
 
         errors = {}
 
@@ -2152,6 +2198,70 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             ),
             errors=errors,
             description_placeholders={"battery_num": str(battery_num)},
+        )
+
+    async def async_step_reconfigure_battery_esphome(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Update the ESPHome bridge device for a battery during reconfiguration."""
+        entry = self._get_reconfigure_entry()
+        current_batteries = entry.data.get("batteries", [])
+        battery_num = self.battery_index + 1
+        current = (
+            current_batteries[self.battery_index]
+            if self.battery_index < len(current_batteries)
+            else {}
+        )
+        errors = {}
+        placeholders: dict[str, str] = {"battery_num": str(battery_num)}
+
+        if user_input is not None:
+            device_id = user_input["esphome_device"]
+            _, missing = EsphomeEntityDriver.resolve(self.hass, device_id)
+            if missing:
+                errors["base"] = "esphome_entities_missing"
+                placeholders["missing"] = ", ".join(missing)
+            else:
+                old_host = current.get(CONF_HOST)
+                old_port = current.get(CONF_PORT)
+                if old_host and old_host != device_id:
+                    self._migrate_battery_registry_ids(
+                        entry, old_host, old_port, device_id, 0
+                    )
+
+                updated = dict(current)
+                updated[CONF_NAME] = user_input[CONF_NAME]
+                updated[CONF_HOST] = device_id
+                updated[CONF_PORT] = 0
+                updated["esphome_device_id"] = device_id
+                self._reconfigure_batteries.append(updated)
+                self.battery_index += 1
+
+                if self.battery_index >= len(current_batteries):
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        data_updates={"batteries": self._reconfigure_batteries},
+                    )
+                return await self.async_step_reconfigure_battery()
+
+        schema: dict = {
+            vol.Required(CONF_NAME, default=current.get(CONF_NAME, f"Marstek Venus {battery_num}")): str,
+        }
+        current_device = current.get("esphome_device_id")
+        if current_device:
+            schema[vol.Required("esphome_device", default=current_device)] = DeviceSelector(
+                DeviceSelectorConfig(integration="esphome")
+            )
+        else:
+            schema[vol.Required("esphome_device")] = DeviceSelector(
+                DeviceSelectorConfig(integration="esphome")
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure_battery_esphome",
+            data_schema=vol.Schema(schema),
+            errors=errors,
+            description_placeholders=placeholders,
         )
 
     @staticmethod
@@ -2365,6 +2475,8 @@ class OptionsFlowHandler(OptionsFlow):
             self._current_battery_data = {"brand": brand}
             if brand == "zendure":
                 return await self.async_step_battery_connection_zendure()
+            if brand == "esphome":
+                return await self.async_step_battery_connection_esphome()
             return await self.async_step_battery_connection()
 
         return self.async_show_form(
@@ -2376,6 +2488,7 @@ class OptionsFlowHandler(OptionsFlow):
                             options=[
                                 {"value": "marstek", "label": "Marstek Venus"},
                                 {"value": "zendure", "label": "Zendure SolarFlow"},
+                                {"value": "esphome", "label": "Marstek via LilyGo RS485 (ESPHome)"},
                             ],
                             mode=SelectSelectorMode.DROPDOWN,
                         )),
@@ -2530,6 +2643,60 @@ class OptionsFlowHandler(OptionsFlow):
             ),
             errors=errors,
             description_placeholders={"battery_num": str(battery_num)},
+        )
+
+    async def async_step_battery_connection_esphome(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Pick the LilyGo/ESPHome device bridging a Marstek battery."""
+        errors = {}
+        battery_num = self.battery_index + 1
+        placeholders: dict[str, str] = {"battery_num": str(battery_num)}
+
+        try:
+            current_batteries = self.config_entry.data.get("batteries", [])
+
+            if user_input is not None:
+                device_id = user_input["esphome_device"]
+                _, missing = EsphomeEntityDriver.resolve(self.hass, device_id)
+                if missing:
+                    errors["base"] = "esphome_entities_missing"
+                    placeholders["missing"] = ", ".join(missing)
+                else:
+                    self._current_battery_data.update({
+                        CONF_NAME: user_input[CONF_NAME],
+                        CONF_HOST: device_id,
+                        CONF_PORT: 0,
+                        "brand": "esphome",
+                        "esphome_device_id": device_id,
+                    })
+                    return await self.async_step_battery_limits()
+
+            if self.battery_index < len(current_batteries):
+                current_battery = current_batteries[self.battery_index]
+                defaults = {
+                    CONF_NAME: current_battery.get(CONF_NAME, f"Marstek Venus {battery_num}"),
+                    "esphome_device": current_battery.get("esphome_device_id"),
+                }
+            else:
+                defaults = {
+                    CONF_NAME: f"Marstek Venus {battery_num}",
+                    "esphome_device": None,
+                }
+        except Exception as e:
+            _LOGGER.error("Error in options flow battery_connection_esphome step: %s", e, exc_info=True)
+            return self.async_abort(reason="unknown_error")
+
+        device_selector = DeviceSelector(DeviceSelectorConfig(integration="esphome"))
+        schema: dict = {vol.Required(CONF_NAME, default=defaults[CONF_NAME]): str}
+        if defaults["esphome_device"]:
+            schema[vol.Required("esphome_device", default=defaults["esphome_device"])] = device_selector
+        else:
+            schema[vol.Required("esphome_device")] = device_selector
+
+        return self.async_show_form(
+            step_id="battery_connection_esphome",
+            data_schema=vol.Schema(schema),
+            errors=errors,
+            description_placeholders=placeholders,
         )
 
     async def async_step_battery_limits(self, user_input: dict[str, Any] | None = None) -> FlowResult:

--- a/custom_components/omnibattery/drivers/__init__.py
+++ b/custom_components/omnibattery/drivers/__init__.py
@@ -9,6 +9,7 @@ writing a new driver, not by editing the control logic.
 Drivers:
   - ``marstek``: Modbus-TCP, register based, polled (the original hardware).
   - ``zendure``: local HTTP REST, property based, polled (SolarFlow series).
+  - ``esphome``: HA-entity based, push (Marstek behind a LilyGo RS485 bridge).
 
 See ``docs/plans/driver_abstraction.md`` for the phased extraction plan.
 """
@@ -20,6 +21,7 @@ from .base import (
     SetpointResult,
     TelemetrySnapshot,
 )
+from .esphome import EsphomeEntityDriver
 from .marstek import MarstekModbusDriver
 from .zendure import ZendureLocalDriver
 
@@ -29,6 +31,7 @@ __all__ = [
     "ReadGroup",
     "SetpointResult",
     "TelemetrySnapshot",
+    "EsphomeEntityDriver",
     "MarstekModbusDriver",
     "ZendureLocalDriver",
 ]

--- a/custom_components/omnibattery/drivers/esphome.py
+++ b/custom_components/omnibattery/drivers/esphome.py
@@ -1,0 +1,640 @@
+"""ESPHome-entity driver for Marstek batteries behind a LilyGo RS485 bridge.
+
+Supports the community LilyGO T-CAN485 firmware
+(https://github.com/whyisthisbroken/marstek-lilygo-rs485), which talks Modbus
+RTU to the Venus E over its RS485 port and exposes the decoded registers as
+ESPHome entities in Home Assistant. The RS485 port is occupied by the ESP32,
+so there is no direct Modbus path — this driver reads and writes the HA
+entities that firmware creates instead:
+
+  Read:  ``hass.states`` lookups (ESPHome pushes state; the ESP polls the
+         battery every 3 s, so telemetry freshness is ~3 s).
+  Write: ``select.select_option`` / ``number.set_value`` service calls on the
+         ESPHome control entities.
+
+The underlying hardware is a Marstek Venus E with the v2 register map, so this
+driver reuses the Marstek logical keys and control semantics verbatim
+(force_mode + set_charge/discharge_power); the whole register-style entity and
+control machinery works unchanged. Entities are matched by the slugified
+ESPHome entity name (the ``name:`` field of the upstream YAML), which survives
+user entity_id renames via the registry's original_name.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
+
+from .base import (
+    BatteryDriver,
+    DriverCapabilities,
+    ReadGroup,
+    SetpointResult,
+    TelemetrySnapshot,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Marstek force_mode wire values (same as the Modbus driver).
+_FORCE_NONE = 0
+_FORCE_CHARGE = 1
+_FORCE_DISCHARGE = 2
+
+# Logical key → (HA domain, upstream ESPHome entity name). The name is the
+# ``name:`` field of the upstream YAML; matching is on its slug so punctuation
+# ("Max. Cell Voltage") is irrelevant.
+_ENTITY_MAP: dict[str, tuple[str, str]] = {
+    # telemetry
+    "battery_soc":                    ("sensor", "Battery State Of Charge"),
+    "battery_power":                  ("sensor", "Battery Power"),
+    "battery_voltage":                ("sensor", "Battery Voltage"),
+    "battery_total_energy":           ("sensor", "Battery Total Energy"),
+    "ac_power":                       ("sensor", "AC Power"),
+    "internal_temperature":           ("sensor", "Internal Temperature"),
+    "max_cell_voltage":               ("sensor", "Max. Cell Voltage"),
+    "min_cell_voltage":               ("sensor", "Min. Cell Voltage"),
+    "wifi_signal_strength":           ("sensor", "Wifi Signal Strength"),
+    "inverter_state":                 ("sensor", "Inverter State"),
+    "total_charging_energy":          ("sensor", "Total Charging Energy"),
+    "total_discharging_energy":       ("sensor", "Total Discharging Energy"),
+    "total_daily_charging_energy":    ("sensor", "Daily Charging Energy"),
+    "total_daily_discharging_energy": ("sensor", "Daily Discharging Energy"),
+    # controls
+    "force_mode":                     ("select", "Forcible Charge-Discharge"),
+    "user_work_mode":                 ("select", "User Work Mode"),
+    "backup_function":                ("select", "Backup Function"),
+    "rs485_control_mode":             ("select", "RS485 Control Mode"),
+    "set_charge_power":               ("number", "Forcible Charge Power"),
+    "set_discharge_power":            ("number", "Forcible Discharge Power"),
+    "max_charge_power":               ("number", "Max. Charge Power"),
+    "max_discharge_power":            ("number", "Max. Discharge Power"),
+    "charging_cutoff_capacity":       ("number", "Charging Cutoff Capacity"),
+    "discharging_cutoff_capacity":    ("number", "Discharging Cutoff Capacity"),
+}
+
+# Wire value → ESPHome select option, per select key. Wire values match the
+# Marstek register semantics so the shared entity layer (which speaks wire
+# values through write_control / coordinator.data) needs no changes.
+_SELECT_WIRE_TO_OPTION: dict[str, dict[int, str]] = {
+    "force_mode":         {0: "stop", 1: "charge", 2: "discharge"},
+    "user_work_mode":     {0: "manual", 1: "anti-feed", 2: "ai"},
+    "backup_function":    {0: "enable", 1: "disable"},
+    "rs485_control_mode": {21930: "enable", 21947: "disable"},
+}
+_SELECT_OPTION_TO_WIRE: dict[str, dict[str, int]] = {
+    key: {opt: wire for wire, opt in table.items()}
+    for key, table in _SELECT_WIRE_TO_OPTION.items()
+}
+
+# The upstream "Inverter State" text sensor's strings → the v2 numeric state
+# codes, so the shared inverter_state sensor definition ("states" map) applies.
+_INVERTER_STATE_TO_CODE: dict[str, int] = {
+    "sleep": 0,
+    "standby": 1,
+    "charge": 2,
+    "discharge": 3,
+    "fault": 4,
+    "idle": 5,
+    "ac bypass": 6,
+}
+
+# Without these the driver cannot run the control loop; connect() refuses the
+# device so the config flow can tell the user which entities are missing.
+_REQUIRED_KEYS: frozenset[str] = frozenset({
+    "battery_soc", "battery_power", "ac_power",
+    "force_mode", "set_charge_power", "set_discharge_power",
+    "rs485_control_mode",
+})
+
+
+# ---------------------------------------------------------------------------
+# Entity definitions
+# ---------------------------------------------------------------------------
+# Same logical keys and presentation as registers_v2 (shared translations,
+# dashboard cards, control machinery), minus register/data_type: HA states are
+# already final scaled values, so every definition is scale 1.
+
+SENSOR_DEFINITIONS: list[dict] = [
+    {"name": "Battery SOC", "key": "battery_soc", "unit": "%",
+     "device_class": "battery", "state_class": "measurement",
+     "scale": 1, "precision": 1, "scan_interval": "medium", "enabled_by_default": True},
+    {"name": "Battery Total Energy", "key": "battery_total_energy", "unit": "kWh",
+     "device_class": "energy", "state_class": "total",
+     "scale": 1, "precision": 3, "scan_interval": "low", "enabled_by_default": True},
+    {"name": "Battery Power", "key": "battery_power", "unit": "W",
+     "device_class": "power", "state_class": "measurement",
+     "scale": 1, "precision": 1, "scan_interval": "high", "enabled_by_default": True},
+    {"name": "Internal Temperature", "key": "internal_temperature", "unit": "°C",
+     "device_class": "temperature", "state_class": "measurement",
+     "scale": 1, "precision": 2, "scan_interval": "medium", "enabled_by_default": True},
+    {"name": "AC Power", "key": "ac_power", "unit": "W",
+     "device_class": "power", "state_class": "measurement",
+     "scale": 1, "precision": 0, "scan_interval": "high", "enabled_by_default": True},
+    {"name": "Total Charging Energy", "key": "total_charging_energy", "unit": "kWh",
+     "device_class": "energy", "state_class": "total_increasing",
+     "scale": 1, "precision": 2, "scan_interval": "low", "enabled_by_default": True},
+    {"name": "Total Discharging Energy", "key": "total_discharging_energy", "unit": "kWh",
+     "device_class": "energy", "state_class": "total_increasing",
+     "scale": 1, "precision": 2, "scan_interval": "low", "enabled_by_default": True},
+    {"name": "Total Daily Charging Energy", "key": "total_daily_charging_energy", "unit": "kWh",
+     "device_class": "energy", "state_class": "total_increasing",
+     "scale": 1, "precision": 2, "scan_interval": "low", "enabled_by_default": True},
+    {"name": "Total Daily Discharging Energy", "key": "total_daily_discharging_energy", "unit": "kWh",
+     "device_class": "energy", "state_class": "total_increasing",
+     "scale": 1, "precision": 2, "scan_interval": "low", "enabled_by_default": True},
+    {"name": "Inverter State", "key": "inverter_state", "unit": None,
+     "icon": "mdi:state-machine", "scale": 1, "precision": 0,
+     "scan_interval": "high", "enabled_by_default": True,
+     "states": {
+         0: "Sleep", 1: "Standby", 2: "Charge", 3: "Discharge",
+         4: "Backup Mode", 5: "OTA Upgrade", 6: "Bypass",
+     }},
+    {"name": "Battery Voltage", "key": "battery_voltage", "unit": "V",
+     "device_class": "voltage", "state_class": "measurement",
+     "scale": 1, "precision": 1, "scan_interval": "medium", "enabled_by_default": True},
+    {"name": "Max Cell Voltage", "key": "max_cell_voltage", "unit": "V",
+     "device_class": "voltage", "state_class": "measurement",
+     "scale": 1, "precision": 3, "scan_interval": "high", "enabled_by_default": True},
+    {"name": "Min Cell Voltage", "key": "min_cell_voltage", "unit": "V",
+     "device_class": "voltage", "state_class": "measurement",
+     "scale": 1, "precision": 3, "scan_interval": "high", "enabled_by_default": True},
+    {"name": "WiFi Signal Strength", "key": "wifi_signal_strength", "unit": "dBm",
+     "device_class": "signal_strength", "state_class": "measurement",
+     "category": "diagnostic", "scale": 1, "precision": 0,
+     "scan_interval": "low", "enabled_by_default": True},
+]
+
+SELECT_DEFINITIONS: list[dict] = [
+    {"name": "Force Mode", "key": "force_mode", "enabled_by_default": True,
+     "scan_interval": "high",
+     "options": {"None": 0, "Charge": 1, "Discharge": 2}},
+    {"name": "User Work Mode", "key": "user_work_mode", "enabled_by_default": False,
+     "scan_interval": "high",
+     "options": {"manual": 0, "anti_feed": 1, "trade_mode": 2}},
+]
+
+SWITCH_DEFINITIONS: list[dict] = [
+    {"name": "Backup Function", "key": "backup_function",
+     "command_on": 0, "command_off": 1,
+     "enabled_by_default": True, "scan_interval": "medium"},
+    {"name": "RS485 Control Mode", "key": "rs485_control_mode",
+     "command_on": 21930, "command_off": 21947,
+     "enabled_by_default": True, "scan_interval": "medium"},
+]
+
+NUMBER_DEFINITIONS: list[dict] = [
+    {"name": "Set Forcible Charge Power", "key": "set_charge_power",
+     "icon": "mdi:battery-arrow-up-outline", "min": 0, "max": 2500, "step": 5,
+     "unit": "W", "enabled_by_default": True, "scan_interval": "high"},
+    {"name": "Set Forcible Discharge Power", "key": "set_discharge_power",
+     "icon": "mdi:battery-arrow-down-outline", "min": 0, "max": 2500, "step": 5,
+     "unit": "W", "enabled_by_default": True, "scan_interval": "high"},
+    {"name": "Max Charge Power", "key": "max_charge_power",
+     "icon": "mdi:battery-arrow-up-outline", "min": 800, "max": 2500, "step": 50,
+     "unit": "W", "enabled_by_default": True, "scan_interval": "medium"},
+    {"name": "Max Discharge Power", "key": "max_discharge_power",
+     "icon": "mdi:battery-arrow-down-outline", "min": 800, "max": 2500, "step": 50,
+     "unit": "W", "enabled_by_default": True, "scan_interval": "medium"},
+    # Percent on both sides (scale 1): the ESPHome number is already in %, its
+    # firmware does the ×10 deci-percent conversion on the RS485 wire.
+    {"name": "Charging Cutoff Capacity", "key": "charging_cutoff_capacity",
+     "icon": "mdi:battery-arrow-up-outline", "min": 80, "max": 100, "step": 1,
+     "unit": "%", "scale": 1, "enabled_by_default": True, "scan_interval": "medium"},
+    {"name": "Discharging Cutoff Capacity", "key": "discharging_cutoff_capacity",
+     "icon": "mdi:battery-arrow-down-outline", "min": 12, "max": 30, "step": 1,
+     "unit": "%", "scale": 1, "enabled_by_default": True, "scan_interval": "medium"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+class EsphomeEntityDriver(BatteryDriver):
+    """Drives a Marstek battery through the LilyGo/ESPHome HA entities."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device_id: str,
+        *,
+        max_charge_power_w: int = 2500,
+        max_discharge_power_w: int = 2500,
+    ) -> None:
+        self.hass = hass
+        self._device_id = device_id
+        self._connected = False
+        self._shutting_down = False
+        # logical key → HA entity_id, resolved from the registry on connect().
+        self._entities: dict[str, str] = {}
+
+        self._capabilities = DriverCapabilities(
+            hardware_soc_cutoff=True,     # cutoff registers exposed as numbers
+            has_force_mode=True,
+            push_telemetry=True,          # ESPHome pushes state into HA
+            max_charge_power_w=max_charge_power_w,
+            max_discharge_power_w=max_discharge_power_w,
+            has_mppt_pv=False,            # Venus E is AC-coupled
+            has_alarm_registers=False,    # firmware decodes alarms into its own binary sensors
+            has_rs485_control=True,
+            has_energy_counters=True,
+            # State echoes ride the ESP's 3 s battery poll (plus delta filters),
+            # so a readback right after a write compares against stale values.
+            setpoint_confirm_reliable=False,
+            actuator_latency_s=4.0,       # HA service → ESP write → 3 s telemetry grain
+            # Venus E firmware floor, same as the direct Modbus v2 driver.
+            min_charge_power_w=800,
+            min_discharge_power_w=800,
+        )
+
+        self._definitions: dict[str, list[dict]] = {
+            "sensor":        SENSOR_DEFINITIONS,
+            "number":        NUMBER_DEFINITIONS,
+            "select":        SELECT_DEFINITIONS,
+            "switch":        SWITCH_DEFINITIONS,
+            "binary_sensor": [],
+            "button":        [],
+            "all": SENSOR_DEFINITIONS + NUMBER_DEFINITIONS + SELECT_DEFINITIONS + SWITCH_DEFINITIONS,
+        }
+
+        # Single read group: telemetry is a set of hass.states lookups, so
+        # there is nothing to batch or pace — return everything every poll and
+        # let the coordinator gate per key.
+        self._read_groups = [
+            ReadGroup(
+                scan_interval="high",
+                keys=tuple(d["key"] for d in self._definitions["all"]),
+            )
+        ]
+
+    # --- entity definitions ---------------------------------------------------
+
+    @property
+    def sensor_definitions(self) -> list[dict]:
+        return self._definitions["sensor"]
+
+    @property
+    def number_definitions(self) -> list[dict]:
+        return self._definitions["number"]
+
+    @property
+    def select_definitions(self) -> list[dict]:
+        return self._definitions["select"]
+
+    @property
+    def switch_definitions(self) -> list[dict]:
+        return self._definitions["switch"]
+
+    @property
+    def binary_sensor_definitions(self) -> list[dict]:
+        return self._definitions["binary_sensor"]
+
+    @property
+    def button_definitions(self) -> list[dict]:
+        return self._definitions["button"]
+
+    @property
+    def all_definitions(self) -> list[dict]:
+        return self._definitions["all"]
+
+    # --- identity ---------------------------------------------------------
+
+    @property
+    def capabilities(self) -> DriverCapabilities:
+        return self._capabilities
+
+    @property
+    def model_label(self) -> Optional[str]:
+        return "Venus E (LilyGo RS485)"
+
+    # --- entity resolution --------------------------------------------------
+
+    @staticmethod
+    def _match_entities(entries: list[tuple[str, Optional[str], str]]) -> dict[str, str]:
+        """Match registry entries to logical keys.
+
+        ``entries`` is (domain, original_name, entity_id) per registry entry of
+        the ESPHome device. Matching is by slugified original_name (the
+        firmware's ``name:``, stable across user entity_id renames), falling
+        back to the entity_id suffix for entries whose original_name was lost.
+        Pure function so tests need no registry.
+        """
+        by_slug: dict[tuple[str, str], str] = {}
+        for domain, original_name, entity_id in entries:
+            if original_name:
+                by_slug.setdefault((domain, slugify(original_name)), entity_id)
+            # entity_id fallback: "sensor.mydevice_battery_power" → suffix match
+            object_id = entity_id.split(".", 1)[1]
+            by_slug.setdefault((domain, object_id), entity_id)
+
+        resolved: dict[str, str] = {}
+        for key, (domain, name) in _ENTITY_MAP.items():
+            slug = slugify(name)
+            entity_id = by_slug.get((domain, slug))
+            if entity_id is None:
+                # suffix match against the object_id fallback entries
+                entity_id = next(
+                    (
+                        eid for (dom, oid), eid in by_slug.items()
+                        if dom == domain and oid.endswith(f"_{slug}")
+                    ),
+                    None,
+                )
+            if entity_id:
+                resolved[key] = entity_id
+        return resolved
+
+    @classmethod
+    def resolve(
+        cls, hass: HomeAssistant, device_id: str
+    ) -> tuple[dict[str, str], list[str]]:
+        """Resolve the device's entities and report missing required keys.
+
+        Returns (logical key → entity_id, missing required keys). Used by both
+        connect() and the config flow's validation step.
+        """
+        registry = er.async_get(hass)
+        entries = [
+            (entry.domain, entry.original_name, entry.entity_id)
+            for entry in er.async_entries_for_device(
+                registry, device_id, include_disabled_entities=True
+            )
+        ]
+        resolved = cls._match_entities(entries)
+        missing = sorted(_REQUIRED_KEYS - resolved.keys())
+        return resolved, missing
+
+    # --- connection lifecycle -----------------------------------------------
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> bool:
+        """Resolve the entity map and verify the device is reporting."""
+        resolved, missing = self.resolve(self.hass, self._device_id)
+        if missing:
+            if not self._shutting_down:
+                _LOGGER.error(
+                    "ESPHome device %s is missing required entities for %s",
+                    self._device_id, missing,
+                )
+            self._connected = False
+            return False
+        self._entities = resolved
+
+        soc_state = self.hass.states.get(resolved["battery_soc"])
+        if soc_state is None or soc_state.state in ("unavailable", "unknown"):
+            if not self._shutting_down:
+                _LOGGER.warning(
+                    "ESPHome device %s found but %s is %s (device offline?)",
+                    self._device_id, resolved["battery_soc"],
+                    soc_state.state if soc_state else "absent",
+                )
+            self._connected = False
+            return False
+
+        self._connected = True
+        _LOGGER.info(
+            "Connected to ESPHome-bridged Marstek (device %s, %d entities mapped)",
+            self._device_id, len(resolved),
+        )
+        return True
+
+    async def close(self) -> None:
+        self._connected = False
+
+    def set_shutting_down(self, value: bool) -> None:
+        self._shutting_down = value
+
+    # --- telemetry (read) -----------------------------------------------------
+
+    @property
+    def read_groups(self) -> list[ReadGroup]:
+        return self._read_groups
+
+    async def read_telemetry(self, keys: Optional[list[str]] = None) -> TelemetrySnapshot:
+        """Return the mapped entities' current HA states as a snapshot.
+
+        States are already final scaled values (the ESP applies the register
+        scaling), so the entity definitions all carry scale 1. Unavailable /
+        unknown / unparseable states are omitted; an all-offline device yields
+        an empty snapshot, which drives the coordinator's failure ladder.
+        """
+        wanted = keys if keys is not None else list(self._entities)
+        snapshot: TelemetrySnapshot = {}
+        for key in wanted:
+            entity_id = self._entities.get(key)
+            if entity_id is None:
+                continue
+            state = self.hass.states.get(entity_id)
+            if state is None or state.state in ("unavailable", "unknown"):
+                continue
+            value = self._decode(key, state.state)
+            if value is not None:
+                snapshot[key] = value
+        return snapshot
+
+    @staticmethod
+    def _decode(key: str, raw: str):
+        """Decode one HA state string into the logical wire value."""
+        option_map = _SELECT_OPTION_TO_WIRE.get(key)
+        if option_map is not None:
+            return option_map.get(raw)
+        if key == "inverter_state":
+            return _INVERTER_STATE_TO_CODE.get(raw.strip().lower())
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return None
+        return int(value) if value.is_integer() else value
+
+    # --- service-call helpers -------------------------------------------------
+
+    async def _call(self, domain: str, service: str, entity_id: str, data: dict) -> bool:
+        """Call an HA service on an ESPHome entity; False on any failure."""
+        try:
+            await self.hass.services.async_call(
+                domain, service, {"entity_id": entity_id, **data}, blocking=True
+            )
+            return True
+        except Exception as exc:
+            if not self._shutting_down:
+                _LOGGER.warning(
+                    "ESPHome driver: %s.%s on %s failed: %s",
+                    domain, service, entity_id, exc,
+                )
+            return False
+
+    async def _write_number(self, key: str, value: float) -> bool:
+        entity_id = self._entities.get(key)
+        if entity_id is None:
+            return False
+        return await self._call("number", "set_value", entity_id, {"value": value})
+
+    async def _write_select(self, key: str, wire_value: int) -> bool:
+        entity_id = self._entities.get(key)
+        if entity_id is None:
+            return False
+        option = _SELECT_WIRE_TO_OPTION.get(key, {}).get(int(wire_value))
+        if option is None:
+            _LOGGER.warning(
+                "ESPHome driver: no option for %s wire value %s", key, wire_value
+            )
+            return False
+        return await self._call("select", "select_option", entity_id, {"option": option})
+
+    # --- control (write) --------------------------------------------------------
+
+    async def apply_setpoint(
+        self,
+        net_power_w: int,
+        *,
+        mode_hint: Optional[str] = None,
+        read_back: bool = True,
+    ) -> SetpointResult:
+        """Translate a signed net power into the force select + power numbers.
+
+        Same wire semantics and write order as the Marstek Modbus driver
+        (discharge, charge, then force mode), delivered via HA service calls.
+        """
+        if net_power_w > 0:
+            charge = min(net_power_w, self._capabilities.max_charge_power_w)
+            discharge = 0
+            force_mode = _FORCE_CHARGE
+            applied_net = charge
+        elif net_power_w < 0:
+            charge = 0
+            discharge = min(-net_power_w, self._capabilities.max_discharge_power_w)
+            force_mode = _FORCE_DISCHARGE
+            applied_net = -discharge
+        else:
+            charge = discharge = 0
+            force_mode = _FORCE_NONE
+            applied_net = 0
+
+        ok1 = await self._write_number("set_discharge_power", discharge)
+        ok2 = await self._write_number("set_charge_power", charge)
+        ok3 = await self._write_select("force_mode", force_mode)
+        if not (ok1 and ok2 and ok3):
+            return SetpointResult(
+                ok=False, net_power_w=applied_net, confirmed=False,
+                failure_reason="service_call_failed",
+            )
+
+        applied = {
+            "force_mode": force_mode,
+            "set_charge_power": charge,
+            "set_discharge_power": discharge,
+        }
+        if not read_back:
+            return SetpointResult(ok=True, net_power_w=applied_net, confirmed=False, applied=applied)
+
+        # ESPHome's modbus number/select publish the new state right after the
+        # RTU write is queued, so a short settle is enough for the command echo;
+        # battery_power still rides the 3 s battery poll and may lag.
+        await asyncio.sleep(1.0)
+
+        echo = await self.read_telemetry(
+            ["force_mode", "set_charge_power", "set_discharge_power", "battery_power"]
+        )
+        if not echo:
+            return SetpointResult(
+                ok=True, net_power_w=applied_net, confirmed=False,
+                failure_reason="feedback_timeout", applied=applied,
+            )
+
+        confirmed = (
+            echo.get("force_mode") == force_mode
+            and echo.get("set_charge_power") == charge
+            and echo.get("set_discharge_power") == discharge
+        )
+        battery_power = echo.get("battery_power")
+        applied.update(echo)
+        return SetpointResult(
+            ok=True, net_power_w=applied_net, confirmed=confirmed,
+            battery_power_w=int(battery_power) if battery_power is not None else None,
+            applied=applied,
+        )
+
+    async def write_control(self, key: str, value: int) -> bool:
+        """Write one logical control (entity-write path, wire values in)."""
+        if key in _SELECT_WIRE_TO_OPTION:
+            return await self._write_select(key, value)
+        if self._entities.get(key) and _ENTITY_MAP[key][0] == "number":
+            return await self._write_number(key, value)
+        _LOGGER.debug("EsphomeEntityDriver: no control mapping for key %r", key)
+        return False
+
+    def net_power_from_data(self, data: dict):
+        force = data.get("force_mode")
+        charge = data.get("set_charge_power")
+        discharge = data.get("set_discharge_power")
+        if force is None or charge is None or discharge is None:
+            return None
+        force = int(round(float(force)))
+        if force == _FORCE_CHARGE:
+            return int(round(float(charge)))
+        if force == _FORCE_DISCHARGE:
+            return -int(round(float(discharge)))
+        return 0
+
+    @property
+    def control_dependency_keys(self) -> frozenset:
+        return frozenset({
+            "set_charge_power", "set_discharge_power",
+            "max_charge_power", "max_discharge_power",
+            "force_mode",
+            "charging_cutoff_capacity", "discharging_cutoff_capacity",
+        })
+
+    # --- concrete methods (not on BatteryDriver ABC) ------------------------
+    # Mirror the Marstek/Zendure concrete API so the coordinator can call them
+    # without isinstance guards.
+
+    async def apply_config(
+        self,
+        *,
+        max_soc_pct: float,
+        min_soc_pct: float,
+        max_charge_power_w: int,
+        max_discharge_power_w: int,
+    ) -> bool:
+        """Write SOC cutoffs and power caps through the ESPHome numbers."""
+        ok = True
+        ok &= await self._write_number("charging_cutoff_capacity", int(max_soc_pct))
+        ok &= await self._write_number("discharging_cutoff_capacity", int(min_soc_pct))
+        ok &= await self._write_number("max_charge_power", int(max_charge_power_w))
+        ok &= await self._write_number("max_discharge_power", int(max_discharge_power_w))
+        return bool(ok)
+
+    async def set_charge_cutoff(self, soc_pct: float) -> bool:
+        """Write only the charge-cutoff number (weekly full charge / balance)."""
+        return await self._write_number("charging_cutoff_capacity", int(soc_pct))
+
+    async def standby(self) -> bool:
+        """Idle the battery (zero set-points, no force mode) for teardown."""
+        ok = True
+        ok &= await self._write_number("set_discharge_power", 0)
+        ok &= await self._write_number("set_charge_power", 0)
+        ok &= await self._write_select("force_mode", _FORCE_NONE)
+        return bool(ok)
+
+    async def set_rs485_control(self, enable: bool) -> bool:
+        """Toggle RS485 control mode through the ESPHome select."""
+        return await self._write_select(
+            "rs485_control_mode", 21930 if enable else 21947
+        )
+
+    async def get_rs485_control(self) -> Optional[bool]:
+        """Read back RS485 control mode from the select's state."""
+        snapshot = await self.read_telemetry(["rs485_control_mode"])
+        value = snapshot.get("rs485_control_mode")
+        if value is None:
+            return None
+        return value == 21930

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -20,6 +20,7 @@ from ..const import (
     BURST_POLL_WINDOW_S,
     BURST_POLL_INTERVAL_S,
 )
+from ..drivers.esphome import EsphomeEntityDriver
 from ..drivers.marstek import MarstekModbusDriver
 from ..drivers.zendure import ZendureLocalDriver, ZENDURE_MODEL_2400AC_PRO
 from ..drivers.base import SetpointResult
@@ -93,7 +94,8 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                  full_charge_voltage_taper_enabled: bool = DEFAULT_FULL_CHARGE_VOLTAGE_TAPER_ENABLED,
                  brand: str = "marstek",
                  zendure_model: str = ZENDURE_MODEL_2400AC_PRO,
-                 serial_port: str | None = None) -> None:
+                 serial_port: str | None = None,
+                 esphome_device_id: str | None = None) -> None:
         """Initialize the data update coordinator."""
         super().__init__(
             hass,
@@ -234,6 +236,17 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 self.host,
                 port=self.port,
                 model=zendure_model,
+            )
+        elif self.brand == "esphome":
+            # Marstek behind a LilyGo RS485 bridge: telemetry/control go through
+            # the ESPHome integration's HA entities. host carries the ESPHome
+            # device registry id (stable identity for device_key / persistence);
+            # esphome_device_id is the explicit config field.
+            self.driver = EsphomeEntityDriver(
+                hass,
+                esphome_device_id or self.host,
+                max_charge_power_w=self.max_charge_power,
+                max_discharge_power_w=self.max_discharge_power,
             )
         else:
             self.driver = MarstekModbusDriver(

--- a/custom_components/omnibattery/manifest.json
+++ b/custom_components/omnibattery/manifest.json
@@ -2,7 +2,8 @@
   "domain": "omnibattery",
   "name": "Omnibattery",
   "after_dependencies": [
-    "recorder"
+    "recorder",
+    "esphome"
   ],
   "codeowners": [
     "@ffunes"

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -74,6 +74,18 @@
           "port": "HTTP port (default 80)"
         }
       },
+      "battery_connection_esphome": {
+        "title": "Configure battery {battery_num} — Connection (LilyGo/ESPHome)",
+        "description": "Select the ESPHome device (LilyGo RS485 bridge) that exposes Marstek battery {battery_num}. It must run the marstek-lilygo-rs485 firmware with the stock entity names.",
+        "data": {
+          "name": "Name",
+          "esphome_device": "ESPHome device"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "esphome_device": "The LilyGo T-CAN485 device flashed with the Marstek ESPHome firmware"
+        }
+      },
       "battery_limits": {
         "title": "Configure battery {battery_num} — Limits",
         "description": "Enter power and SOC limits for battery {battery_num}.",
@@ -461,6 +473,18 @@
           "port": "HTTP port (default 80)"
         }
       },
+      "reconfigure_battery_esphome": {
+        "title": "Reconfigure battery {battery_num} — Connection (LilyGo/ESPHome)",
+        "description": "Update the ESPHome device for Marstek battery {battery_num}. All other settings are preserved.",
+        "data": {
+          "name": "Name",
+          "esphome_device": "ESPHome device"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "esphome_device": "The LilyGo T-CAN485 device flashed with the Marstek ESPHome firmware"
+        }
+      },
       "restore_backup": {
         "title": "Restore previous configuration",
         "description": "Found a saved backup of {count} previous configuration(s) (connection, options and tuning). Restore it to recover everything without setting it up again? Your entities and history reconnect automatically.",
@@ -471,6 +495,7 @@
     },
     "error": {
       "cannot_connect": "Cannot connect to the battery. Check the IP address and that the battery is accessible on the network.",
+      "esphome_entities_missing": "The selected ESPHome device is missing required entities: {missing}. Make sure it runs the marstek-lilygo-rs485 firmware with the stock entity names.",
       "sensor_not_found": "Solar forecast sensor does not exist. Verify the sensor is available.",
       "invalid_unit": "Solar forecast sensor must have 'kWh' or 'Wh' as unit.",
       "incomplete_window": "Each extra charging window needs both a start and an end time. Fill both, or leave both empty to skip it.",
@@ -576,6 +601,18 @@
           "name": "Descriptive name to identify this battery",
           "host": "IP address of the Zendure device on your local network",
           "port": "HTTP port (default 80)"
+        }
+      },
+      "battery_connection_esphome": {
+        "title": "Configure battery {battery_num} — Connection (LilyGo/ESPHome)",
+        "description": "Select the ESPHome device (LilyGo RS485 bridge) that exposes Marstek battery {battery_num}. It must run the marstek-lilygo-rs485 firmware with the stock entity names.",
+        "data": {
+          "name": "Name",
+          "esphome_device": "ESPHome device"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "esphome_device": "The LilyGo T-CAN485 device flashed with the Marstek ESPHome firmware"
         }
       },
       "battery_limits": {
@@ -934,6 +971,7 @@
     },
     "error": {
       "cannot_connect": "Cannot connect to the battery. Check the IP address and that the battery is accessible on the network.",
+      "esphome_entities_missing": "The selected ESPHome device is missing required entities: {missing}. Make sure it runs the marstek-lilygo-rs485 firmware with the stock entity names.",
       "sensor_not_found": "Solar forecast sensor does not exist. Verify the sensor is available.",
       "invalid_unit": "Solar forecast sensor must have 'kWh' or 'Wh' as unit.",
       "incomplete_window": "Each extra charging window needs both a start and an end time. Fill both, or leave both empty to skip it.",

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -74,6 +74,18 @@
           "port": "Port HTTP (per defecte 80)"
         }
       },
+      "battery_connection_esphome": {
+        "title": "Configura la bateria {battery_num} — Connexió (LilyGo/ESPHome)",
+        "description": "Selecciona el dispositiu ESPHome (pont LilyGo RS485) que exposa la bateria Marstek {battery_num}. Ha d'executar el firmware marstek-lilygo-rs485 amb els noms d'entitat originals.",
+        "data": {
+          "name": "Nom",
+          "esphome_device": "Dispositiu ESPHome"
+        },
+        "data_description": {
+          "name": "Nom descriptiu per identificar aquesta bateria",
+          "esphome_device": "El dispositiu LilyGo T-CAN485 amb el firmware ESPHome de Marstek"
+        }
+      },
       "battery_limits": {
         "title": "Configurar bateria {battery_num} — Límits",
         "description": "Introdueix els límits de potència i SOC de la bateria {battery_num}.",
@@ -469,6 +481,18 @@
           "port": "Port HTTP (per defecte 80)"
         }
       },
+      "reconfigure_battery_esphome": {
+        "title": "Reconfigura la bateria {battery_num} — Connexió (LilyGo/ESPHome)",
+        "description": "Actualitza el dispositiu ESPHome de la bateria Marstek {battery_num}. La resta d'ajustos es conserven.",
+        "data": {
+          "name": "Nom",
+          "esphome_device": "Dispositiu ESPHome"
+        },
+        "data_description": {
+          "name": "Nom descriptiu per identificar aquesta bateria",
+          "esphome_device": "El dispositiu LilyGo T-CAN485 amb el firmware ESPHome de Marstek"
+        }
+      },
       "restore_backup": {
         "title": "Restaura la configuració anterior",
         "description": "S'ha trobat una còpia de seguretat de {count} configuració(ns) anterior(s) (connexió, opcions i ajust). Vols restaurar-la per recuperar-ho tot sense tornar a configurar? Les teves entitats i historial es reconnectaran automàticament.",
@@ -479,6 +503,7 @@
     },
     "error": {
       "cannot_connect": "No es pot connectar a la bateria. Verifica l'adreça IP i que la bateria sigui accessible a la xarxa.",
+      "esphome_entities_missing": "Al dispositiu ESPHome seleccionat li falten entitats necessàries: {missing}. Assegura't que executa el firmware marstek-lilygo-rs485 amb els noms d'entitat originals.",
       "sensor_not_found": "El sensor de predicció solar no existeix. Verifica que el sensor estigui disponible.",
       "invalid_unit": "El sensor de predicció solar ha de tenir com a unitat 'kWh' o 'Wh'.",
       "incomplete_window": "Cada franja de càrrega addicional necessita hora d'inici i de fi. Omple les dues o deixa-les buides per ometre-la.",
@@ -585,6 +610,18 @@
           "name": "Nom descriptiu per identificar aquesta bateria",
           "host": "Adreça IP del Zendure SolarFlow a la teva xarxa local",
           "port": "Port HTTP (per defecte 80)"
+        }
+      },
+      "battery_connection_esphome": {
+        "title": "Configura la bateria {battery_num} — Connexió (LilyGo/ESPHome)",
+        "description": "Selecciona el dispositiu ESPHome (pont LilyGo RS485) que exposa la bateria Marstek {battery_num}. Ha d'executar el firmware marstek-lilygo-rs485 amb els noms d'entitat originals.",
+        "data": {
+          "name": "Nom",
+          "esphome_device": "Dispositiu ESPHome"
+        },
+        "data_description": {
+          "name": "Nom descriptiu per identificar aquesta bateria",
+          "esphome_device": "El dispositiu LilyGo T-CAN485 amb el firmware ESPHome de Marstek"
         }
       },
       "battery_limits": {
@@ -951,6 +988,7 @@
     },
     "error": {
       "cannot_connect": "No es pot connectar a la bateria. Verifica l'adreça IP i que la bateria sigui accessible a la xarxa.",
+      "esphome_entities_missing": "Al dispositiu ESPHome seleccionat li falten entitats necessàries: {missing}. Assegura't que executa el firmware marstek-lilygo-rs485 amb els noms d'entitat originals.",
       "sensor_not_found": "El sensor de predicció solar no existeix. Verifica que el sensor estigui disponible.",
       "invalid_unit": "El sensor de predicció solar ha de tenir com a unitat 'kWh' o 'Wh'.",
       "incomplete_window": "Cada franja de càrrega addicional necessita hora d'inici i de fi. Omple les dues o deixa-les buides per ometre-la.",

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -74,6 +74,18 @@
           "port": "HTTP-Port (Standard 80)"
         }
       },
+      "battery_connection_esphome": {
+        "title": "Batterie {battery_num} konfigurieren — Verbindung (LilyGo/ESPHome)",
+        "description": "Wähle das ESPHome-Gerät (LilyGo-RS485-Brücke), das die Marstek-Batterie {battery_num} bereitstellt. Es muss die marstek-lilygo-rs485-Firmware mit den Original-Entitätsnamen ausführen.",
+        "data": {
+          "name": "Name",
+          "esphome_device": "ESPHome-Gerät"
+        },
+        "data_description": {
+          "name": "Beschreibender Name zur Identifikation dieser Batterie",
+          "esphome_device": "Das mit der Marstek-ESPHome-Firmware geflashte LilyGo-T-CAN485-Gerät"
+        }
+      },
       "battery_limits": {
         "title": "Batterie {battery_num} konfigurieren — Grenzwerte",
         "description": "Geben Sie Leistungs- und SOC-Grenzwerte für Batterie {battery_num} ein.",
@@ -469,6 +481,18 @@
           "port": "HTTP-Port (Standard 80)"
         }
       },
+      "reconfigure_battery_esphome": {
+        "title": "Batterie {battery_num} neu konfigurieren — Verbindung (LilyGo/ESPHome)",
+        "description": "Aktualisiere das ESPHome-Gerät der Marstek-Batterie {battery_num}. Alle anderen Einstellungen bleiben erhalten.",
+        "data": {
+          "name": "Name",
+          "esphome_device": "ESPHome-Gerät"
+        },
+        "data_description": {
+          "name": "Beschreibender Name zur Identifikation dieser Batterie",
+          "esphome_device": "Das mit der Marstek-ESPHome-Firmware geflashte LilyGo-T-CAN485-Gerät"
+        }
+      },
       "restore_backup": {
         "title": "Vorherige Konfiguration wiederherstellen",
         "description": "Eine gespeicherte Sicherung von {count} vorherigen Konfiguration(en) (Verbindung, Optionen und Abstimmung) wurde gefunden. Wiederherstellen, um alles ohne erneute Einrichtung zurückzubekommen? Deine Entitäten und der Verlauf werden automatisch wieder verbunden.",
@@ -479,6 +503,7 @@
     },
     "error": {
       "cannot_connect": "Verbindung zur Batterie nicht möglich. Überprüfen Sie die IP-Adresse und dass die Batterie im Netzwerk erreichbar ist.",
+      "esphome_entities_missing": "Dem ausgewählten ESPHome-Gerät fehlen erforderliche Entitäten: {missing}. Stelle sicher, dass es die marstek-lilygo-rs485-Firmware mit den Original-Entitätsnamen ausführt.",
       "sensor_not_found": "Solarprognose-Sensor existiert nicht. Überprüfen Sie, dass der Sensor verfügbar ist.",
       "invalid_unit": "Solarprognose-Sensor muss 'kWh' oder 'Wh' als Einheit haben.",
       "incomplete_window": "Jedes zusätzliche Ladefenster benötigt eine Start- und eine Endzeit. Füllen Sie beide aus oder lassen Sie beide leer, um es zu überspringen.",
@@ -585,6 +610,18 @@
           "name": "Beschreibender Name zur Identifizierung dieser Batterie",
           "host": "IP-Adresse des Zendure SolarFlow in Ihrem lokalen Netzwerk",
           "port": "HTTP-Port (Standard 80)"
+        }
+      },
+      "battery_connection_esphome": {
+        "title": "Batterie {battery_num} konfigurieren — Verbindung (LilyGo/ESPHome)",
+        "description": "Wähle das ESPHome-Gerät (LilyGo-RS485-Brücke), das die Marstek-Batterie {battery_num} bereitstellt. Es muss die marstek-lilygo-rs485-Firmware mit den Original-Entitätsnamen ausführen.",
+        "data": {
+          "name": "Name",
+          "esphome_device": "ESPHome-Gerät"
+        },
+        "data_description": {
+          "name": "Beschreibender Name zur Identifikation dieser Batterie",
+          "esphome_device": "Das mit der Marstek-ESPHome-Firmware geflashte LilyGo-T-CAN485-Gerät"
         }
       },
       "battery_limits": {
@@ -951,6 +988,7 @@
     },
     "error": {
       "cannot_connect": "Verbindung zur Batterie nicht möglich. Überprüfen Sie die IP-Adresse und dass die Batterie im Netzwerk erreichbar ist.",
+      "esphome_entities_missing": "Dem ausgewählten ESPHome-Gerät fehlen erforderliche Entitäten: {missing}. Stelle sicher, dass es die marstek-lilygo-rs485-Firmware mit den Original-Entitätsnamen ausführt.",
       "sensor_not_found": "Solarprognose-Sensor existiert nicht. Überprüfen Sie, dass der Sensor verfügbar ist.",
       "invalid_unit": "Solarprognose-Sensor muss 'kWh' oder 'Wh' als Einheit haben.",
       "incomplete_window": "Jedes zusätzliche Ladefenster benötigt eine Start- und eine Endzeit. Füllen Sie beide aus oder lassen Sie beide leer, um es zu überspringen.",

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -74,6 +74,18 @@
           "port": "HTTP port (default 80)"
         }
       },
+      "battery_connection_esphome": {
+        "title": "Configure battery {battery_num} — Connection (LilyGo/ESPHome)",
+        "description": "Select the ESPHome device (LilyGo RS485 bridge) that exposes Marstek battery {battery_num}. It must run the marstek-lilygo-rs485 firmware with the stock entity names.",
+        "data": {
+          "name": "Name",
+          "esphome_device": "ESPHome device"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "esphome_device": "The LilyGo T-CAN485 device flashed with the Marstek ESPHome firmware"
+        }
+      },
       "battery_limits": {
         "title": "Configure battery {battery_num} — Limits",
         "description": "Enter power and SOC limits for battery {battery_num}.",
@@ -463,6 +475,18 @@
           "port": "HTTP port (default 80)"
         }
       },
+      "reconfigure_battery_esphome": {
+        "title": "Reconfigure battery {battery_num} — Connection (LilyGo/ESPHome)",
+        "description": "Update the ESPHome device for Marstek battery {battery_num}. All other settings are preserved.",
+        "data": {
+          "name": "Name",
+          "esphome_device": "ESPHome device"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "esphome_device": "The LilyGo T-CAN485 device flashed with the Marstek ESPHome firmware"
+        }
+      },
       "restore_backup": {
         "title": "Restore previous configuration",
         "description": "Found a saved backup of {count} previous configuration(s) (connection, options and tuning). Restore it to recover everything without setting it up again? Your entities and history reconnect automatically.",
@@ -473,6 +497,7 @@
     },
     "error": {
       "cannot_connect": "Cannot connect to the battery. Check the IP address and that the battery is accessible on the network.",
+      "esphome_entities_missing": "The selected ESPHome device is missing required entities: {missing}. Make sure it runs the marstek-lilygo-rs485 firmware with the stock entity names.",
       "sensor_not_found": "Solar forecast sensor does not exist. Verify the sensor is available.",
       "invalid_unit": "Solar forecast sensor must have 'kWh' or 'Wh' as unit.",
       "incomplete_window": "Each extra charging window needs both a start and an end time. Fill both, or leave both empty to skip it.",
@@ -579,6 +604,18 @@
           "name": "Descriptive name to identify this battery",
           "host": "IP address of the Zendure device on your local network",
           "port": "HTTP port (default 80)"
+        }
+      },
+      "battery_connection_esphome": {
+        "title": "Configure battery {battery_num} — Connection (LilyGo/ESPHome)",
+        "description": "Select the ESPHome device (LilyGo RS485 bridge) that exposes Marstek battery {battery_num}. It must run the marstek-lilygo-rs485 firmware with the stock entity names.",
+        "data": {
+          "name": "Name",
+          "esphome_device": "ESPHome device"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "esphome_device": "The LilyGo T-CAN485 device flashed with the Marstek ESPHome firmware"
         }
       },
       "battery_limits": {
@@ -939,6 +976,7 @@
     },
     "error": {
       "cannot_connect": "Cannot connect to the battery. Check the IP address and that the battery is accessible on the network.",
+      "esphome_entities_missing": "The selected ESPHome device is missing required entities: {missing}. Make sure it runs the marstek-lilygo-rs485 firmware with the stock entity names.",
       "sensor_not_found": "Solar forecast sensor does not exist. Verify the sensor is available.",
       "invalid_unit": "Solar forecast sensor must have 'kWh' or 'Wh' as unit.",
       "incomplete_window": "Each extra charging window needs both a start and an end time. Fill both, or leave both empty to skip it.",

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -74,6 +74,18 @@
           "port": "Puerto HTTP (por defecto 80)"
         }
       },
+      "battery_connection_esphome": {
+        "title": "Configurar batería {battery_num} — Conexión (LilyGo/ESPHome)",
+        "description": "Selecciona el dispositivo ESPHome (puente LilyGo RS485) que expone la batería Marstek {battery_num}. Debe ejecutar el firmware marstek-lilygo-rs485 con los nombres de entidad originales.",
+        "data": {
+          "name": "Nombre",
+          "esphome_device": "Dispositivo ESPHome"
+        },
+        "data_description": {
+          "name": "Nombre descriptivo para identificar esta batería",
+          "esphome_device": "El dispositivo LilyGo T-CAN485 flasheado con el firmware ESPHome de Marstek"
+        }
+      },
       "battery_limits": {
         "title": "Configurar batería {battery_num} — Límites",
         "description": "Introduce los límites de potencia y SOC de la batería {battery_num}.",
@@ -469,6 +481,18 @@
           "port": "Puerto HTTP (por defecto 80)"
         }
       },
+      "reconfigure_battery_esphome": {
+        "title": "Reconfigurar batería {battery_num} — Conexión (LilyGo/ESPHome)",
+        "description": "Actualiza el dispositivo ESPHome de la batería Marstek {battery_num}. El resto de ajustes se conservan.",
+        "data": {
+          "name": "Nombre",
+          "esphome_device": "Dispositivo ESPHome"
+        },
+        "data_description": {
+          "name": "Nombre descriptivo para identificar esta batería",
+          "esphome_device": "El dispositivo LilyGo T-CAN485 flasheado con el firmware ESPHome de Marstek"
+        }
+      },
       "restore_backup": {
         "title": "Restaurar configuración anterior",
         "description": "Se encontró una copia de seguridad de {count} configuración(es) anterior(es) (conexión, opciones y ajuste). ¿Restaurarla para recuperar todo sin configurarlo de nuevo? Tus entidades e histórico se reconectarán automáticamente.",
@@ -479,6 +503,7 @@
     },
     "error": {
       "cannot_connect": "No se puede conectar a la batería. Verifica la dirección IP y que la batería esté accesible en la red.",
+      "esphome_entities_missing": "Al dispositivo ESPHome seleccionado le faltan entidades necesarias: {missing}. Asegúrate de que ejecuta el firmware marstek-lilygo-rs485 con los nombres de entidad originales.",
       "sensor_not_found": "El sensor de predicción solar no existe. Verifica que el sensor esté disponible.",
       "invalid_unit": "El sensor de predicción solar debe tener como unidad 'kWh' o 'Wh'.",
       "incomplete_window": "Cada franja de carga adicional necesita hora de inicio y de fin. Rellena ambas o deja ambas vacías para omitirla.",
@@ -585,6 +610,18 @@
           "name": "Nombre descriptivo para identificar esta batería",
           "host": "Dirección IP del Zendure SolarFlow en tu red local",
           "port": "Puerto HTTP (por defecto 80)"
+        }
+      },
+      "battery_connection_esphome": {
+        "title": "Configurar batería {battery_num} — Conexión (LilyGo/ESPHome)",
+        "description": "Selecciona el dispositivo ESPHome (puente LilyGo RS485) que expone la batería Marstek {battery_num}. Debe ejecutar el firmware marstek-lilygo-rs485 con los nombres de entidad originales.",
+        "data": {
+          "name": "Nombre",
+          "esphome_device": "Dispositivo ESPHome"
+        },
+        "data_description": {
+          "name": "Nombre descriptivo para identificar esta batería",
+          "esphome_device": "El dispositivo LilyGo T-CAN485 flasheado con el firmware ESPHome de Marstek"
         }
       },
       "battery_limits": {
@@ -951,6 +988,7 @@
     },
     "error": {
       "cannot_connect": "No se puede conectar a la batería. Verifica la dirección IP y que la batería esté accesible en la red.",
+      "esphome_entities_missing": "Al dispositivo ESPHome seleccionado le faltan entidades necesarias: {missing}. Asegúrate de que ejecuta el firmware marstek-lilygo-rs485 con los nombres de entidad originales.",
       "sensor_not_found": "El sensor de predicción solar no existe. Verifica que el sensor esté disponible.",
       "invalid_unit": "El sensor de predicción solar debe tener como unidad 'kWh' o 'Wh'.",
       "incomplete_window": "Cada franja de carga adicional necesita hora de inicio y de fin. Rellena ambas o deja ambas vacías para omitirla.",

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -74,6 +74,18 @@
           "port": "Port HTTP (par défaut 80)"
         }
       },
+      "battery_connection_esphome": {
+        "title": "Configurer la batterie {battery_num} — Connexion (LilyGo/ESPHome)",
+        "description": "Sélectionnez l'appareil ESPHome (pont LilyGo RS485) qui expose la batterie Marstek {battery_num}. Il doit exécuter le firmware marstek-lilygo-rs485 avec les noms d'entités d'origine.",
+        "data": {
+          "name": "Nom",
+          "esphome_device": "Appareil ESPHome"
+        },
+        "data_description": {
+          "name": "Nom descriptif pour identifier cette batterie",
+          "esphome_device": "L'appareil LilyGo T-CAN485 flashé avec le firmware ESPHome Marstek"
+        }
+      },
       "battery_limits": {
         "title": "Configurer la batterie {battery_num} — Limites",
         "description": "Entrez les limites de puissance et de SOC pour la batterie {battery_num}.",
@@ -469,6 +481,18 @@
           "port": "Port HTTP (par défaut 80)"
         }
       },
+      "reconfigure_battery_esphome": {
+        "title": "Reconfigurer la batterie {battery_num} — Connexion (LilyGo/ESPHome)",
+        "description": "Mettez à jour l'appareil ESPHome de la batterie Marstek {battery_num}. Tous les autres réglages sont conservés.",
+        "data": {
+          "name": "Nom",
+          "esphome_device": "Appareil ESPHome"
+        },
+        "data_description": {
+          "name": "Nom descriptif pour identifier cette batterie",
+          "esphome_device": "L'appareil LilyGo T-CAN485 flashé avec le firmware ESPHome Marstek"
+        }
+      },
       "restore_backup": {
         "title": "Restaurer la configuration précédente",
         "description": "Une sauvegarde de {count} configuration(s) précédente(s) (connexion, options et réglages) a été trouvée. La restaurer pour tout récupérer sans reconfigurer ? Vos entités et votre historique se reconnecteront automatiquement.",
@@ -479,6 +503,7 @@
     },
     "error": {
       "cannot_connect": "Impossible de se connecter à la batterie. Vérifiez l'adresse IP et que la batterie est accessible sur le réseau.",
+      "esphome_entities_missing": "Il manque des entités requises à l'appareil ESPHome sélectionné : {missing}. Vérifiez qu'il exécute le firmware marstek-lilygo-rs485 avec les noms d'entités d'origine.",
       "sensor_not_found": "Le capteur de prévision solaire n'existe pas. Vérifiez que le capteur est disponible.",
       "invalid_unit": "Le capteur de prévision solaire doit avoir 'kWh' ou 'Wh' comme unité.",
       "incomplete_window": "Chaque fenêtre de charge supplémentaire nécessite une heure de début et de fin. Remplissez les deux, ou laissez les deux vides pour l'ignorer.",
@@ -585,6 +610,18 @@
           "name": "Nom descriptif pour identifier cette batterie",
           "host": "Adresse IP du Zendure SolarFlow sur votre réseau local",
           "port": "Port HTTP (par défaut 80)"
+        }
+      },
+      "battery_connection_esphome": {
+        "title": "Configurer la batterie {battery_num} — Connexion (LilyGo/ESPHome)",
+        "description": "Sélectionnez l'appareil ESPHome (pont LilyGo RS485) qui expose la batterie Marstek {battery_num}. Il doit exécuter le firmware marstek-lilygo-rs485 avec les noms d'entités d'origine.",
+        "data": {
+          "name": "Nom",
+          "esphome_device": "Appareil ESPHome"
+        },
+        "data_description": {
+          "name": "Nom descriptif pour identifier cette batterie",
+          "esphome_device": "L'appareil LilyGo T-CAN485 flashé avec le firmware ESPHome Marstek"
         }
       },
       "battery_limits": {
@@ -951,6 +988,7 @@
     },
     "error": {
       "cannot_connect": "Impossible de se connecter à la batterie. Vérifiez l'adresse IP et que la batterie est accessible sur le réseau.",
+      "esphome_entities_missing": "Il manque des entités requises à l'appareil ESPHome sélectionné : {missing}. Vérifiez qu'il exécute le firmware marstek-lilygo-rs485 avec les noms d'entités d'origine.",
       "sensor_not_found": "Le capteur de prévision solaire n'existe pas. Vérifiez que le capteur est disponible.",
       "invalid_unit": "Le capteur de prévision solaire doit avoir 'kWh' ou 'Wh' comme unité.",
       "incomplete_window": "Chaque fenêtre de charge supplémentaire nécessite une heure de début et de fin. Remplissez les deux, ou laissez les deux vides pour l'ignorer.",

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -74,6 +74,18 @@
           "port": "HTTP-poort (standaard 80)"
         }
       },
+      "battery_connection_esphome": {
+        "title": "Batterij {battery_num} configureren — Verbinding (LilyGo/ESPHome)",
+        "description": "Selecteer het ESPHome-apparaat (LilyGo RS485-brug) dat Marstek-batterij {battery_num} beschikbaar maakt. Het moet de marstek-lilygo-rs485-firmware met de originele entiteitsnamen draaien.",
+        "data": {
+          "name": "Naam",
+          "esphome_device": "ESPHome-apparaat"
+        },
+        "data_description": {
+          "name": "Beschrijvende naam om deze batterij te identificeren",
+          "esphome_device": "Het LilyGo T-CAN485-apparaat geflasht met de Marstek ESPHome-firmware"
+        }
+      },
       "battery_limits": {
         "title": "Batterij {battery_num} configureren — Limieten",
         "description": "Voer vermogen- en SOC-limieten in voor batterij {battery_num}.",
@@ -469,6 +481,18 @@
           "port": "HTTP-poort (standaard 80)"
         }
       },
+      "reconfigure_battery_esphome": {
+        "title": "Batterij {battery_num} opnieuw configureren — Verbinding (LilyGo/ESPHome)",
+        "description": "Werk het ESPHome-apparaat van Marstek-batterij {battery_num} bij. Alle andere instellingen blijven behouden.",
+        "data": {
+          "name": "Naam",
+          "esphome_device": "ESPHome-apparaat"
+        },
+        "data_description": {
+          "name": "Beschrijvende naam om deze batterij te identificeren",
+          "esphome_device": "Het LilyGo T-CAN485-apparaat geflasht met de Marstek ESPHome-firmware"
+        }
+      },
       "restore_backup": {
         "title": "Vorige configuratie herstellen",
         "description": "Er is een back-up van {count} vorige configuratie(s) (verbinding, opties en afstemming) gevonden. Herstellen om alles terug te krijgen zonder opnieuw in te stellen? Je entiteiten en geschiedenis worden automatisch opnieuw verbonden.",
@@ -479,6 +503,7 @@
     },
     "error": {
       "cannot_connect": "Kan geen verbinding maken met de batterij. Controleer het IP-adres en of de batterij toegankelijk is op het netwerk.",
+      "esphome_entities_missing": "Het geselecteerde ESPHome-apparaat mist vereiste entiteiten: {missing}. Zorg dat het de marstek-lilygo-rs485-firmware met de originele entiteitsnamen draait.",
       "sensor_not_found": "Zonnevoorspellingssensor bestaat niet. Controleer of de sensor beschikbaar is.",
       "invalid_unit": "Zonnevoorspellingssensor moet 'kWh' of 'Wh' als eenheid hebben.",
       "incomplete_window": "Elk extra laadvenster heeft een start- en een eindtijd nodig. Vul beide in, of laat beide leeg om het over te slaan.",
@@ -585,6 +610,18 @@
           "name": "Beschrijvende naam om deze batterij te identificeren",
           "host": "IP-adres van de Zendure SolarFlow op uw lokale netwerk",
           "port": "HTTP-poort (standaard 80)"
+        }
+      },
+      "battery_connection_esphome": {
+        "title": "Batterij {battery_num} configureren — Verbinding (LilyGo/ESPHome)",
+        "description": "Selecteer het ESPHome-apparaat (LilyGo RS485-brug) dat Marstek-batterij {battery_num} beschikbaar maakt. Het moet de marstek-lilygo-rs485-firmware met de originele entiteitsnamen draaien.",
+        "data": {
+          "name": "Naam",
+          "esphome_device": "ESPHome-apparaat"
+        },
+        "data_description": {
+          "name": "Beschrijvende naam om deze batterij te identificeren",
+          "esphome_device": "Het LilyGo T-CAN485-apparaat geflasht met de Marstek ESPHome-firmware"
         }
       },
       "battery_limits": {
@@ -951,6 +988,7 @@
     },
     "error": {
       "cannot_connect": "Kan geen verbinding maken met de batterij. Controleer het IP-adres en of de batterij toegankelijk is op het netwerk.",
+      "esphome_entities_missing": "Het geselecteerde ESPHome-apparaat mist vereiste entiteiten: {missing}. Zorg dat het de marstek-lilygo-rs485-firmware met de originele entiteitsnamen draait.",
       "sensor_not_found": "Zonnevoorspellingssensor bestaat niet. Controleer of de sensor beschikbaar is.",
       "invalid_unit": "Zonnevoorspellingssensor moet 'kWh' of 'Wh' als eenheid hebben.",
       "incomplete_window": "Elk extra laadvenster heeft een start- en een eindtijd nodig. Vul beide in, of laat beide leeg om het over te slaan.",

--- a/tests/test_esphome_driver.py
+++ b/tests/test_esphome_driver.py
@@ -1,0 +1,275 @@
+"""Unit tests for the ESPHome-entity driver (Marstek behind a LilyGo RS485 bridge).
+
+HA is faked with a minimal states/services stub, so no runtime is required.
+Entity resolution is tested through the pure ``_match_entities`` helper.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.omnibattery.drivers.esphome import (
+    EsphomeEntityDriver,
+    NUMBER_DEFINITIONS,
+    SELECT_DEFINITIONS,
+    SENSOR_DEFINITIONS,
+    SWITCH_DEFINITIONS,
+)
+
+
+# ---------------------------------------------------------------------------
+# HA fakes
+# ---------------------------------------------------------------------------
+
+class _State:
+    def __init__(self, state: str):
+        self.state = state
+
+
+class _States:
+    def __init__(self, table: dict[str, str]):
+        self._table = table
+
+    def get(self, entity_id):
+        raw = self._table.get(entity_id)
+        return _State(raw) if raw is not None else None
+
+
+def _hass(states: dict[str, str]) -> MagicMock:
+    hass = MagicMock()
+    hass.states = _States(states)
+    hass.services.async_call = AsyncMock()
+    return hass
+
+
+# Entity ids as the upstream YAML creates them on a device named "marstek".
+_ENTITIES = {
+    "battery_soc":                 "sensor.marstek_battery_state_of_charge",
+    "battery_power":               "sensor.marstek_battery_power",
+    "ac_power":                    "sensor.marstek_ac_power",
+    "battery_voltage":             "sensor.marstek_battery_voltage",
+    "internal_temperature":        "sensor.marstek_internal_temperature",
+    "inverter_state":              "sensor.marstek_inverter_state",
+    "force_mode":                  "select.marstek_forcible_charge_discharge",
+    "user_work_mode":              "select.marstek_user_work_mode",
+    "backup_function":             "select.marstek_backup_function",
+    "rs485_control_mode":          "select.marstek_rs485_control_mode",
+    "set_charge_power":            "number.marstek_forcible_charge_power",
+    "set_discharge_power":         "number.marstek_forcible_discharge_power",
+    "max_charge_power":            "number.marstek_max_charge_power",
+    "max_discharge_power":         "number.marstek_max_discharge_power",
+    "charging_cutoff_capacity":    "number.marstek_charging_cutoff_capacity",
+    "discharging_cutoff_capacity": "number.marstek_discharging_cutoff_capacity",
+}
+
+
+def _driver(states: dict[str, str]) -> EsphomeEntityDriver:
+    driver = EsphomeEntityDriver(_hass(states), "devid123")
+    driver._entities = dict(_ENTITIES)
+    return driver
+
+
+# ---------------------------------------------------------------------------
+# Entity resolution
+# ---------------------------------------------------------------------------
+
+def test_match_entities_by_original_name():
+    entries = [
+        ("sensor", "Battery State Of Charge", "sensor.renamed_by_user"),
+        ("sensor", "Max. Cell Voltage", "sensor.marstek_max_cell_voltage"),
+        ("select", "Forcible Charge-Discharge", "select.marstek_forcible_charge_discharge"),
+        ("number", "Forcible Charge Power", "number.marstek_forcible_charge_power"),
+        ("sensor", "Battery Runtime Estimate", "sensor.marstek_battery_runtime_estimate"),
+    ]
+    resolved = EsphomeEntityDriver._match_entities(entries)
+    # original_name match survives an entity_id rename
+    assert resolved["battery_soc"] == "sensor.renamed_by_user"
+    # punctuation in the name slugs away
+    assert resolved["max_cell_voltage"] == "sensor.marstek_max_cell_voltage"
+    assert resolved["force_mode"] == "select.marstek_forcible_charge_discharge"
+    assert resolved["set_charge_power"] == "number.marstek_forcible_charge_power"
+    # unmapped upstream entities are ignored
+    assert "battery_runtime_estimate" not in resolved
+
+
+def test_match_entities_entity_id_fallback():
+    # original_name lost (None): the entity_id suffix still matches.
+    entries = [
+        ("sensor", None, "sensor.mydevice_battery_state_of_charge"),
+        ("select", None, "select.mydevice_forcible_charge_discharge"),
+    ]
+    resolved = EsphomeEntityDriver._match_entities(entries)
+    assert resolved["battery_soc"] == "sensor.mydevice_battery_state_of_charge"
+    assert resolved["force_mode"] == "select.mydevice_forcible_charge_discharge"
+
+
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_telemetry_decodes_states():
+    driver = _driver({
+        _ENTITIES["battery_soc"]: "57",
+        _ENTITIES["battery_power"]: "-612.0",
+        _ENTITIES["ac_power"]: "830",
+        _ENTITIES["battery_voltage"]: "52.3",
+        _ENTITIES["inverter_state"]: "Discharge",
+        _ENTITIES["force_mode"]: "discharge",
+        _ENTITIES["user_work_mode"]: "manual",
+        _ENTITIES["backup_function"]: "disable",
+        _ENTITIES["rs485_control_mode"]: "enable",
+        _ENTITIES["set_charge_power"]: "0",
+        _ENTITIES["set_discharge_power"]: "650",
+        _ENTITIES["charging_cutoff_capacity"]: "95",
+        _ENTITIES["max_charge_power"]: "2500",
+    })
+    snap = await driver.read_telemetry()
+    assert snap["battery_soc"] == 57
+    assert snap["battery_power"] == -612
+    assert snap["battery_voltage"] == 52.3
+    # select states decode to Marstek wire values
+    assert snap["force_mode"] == 2
+    assert snap["user_work_mode"] == 0
+    assert snap["backup_function"] == 1
+    assert snap["rs485_control_mode"] == 21930
+    # inverter state text → v2 numeric code
+    assert snap["inverter_state"] == 3
+    # cutoffs stay in percent (scale 1 end to end)
+    assert snap["charging_cutoff_capacity"] == 95
+    # unavailable / unmapped keys are omitted
+    assert "min_cell_voltage" not in snap
+
+
+@pytest.mark.asyncio
+async def test_read_telemetry_offline_device_returns_empty():
+    driver = _driver({
+        _ENTITIES["battery_soc"]: "unavailable",
+        _ENTITIES["battery_power"]: "unknown",
+    })
+    assert await driver.read_telemetry() == {}
+
+
+@pytest.mark.asyncio
+async def test_read_telemetry_key_filter():
+    driver = _driver({
+        _ENTITIES["battery_soc"]: "57",
+        _ENTITIES["ac_power"]: "830",
+    })
+    snap = await driver.read_telemetry(["battery_soc"])
+    assert snap == {"battery_soc": 57}
+
+
+# ---------------------------------------------------------------------------
+# Control
+# ---------------------------------------------------------------------------
+
+def _calls(driver):
+    return [
+        (c.args[0], c.args[1], c.args[2])
+        for c in driver.hass.services.async_call.call_args_list
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_setpoint_charge(monkeypatch):
+    import asyncio as _asyncio
+    monkeypatch.setattr(_asyncio, "sleep", AsyncMock())
+    driver = _driver({
+        _ENTITIES["force_mode"]: "charge",
+        _ENTITIES["set_charge_power"]: "800",
+        _ENTITIES["set_discharge_power"]: "0",
+        _ENTITIES["battery_power"]: "790",
+    })
+    result = await driver.apply_setpoint(800)
+    assert result.ok and result.confirmed
+    assert result.net_power_w == 800
+    assert result.battery_power_w == 790
+    calls = _calls(driver)
+    # discharge number, charge number, then the force select — Marstek order
+    assert calls[0] == ("number", "set_value", {"entity_id": _ENTITIES["set_discharge_power"], "value": 0})
+    assert calls[1] == ("number", "set_value", {"entity_id": _ENTITIES["set_charge_power"], "value": 800})
+    assert calls[2] == ("select", "select_option", {"entity_id": _ENTITIES["force_mode"], "option": "charge"})
+
+
+@pytest.mark.asyncio
+async def test_apply_setpoint_discharge_clamps_to_capability():
+    driver = _driver({})
+    result = await driver.apply_setpoint(-9999, read_back=False)
+    assert result.ok and not result.confirmed
+    assert result.net_power_w == -2500
+    calls = _calls(driver)
+    assert calls[0][2]["value"] == 2500
+    assert calls[2][2]["option"] == "discharge"
+
+
+@pytest.mark.asyncio
+async def test_apply_setpoint_idle_and_failure():
+    driver = _driver({})
+    result = await driver.apply_setpoint(0, read_back=False)
+    assert result.ok
+    assert _calls(driver)[2][2]["option"] == "stop"
+
+    driver.hass.services.async_call = AsyncMock(side_effect=Exception("boom"))
+    result = await driver.apply_setpoint(500, read_back=False)
+    assert not result.ok
+    assert result.failure_reason == "service_call_failed"
+
+
+@pytest.mark.asyncio
+async def test_write_control_maps_wire_values():
+    driver = _driver({})
+    assert await driver.write_control("force_mode", 1)
+    assert await driver.write_control("rs485_control_mode", 21947)
+    assert await driver.write_control("max_charge_power", 2000)
+    assert not await driver.write_control("nonexistent_key", 1)
+    calls = _calls(driver)
+    assert calls[0] == ("select", "select_option", {"entity_id": _ENTITIES["force_mode"], "option": "charge"})
+    assert calls[1] == ("select", "select_option", {"entity_id": _ENTITIES["rs485_control_mode"], "option": "disable"})
+    assert calls[2] == ("number", "set_value", {"entity_id": _ENTITIES["max_charge_power"], "value": 2000})
+
+
+@pytest.mark.asyncio
+async def test_net_power_from_data():
+    driver = _driver({})
+    assert driver.net_power_from_data({"force_mode": 1, "set_charge_power": 700, "set_discharge_power": 0}) == 700
+    assert driver.net_power_from_data({"force_mode": 2, "set_charge_power": 0, "set_discharge_power": 400}) == -400
+    assert driver.net_power_from_data({"force_mode": 0, "set_charge_power": 0, "set_discharge_power": 0}) == 0
+    assert driver.net_power_from_data({}) is None
+
+
+@pytest.mark.asyncio
+async def test_concrete_config_methods():
+    driver = _driver({_ENTITIES["rs485_control_mode"]: "enable"})
+    assert await driver.apply_config(
+        max_soc_pct=95, min_soc_pct=15, max_charge_power_w=2000, max_discharge_power_w=1800
+    )
+    assert await driver.set_rs485_control(True)
+    assert await driver.get_rs485_control() is True
+    assert await driver.standby()
+    calls = _calls(driver)
+    assert calls[0][2] == {"entity_id": _ENTITIES["charging_cutoff_capacity"], "value": 95}
+    assert calls[1][2] == {"entity_id": _ENTITIES["discharging_cutoff_capacity"], "value": 15}
+    assert calls[4][2] == {"entity_id": _ENTITIES["rs485_control_mode"], "option": "enable"}
+
+
+# ---------------------------------------------------------------------------
+# Definitions / capabilities sanity
+# ---------------------------------------------------------------------------
+
+def test_definitions_have_no_register_and_scale_one():
+    for d in SENSOR_DEFINITIONS + NUMBER_DEFINITIONS + SELECT_DEFINITIONS + SWITCH_DEFINITIONS:
+        assert "register" not in d
+        assert d.get("scale", 1) == 1  # HA states are already final values
+
+
+def test_capabilities_force_mode_keeps_hardware_manual_path():
+    driver = _driver({})
+    assert driver.capabilities.has_force_mode
+    # force_mode select + set_charge_power number exist → the coordinator's
+    # needs_software_manual_control stays False (Marstek-style manual entities).
+    assert any(d["key"] == "force_mode" for d in driver.select_definitions)
+    assert any(d["key"] == "set_charge_power" for d in driver.number_definitions)
+    assert driver.capabilities.has_energy_counters
+    assert not driver.capabilities.has_alarm_registers


### PR DESCRIPTION
Supports the marstek-lilygo-rs485 firmware (whyisthisbroken): the ESP32 owns the battery's RS485 port and exposes the decoded v2 registers as ESPHome entities, so the driver reads hass.states and writes select/number services instead of Modbus. Reuses the Marstek logical keys verbatim (force_mode + set_charge/discharge_power, cutoffs, rs485_control_mode) so the existing entity, manual-mode and PD machinery work unchanged.

- drivers/esphome.py: EsphomeEntityDriver + entity-name mapping table, resolved from the registry by slugified original_name (survives renames)
- config flow: new "esphome" brand with device picker + required-entity validation, in initial, options and reconfigure flows
- coordinator: brand wiring; host carries the ESPHome device id (identity)
- translations for the new flow steps in all 6 languages
- tests/test_esphome_driver.py (13 tests)