### PR TITLE
fix: skip zero-limit batteries in load-sharing selection (ZeroDivisio…

### DIFF
--- a/custom_components/omnibattery/control/power_distribution.py
+++ b/custom_components/omnibattery/control/power_distribution.py
@@ -218,8 +218,13 @@ class PowerDistribution:
         combined_capacity = 0
 
         for battery in sorted_batteries:
-            selected.append(battery)
             limit = self._controller._battery_power_limit(battery, is_charging)
+            if limit <= 0:
+                # Can't contribute in this direction (e.g. hardware
+                # max_charge/discharge_power register reads 0) — skipping also
+                # avoids a ZeroDivisionError below (issue: Venus D idle).
+                continue
+            selected.append(battery)
             combined_capacity += limit
             activation_threshold = max(
                 MULTI_BATTERY_MIN_ACTIVATION,
@@ -236,6 +241,8 @@ class PowerDistribution:
             for battery in previous_active:
                 if battery not in selected and battery in available_batteries:
                     limit = self._controller._battery_power_limit(battery, is_charging)
+                    if limit <= 0:
+                        continue
                     first_limit = (
                         self._controller._battery_power_limit(selected[0], is_charging)
                     ) if selected else limit

--- a/tests/test_power_distribution.py
+++ b/tests/test_power_distribution.py
@@ -215,6 +215,30 @@ def test_select_below_deactivation_drops_active_battery():
     assert c._controller._active_discharge_batteries == [a]
 
 
+def test_select_skips_zero_limit_battery_no_zerodivision():
+    # Venus D bug: hardware max_discharge_power register reads 0 -> crossover_w / 0
+    # crashed the whole control cycle. Zero-limit batteries must be skipped.
+    a, b, z = _coord("a", 2500, soc=90), _coord("b", 2500, soc=50), _coord("z", 0, soc=95)
+    c = _build([a, b, z])
+    # z sorts first (highest SOC) but can't contribute -> skipped, no crash.
+    selected = c._select_batteries_for_operation(4000, [a, b, z], is_charging=False)
+    assert set(selected) == {a, b}
+
+
+def test_select_all_zero_limits_returns_empty():
+    a, b = _coord("a", 0), _coord("b", 0)
+    c = _build([a, b])
+    assert c._select_batteries_for_operation(1000, [a, b], is_charging=False) == []
+
+
+def test_select_zero_limit_previous_active_not_readded():
+    # Case A hysteresis must not re-add (or divide by) a battery whose limit
+    # dropped to 0 while it was active.
+    a, z = _coord("a", 2500, soc=90), _coord("z", 0, soc=95)
+    c = _build([a, z], active_discharge=[a, z])
+    assert c._select_batteries_for_operation(1400, [a, z], is_charging=False) == [a]
+
+
 def test_select_wallclock_hold_retains_dropped_battery():
     a, b = _coord("a", 2500, soc=90), _coord("b", 2500, soc=50)
     c = _build([a, b], active_discharge=[a, b],


### PR DESCRIPTION
…nError)

Venus D units whose max_charge/discharge_power register reads 0 crashed the whole control cycle with crossover_w / 0 in
_select_batteries_for_operation, leaving every battery after them idle. Batteries with a non-positive limit cannot contribute in that direction, so the selector now skips them (main loop + deactivation hysteresis).