### PR TITLE
fix: predictive charging toggle disappears when disabled (#68)

### DIFF
--- a/custom_components/omnibattery/switch.py
+++ b/custom_components/omnibattery/switch.py
@@ -424,6 +424,7 @@ class PredictiveChargingSwitch(SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Enable predictive charging (set enabled, clear override)."""
+        was_enabled = self.controller.predictive_charging_enabled
         self.controller.predictive_charging_enabled = True
         self.controller.predictive_charging_overridden = False
         new_data = dict(self.entry.data)
@@ -436,10 +437,11 @@ class PredictiveChargingSwitch(SwitchEntity):
             {"notification_id": f"{NOTIFICATION_ID_PREFIX}predictive_charging_override"},
         )
         _LOGGER.info("Predictive charging enabled")
-        self.async_write_ha_state()
+        await self._apply_enabled_change(was_enabled, now_enabled=True)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Disable predictive charging (clear enabled, set override)."""
+        was_enabled = self.controller.predictive_charging_enabled
         self.controller.predictive_charging_enabled = False
         self.controller.predictive_charging_overridden = True
         new_data = dict(self.entry.data)
@@ -460,7 +462,21 @@ class PredictiveChargingSwitch(SwitchEntity):
             },
         )
         _LOGGER.info("Predictive charging disabled (overridden)")
-        self.async_write_ha_state()
+        await self._apply_enabled_change(was_enabled, now_enabled=False)
+
+    async def _apply_enabled_change(self, was_enabled: bool, *, now_enabled: bool) -> None:
+        """Finish a toggle. When the ``enabled`` value flips, reload the entry so
+        the setup-time gating re-evaluates: the daily consumption-capture and
+        dynamic-pricing schedules and the predictive status sensor are all armed
+        (or torn down) only in ``async_setup_entry`` against this value, and the
+        entry-update listener does not reload. This mirrors the options flow,
+        which reloads on the same change. When only the runtime override moved
+        (a legacy paused entry resuming with ``enabled`` already True), a plain
+        state write suffices and avoids a needless reload."""
+        if was_enabled != now_enabled:
+            await self.hass.config_entries.async_reload(self.entry.entry_id)
+        else:
+            self.async_write_ha_state()
 
     @property
     def device_info(self):

