### PR TITLE
revert: remove v3 RS485 keep-alive write (didn't fix the 0 W dips)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## [1.0.0b6] - 2026-07-04
 
-### Fixed
-- **Attempted fix for steady-state 0 W dips every ~2-3 min on some v3 firmwares**: those firmwares appear to drop out of RS485 forced mode when no Modbus command arrives for ~2 minutes, and the bus-load skip could hold a steady setpoint for minutes without a single write — the battery fell to 0 W until the delivery check re-wrote it. Active setpoints are now refreshed with a real write at least every 60 s (keep-alive). Not yet confirmed on affected hardware; please report back if the dips persist. [`__init__.py`](custom_components/omnibattery/__init__.py).
-
 ### Added
 - **LilyGo RS485 / ESPHome driver**: support for Marstek batteries bridged by the [marstek-lilygo-rs485](https://github.com/whyisthisbroken/marstek-lilygo-rs485) firmware — telemetry and control go through the ESPHome device's HA entities (the battery's RS485 port is occupied by the ESP32). New brand in the config flow; same register semantics as the direct Modbus driver. [`drivers/esphome.py`](custom_components/omnibattery/drivers/esphome.py).
 

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -133,7 +133,6 @@ from .const import (
     NORMAL_BALANCE_RECAL_INVERTER_STANDBY,
     BMS_DISCHARGE_CUTOFF_SOC,
     PD_READBACK_EVERY_N_WRITES,
-    PD_WRITE_KEEPALIVE_S,
     FAST_ACTUATOR_MAX_LATENCY_S,
     DISCHARGE_ENGAGE_GRACE_S,
     IDLE_RUNAWAY_POWER_W,
@@ -3294,25 +3293,6 @@ class ChargeDischargeController:
                     await self._check_non_delivery(
                         coordinator, abs(net_power), float(batt_power), attempt=0,
                     )
-            # Keep-alive: some v3 firmwares drop out of RS485 forced mode when
-            # no Modbus command arrives for ~2 minutes, so an active setpoint
-            # held entirely by skips starves that watchdog — the battery falls
-            # to 0 W until the delivery check forces a re-write. Refresh with a
-            # real write once per PD_WRITE_KEEPALIVE_S even when in-state.
-            if skip_write and net_power != 0:
-                last_write_ts = getattr(coordinator, "_pd_last_write_ts", None)
-                if last_write_ts is None:
-                    # First in-state cycle (e.g. after restart): start the countdown.
-                    coordinator._pd_last_write_ts = dt_util.utcnow()
-                elif (
-                    dt_util.utcnow() - last_write_ts
-                ).total_seconds() >= PD_WRITE_KEEPALIVE_S:
-                    skip_write = False
-                    _LOGGER.debug(
-                        "[%s] Keep-alive write - refreshing setpoint held by "
-                        "skips for %ds",
-                        coordinator.name, PD_WRITE_KEEPALIVE_S,
-                    )
             if skip_write:
                 _LOGGER.debug(
                     "[%s] Power write skipped - already at force=%d charge=%dW "
@@ -3340,7 +3320,6 @@ class ChargeDischargeController:
         # stalled registerless battery is still excluded from the pool.
         write_count = getattr(coordinator, "_pd_write_count", 0)
         coordinator._pd_write_count = write_count + 1
-        coordinator._pd_last_write_ts = dt_util.utcnow()
         read_back = (
             (write_count % PD_READBACK_EVERY_N_WRITES) == 0
             and coordinator.capabilities.actuator_latency_s <= FAST_ACTUATOR_MAX_LATENCY_S

--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -222,13 +222,6 @@ BMS_DISCHARGE_CUTOFF_SOC = 20                  # %: below this, refused discharg
 # delivering are caught up to N writes later instead of immediately.
 PD_READBACK_EVERY_N_WRITES = 5
 
-# Keep-alive for the skip-if-unchanged guard: some v3 firmwares drop out of
-# RS485 forced mode when no Modbus command arrives for ~2 minutes, so a steady
-# setpoint held entirely by skips starves that watchdog and the battery falls
-# to 0 W until the delivery check forces a re-write (a metronomic dip every
-# ~2-3 min). Refresh an active setpoint with a real write at least this often.
-PD_WRITE_KEEPALIVE_S = 60
-
 # Transient burst poll: right after a REAL power command change, the delivered-
 # power reading (ac_power / battery_power) is polled at this cadence instead of
 # its normal "high" scan interval, so _measured_battery_power() isn't stale

--- a/tests/test_set_battery_power_skip.py
+++ b/tests/test_set_battery_power_skip.py
@@ -24,7 +24,6 @@ from custom_components.omnibattery import ChargeDischargeController
 from custom_components.omnibattery.const import (
     IDLE_RUNAWAY_GRACE_S,
     PD_READBACK_EVERY_N_WRITES,
-    PD_WRITE_KEEPALIVE_S,
 )
 from custom_components.omnibattery.drivers import SetpointResult
 from tests.conftest import FakeCoordinator
@@ -296,45 +295,6 @@ async def test_no_record_during_discharge_engage_grace():
     assert result is True
     coord.apply_power.assert_called_once()
     record.assert_not_called()  # suppressed: inverter still within engage grace
-
-
-async def test_keepalive_rewrites_after_interval():
-    """In-state skips must not starve the v3 firmware's RS485 forced-mode
-    watchdog: once the last real write is older than PD_WRITE_KEEPALIVE_S, the
-    next in-state cycle falls through to a real refresh write."""
-    coord = _Coord({"force_mode": 1, "set_charge_power": 500, "set_discharge_power": 0})
-    coord.apply_power = AsyncMock(return_value=_ok(500))
-    ctrl = _controller()
-
-    # First in-state cycle arms the countdown and still skips.
-    await ChargeDischargeController._set_battery_power(ctrl, coord, 500, 0)
-    coord.apply_power.assert_not_called()
-
-    # Age the stamp past the keep-alive window -> next cycle writes for real.
-    coord._pd_last_write_ts = dt_util.utcnow() - timedelta(
-        seconds=PD_WRITE_KEEPALIVE_S + 1
-    )
-    await ChargeDischargeController._set_battery_power(ctrl, coord, 500, 0)
-    coord.apply_power.assert_called_once()
-
-    # The real write restamped the countdown -> skipping resumes.
-    await ChargeDischargeController._set_battery_power(ctrl, coord, 500, 0)
-    coord.apply_power.assert_called_once()
-
-
-async def test_no_keepalive_at_idle():
-    """Keep-alive only defends an *active* setpoint: a battery resting at idle
-    must stay write-free no matter how stale the last write is."""
-    coord = _Coord({"force_mode": 0, "set_charge_power": 0, "set_discharge_power": 0})
-    coord._pd_last_write_ts = dt_util.utcnow() - timedelta(
-        seconds=PD_WRITE_KEEPALIVE_S + 1
-    )
-    ctrl = _controller()
-
-    result = await ChargeDischargeController._set_battery_power(ctrl, coord, 0, 0)
-
-    assert result is True
-    coord.apply_power.assert_not_called()
 
 
 async def test_no_skip_when_setpoints_differ():


### PR DESCRIPTION
Rolls back 1406969. The 60s keep-alive against the skip-if-unchanged guard did not stop the steady-state 0 W dips on affected v3 firmwares, so it adds bus traffic for no benefit. Removes PD_WRITE_KEEPALIVE_S, the keep-alive block and _pd_last_write_ts restamp, the two keep-alive tests, and the CHANGELOG entry.