--- a/custom_components/omnibattery/switch.py
+++ b/custom_components/omnibattery/switch.py
@@ -65,8 +65,15 @@ async def async_setup_entry(
         entities.append(ManualModeSwitch(hass, entry, controller))
         entities.append(NoPdModeSwitch(hass, entry, controller))
 
-    # Add predictive charging switch (system-level, not per-battery)
-    if controller and controller.predictive_charging_enabled:
+    # Add predictive charging switch (system-level, not per-battery). Shown
+    # whenever predictive charging has been through config (the key is always
+    # written, True or False), not only when currently enabled, so the enable
+    # toggle behaves like the other feature blocks (charge delay, capacity
+    # protection): always visible on the dashboard, hiding its sibling sliders
+    # via the panel gate when OFF. Gating it on the enabled *value* previously
+    # made the switch vanish while the sliders (keyed on presence) stayed,
+    # leaving orphaned settings with no toggle (#68).
+    if controller and CONF_ENABLE_PREDICTIVE_CHARGING in entry.data:
         entities.append(PredictiveChargingSwitch(hass, entry, controller))
 
     # Add capacity protection switch (system-level, when configured, regardless of enabled state)
@@ -379,10 +386,19 @@ class BatteryActiveBalanceModeSwitch(SwitchEntity):
 
 
 class PredictiveChargingSwitch(SwitchEntity):
-    """Switch to enable/disable predictive grid charging.
+    """Switch to enable/disable predictive grid charging at runtime.
 
-    ON = predictive charging enabled (default when configured).
-    OFF = predictive charging paused (overridden).
+    Mirrors the other feature toggles (charge delay, capacity protection): always
+    visible once predictive charging is configured, drives the ``enable`` flag,
+    and the panel hides the sibling sliders when OFF.
+
+    ON  = predictive charging enabled and running.
+    OFF = predictive charging disabled/paused.
+
+    The two persisted booleans (``enabled`` = configured on, ``overridden`` =
+    runtime pause) are moved together so the switch stays consistent with every
+    consumer, whichever flag it reads (the pricing engine checks ``overridden``,
+    the time-slot path checks ``enabled``).
     """
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry, controller) -> None:
@@ -400,13 +416,18 @@ class PredictiveChargingSwitch(SwitchEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return True if predictive charging is enabled (not overridden)."""
-        return not self.controller.predictive_charging_overridden
+        """Return True when predictive charging is enabled and not paused."""
+        return (
+            self.controller.predictive_charging_enabled
+            and not self.controller.predictive_charging_overridden
+        )
 
     async def async_turn_on(self, **kwargs) -> None:
-        """Enable predictive charging (remove override)."""
+        """Enable predictive charging (set enabled, clear override)."""
+        self.controller.predictive_charging_enabled = True
         self.controller.predictive_charging_overridden = False
         new_data = dict(self.entry.data)
+        new_data[CONF_ENABLE_PREDICTIVE_CHARGING] = True
         new_data[CONF_PREDICTIVE_CHARGING_OVERRIDDEN] = False
         self.hass.config_entries.async_update_entry(self.entry, data=new_data)
         await self.hass.services.async_call(
@@ -418,9 +439,11 @@ class PredictiveChargingSwitch(SwitchEntity):
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
-        """Disable predictive charging (activate override)."""
+        """Disable predictive charging (clear enabled, set override)."""
+        self.controller.predictive_charging_enabled = False
         self.controller.predictive_charging_overridden = True
         new_data = dict(self.entry.data)
+        new_data[CONF_ENABLE_PREDICTIVE_CHARGING] = False
         new_data[CONF_PREDICTIVE_CHARGING_OVERRIDDEN] = True
         self.hass.config_entries.async_update_entry(self.entry, data=new_data)
         if self.controller.grid_charging_active:

--- a/tests/test_predictive_switch.py
+++ b/tests/test_predictive_switch.py
@@ -2,11 +2,13 @@
 
 The switch is the dashboard enable toggle for predictive grid charging. It must:
   * be created whenever predictive charging is configured, not only while
-    currently enabled (otherwise the sliders show with no toggle), and
+    currently enabled (otherwise the sliders show with no toggle),
   * move the ``enabled`` and ``overridden`` flags together so every consumer
-    stays consistent regardless of which flag it reads.
+    stays consistent regardless of which flag it reads, and
+  * reload the entry when the ``enabled`` value flips, so the setup-time gating
+    (consumption-capture / dynamic-pricing schedules, status sensor) re-arms.
 
-Exercised without the full Home Assistant runtime: the entity is built on stub
+Exercised without the full Home Assistant runtime: entities are built on stub
 hass/entry/controller objects and ``async_write_ha_state`` is neutralised.
 """
 from __future__ import annotations
@@ -17,8 +19,12 @@ from types import SimpleNamespace
 from custom_components.omnibattery.const import (
     CONF_ENABLE_PREDICTIVE_CHARGING,
     CONF_PREDICTIVE_CHARGING_OVERRIDDEN,
+    DOMAIN,
 )
-from custom_components.omnibattery.switch import PredictiveChargingSwitch
+from custom_components.omnibattery.switch import (
+    PredictiveChargingSwitch,
+    async_setup_entry,
+)
 
 
 def _make_switch(*, enabled, overridden, entry_data=None):
@@ -27,21 +33,28 @@ def _make_switch(*, enabled, overridden, entry_data=None):
         predictive_charging_overridden=overridden,
         grid_charging_active=False,
     )
-    entry = SimpleNamespace(data=dict(entry_data or {}))
+    entry = SimpleNamespace(entry_id="test-entry", data=dict(entry_data or {}))
+    reloads: list[str] = []
 
     async def _async_call(*_a, **_k):
         return None
+
+    async def _async_reload(entry_id):
+        reloads.append(entry_id)
 
     def _update_entry(target, *, data):
         target.data = data
 
     hass = SimpleNamespace(
-        config_entries=SimpleNamespace(async_update_entry=_update_entry),
+        config_entries=SimpleNamespace(
+            async_update_entry=_update_entry,
+            async_reload=_async_reload,
+        ),
         services=SimpleNamespace(async_call=_async_call),
     )
     sw = PredictiveChargingSwitch(hass, entry, controller)
     sw.async_write_ha_state = lambda: None  # not registered with HA
-    return sw, controller, entry
+    return sw, controller, entry, reloads
 
 
 def test_is_on_requires_enabled_and_not_overridden():
@@ -53,29 +66,69 @@ def test_is_on_requires_enabled_and_not_overridden():
     assert _make_switch(enabled=False, overridden=False)[0].is_on is False
 
 
-def test_turn_on_enables_and_clears_override():
-    sw, controller, entry = _make_switch(enabled=False, overridden=True)
+def test_turn_on_from_disabled_enables_and_reloads():
+    sw, controller, entry, reloads = _make_switch(enabled=False, overridden=True)
     asyncio.run(sw.async_turn_on())
     assert controller.predictive_charging_enabled is True
     assert controller.predictive_charging_overridden is False
     assert entry.data[CONF_ENABLE_PREDICTIVE_CHARGING] is True
     assert entry.data[CONF_PREDICTIVE_CHARGING_OVERRIDDEN] is False
-    assert sw.is_on is True
+    # Enabling flips the value → the entry reloads so the setup-time schedules and
+    # status sensor re-arm.
+    assert reloads == ["test-entry"]
 
 
-def test_turn_off_disables_and_sets_override():
-    sw, controller, entry = _make_switch(enabled=True, overridden=False)
+def test_turn_off_from_enabled_disables_and_reloads():
+    sw, controller, entry, reloads = _make_switch(enabled=True, overridden=False)
     asyncio.run(sw.async_turn_off())
     assert controller.predictive_charging_enabled is False
     assert controller.predictive_charging_overridden is True
     assert entry.data[CONF_ENABLE_PREDICTIVE_CHARGING] is False
     assert entry.data[CONF_PREDICTIVE_CHARGING_OVERRIDDEN] is True
-    assert sw.is_on is False
+    assert reloads == ["test-entry"]
+
+
+def test_resume_from_legacy_pause_does_not_reload():
+    # Legacy paused entry: enabled stayed True, only overridden was set. Turning
+    # the switch back on clears the override without flipping enabled, so no
+    # reload is needed (the schedules were already armed at setup).
+    sw, controller, entry, reloads = _make_switch(enabled=True, overridden=True)
+    asyncio.run(sw.async_turn_on())
+    assert controller.predictive_charging_overridden is False
+    assert reloads == []
 
 
 def test_toggle_preserves_other_entry_data():
-    sw, _controller, entry = _make_switch(
+    sw, _controller, entry, _reloads = _make_switch(
         enabled=True, overridden=False, entry_data={"unrelated": 42}
     )
     asyncio.run(sw.async_turn_off())
     assert entry.data["unrelated"] == 42
+
+
+def test_switch_created_when_configured_but_disabled():
+    """#68: the enable toggle must be built even when predictive charging is
+    currently disabled, as long as it has been through config (key present)."""
+    controller = SimpleNamespace(weekly_full_charge_enabled=False)
+    entry = SimpleNamespace(
+        entry_id="test-entry",
+        data={CONF_ENABLE_PREDICTIVE_CHARGING: False},
+    )
+    hass = SimpleNamespace(
+        data={DOMAIN: {"test-entry": {"coordinators": [], "controller": controller}}}
+    )
+    added: list = []
+    asyncio.run(async_setup_entry(hass, entry, lambda ents: added.extend(ents)))
+    assert any(isinstance(e, PredictiveChargingSwitch) for e in added)
+
+
+def test_switch_absent_when_never_configured():
+    """No predictive config key at all (legacy/undeclared) → no switch."""
+    controller = SimpleNamespace(weekly_full_charge_enabled=False)
+    entry = SimpleNamespace(entry_id="test-entry", data={})
+    hass = SimpleNamespace(
+        data={DOMAIN: {"test-entry": {"coordinators": [], "controller": controller}}}
+    )
+    added: list = []
+    asyncio.run(async_setup_entry(hass, entry, lambda ents: added.extend(ents)))
+    assert not any(isinstance(e, PredictiveChargingSwitch) for e in added)

--- a/tests/test_predictive_switch.py
+++ b/tests/test_predictive_switch.py
@@ -1,0 +1,81 @@
+"""Unit tests for ``PredictiveChargingSwitch`` (#68).
+
+The switch is the dashboard enable toggle for predictive grid charging. It must:
+  * be created whenever predictive charging is configured, not only while
+    currently enabled (otherwise the sliders show with no toggle), and
+  * move the ``enabled`` and ``overridden`` flags together so every consumer
+    stays consistent regardless of which flag it reads.
+
+Exercised without the full Home Assistant runtime: the entity is built on stub
+hass/entry/controller objects and ``async_write_ha_state`` is neutralised.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from custom_components.omnibattery.const import (
+    CONF_ENABLE_PREDICTIVE_CHARGING,
+    CONF_PREDICTIVE_CHARGING_OVERRIDDEN,
+)
+from custom_components.omnibattery.switch import PredictiveChargingSwitch
+
+
+def _make_switch(*, enabled, overridden, entry_data=None):
+    controller = SimpleNamespace(
+        predictive_charging_enabled=enabled,
+        predictive_charging_overridden=overridden,
+        grid_charging_active=False,
+    )
+    entry = SimpleNamespace(data=dict(entry_data or {}))
+
+    async def _async_call(*_a, **_k):
+        return None
+
+    def _update_entry(target, *, data):
+        target.data = data
+
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_update_entry=_update_entry),
+        services=SimpleNamespace(async_call=_async_call),
+    )
+    sw = PredictiveChargingSwitch(hass, entry, controller)
+    sw.async_write_ha_state = lambda: None  # not registered with HA
+    return sw, controller, entry
+
+
+def test_is_on_requires_enabled_and_not_overridden():
+    assert _make_switch(enabled=True, overridden=False)[0].is_on is True
+    # Enabled but paused (legacy override state) reads OFF, matching the pricing
+    # engine which pauses on ``overridden``.
+    assert _make_switch(enabled=True, overridden=True)[0].is_on is False
+    # Configured-but-disabled (issue #68 reporter's state) reads OFF.
+    assert _make_switch(enabled=False, overridden=False)[0].is_on is False
+
+
+def test_turn_on_enables_and_clears_override():
+    sw, controller, entry = _make_switch(enabled=False, overridden=True)
+    asyncio.run(sw.async_turn_on())
+    assert controller.predictive_charging_enabled is True
+    assert controller.predictive_charging_overridden is False
+    assert entry.data[CONF_ENABLE_PREDICTIVE_CHARGING] is True
+    assert entry.data[CONF_PREDICTIVE_CHARGING_OVERRIDDEN] is False
+    assert sw.is_on is True
+
+
+def test_turn_off_disables_and_sets_override():
+    sw, controller, entry = _make_switch(enabled=True, overridden=False)
+    asyncio.run(sw.async_turn_off())
+    assert controller.predictive_charging_enabled is False
+    assert controller.predictive_charging_overridden is True
+    assert entry.data[CONF_ENABLE_PREDICTIVE_CHARGING] is False
+    assert entry.data[CONF_PREDICTIVE_CHARGING_OVERRIDDEN] is True
+    assert sw.is_on is False
+
+
+def test_toggle_preserves_other_entry_data():
+    sw, _controller, entry = _make_switch(
+        enabled=True, overridden=False, entry_data={"unrelated": 42}
+    )
+    asyncio.run(sw.async_turn_off())
+    assert entry.data["unrelated"] == 42


### PR DESCRIPTION
## What's wrong

On the Controls tab the predictive charging enable switch disappears when the feature is off, but its settings sliders stay visible. Settings with no toggle to control them.

## Why

The switch was only created when `predictive_charging_enabled` was true. The sliders and min-SOC-floor switch key off config-presence instead, and the config flow always writes `enable_predictive_charging` (True or False). So the sliders are always there while the switch drops out when disabled. The panel only hides slider rows when the gate switch exists, so with no switch nothing gets hidden.

## The fix

Create the switch whenever predictive charging has been configured (key present), the same rule charge delay and capacity protection use. The switch drives `enabled` and moves `enabled` and `overridden` together so they don't drift (pricing engine checks `overridden`, time-slot path checks `enabled`).

The catch: consumption-capture and dynamic-pricing schedules and the status sensor are wired up only in `async_setup_entry` off `predictive_charging_enabled`, and the update listener doesn't reload. So flipping the switch on at runtime left predictive half-wired until a manual reload. The switch now reloads the entry when `enabled` flips (what the options flow already does), and skips the reload when only the pause moved.

## Behavior change

Off now disables the feature, not just pauses it. It stays disabled across a restart.

## Tests

`tests/test_predictive_switch.py`: is_on truth table, flag movement, reload-on-flip, no-reload-on-resume, and platform checks that the switch exists when configured-but-disabled and is absent when never configured. 109 pass across predictive, pricing, charge-delay, min-soc, entity-naming suites.

Fixes #68.
