### PR TITLE
fix: block PD charge/discharge flips within actuator settle window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Feedforward on confirmed load steps (PD mode)**: a kettle/oven-sized load step is now covered in one deadbeat cycle (~5-7 s, actuator floor) instead of the ~13 s exponential approach of the incremental P term. Two-sample confirmation rejects meter spikes; a cooldown and an opposite-sign pulse guard keep pulsing loads (induction hobs) on the stable slow-PD averaging. [`__init__.py`](custom_components/omnibattery/__init__.py).
 
 ### Fixed
+- **Discharge dropped to 0 W for 5-40 s on downward load steps**: the transient grid export while the discharging battery ramped down made the incremental PD cross zero and emit a charge order on another battery, zeroing the discharger (ping-pong every 1-3 min). A charge↔discharge flip must now persist past the actuator settle window (~5 s) before it goes through; transients collapse back to discharge, sustained solar surplus still flips. [`__init__.py`](custom_components/omnibattery/__init__.py).
 - **Battery reporting a 0 W power limit crashed the control cycle**: a Venus D whose `max_discharge_power` register reads 0 hit a division by zero in the load-sharing selector, aborting the whole cycle and leaving batteries idle. Zero-limit batteries are now skipped. [`control/power_distribution.py`](custom_components/omnibattery/control/power_distribution.py).
 
 ## [1.0.0b6] - 2026-07-04

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -138,6 +138,7 @@ from .const import (
     FEEDFORWARD_CANDIDATE_MAX_AGE_S,
     FEEDFORWARD_COOLDOWN_S,
     FEEDFORWARD_PULSE_GUARD_S,
+    PD_ZERO_CROSS_MIN_HOLD_S,
     FAST_ACTUATOR_MAX_LATENCY_S,
     DISCHARGE_ENGAGE_GRACE_S,
     IDLE_RUNAWAY_POWER_W,
@@ -354,6 +355,10 @@ class ChargeDischargeController:
         # instant, so the relay doesn't click off as soon as demand falls.
         self._relay_cooldown_s = config_entry.data.get(CONF_PD_RELAY_COOLDOWN, DEFAULT_PD_RELAY_COOLDOWN)
         self._relay_shutoff_since = None
+        # Zero-cross hold (direction-flip dwell): stamped on the first cycle that
+        # requests the opposite charge/discharge direction; the flip is clamped to
+        # 0 until the request persists past the actuator settle window.
+        self._zero_cross_since = None
         # Event-driven cycle rate limit: drop grid-sensor triggers that arrive
         # closer together than this, so fast meters can't flood the Modbus bridge.
         # NOT raised to the slowest actuator's latency: a slow battery (Zendure HTTP)
@@ -4240,6 +4245,69 @@ class ChargeDischargeController:
         )
         return held_power
 
+    def _apply_zero_cross_hold(self, new_power, error):
+        """ZERO-CROSS HOLD (direction-flip dwell).
+
+        On a downward load step the discharging battery keeps delivering its old
+        setpoint for the actuator settle time (~3-6 s measured), so the grid shows
+        a transient export of hundreds of watts. The incremental PD (request =
+        previous + Kp*error...) crosses zero on that transient and, if charging is
+        allowed, emits a real charge command — assigned to another battery while
+        the assignment loop zeroes the discharger. Result: 0 W discharge with the
+        house importing, then the PD swings back — ping-pong every 1-3 min. The
+        direction hysteresis (magnitude-based, ~60 W) cannot stop a -500/-1500 W
+        transient, and the relay dwell only gates active->idle, not flips.
+
+        Gate: the first cycle that requests the OPPOSITE direction to
+        ``last_output_sign`` is clamped to 0 and arms ``_zero_cross_since``; the
+        flip only passes once the opposite-direction request has persisted for the
+        settle window. A transient export collapses back to the previous direction
+        within a couple of cycles and re-arms the timer; a legitimate sustained
+        surplus flips after the window (a few seconds' delay, harmless). Requests
+        of 0 or of the previous direction pass through untouched and re-arm.
+
+        Runs on every control path (PD, feedforward, no-PD) and BEFORE the
+        min-power floor, so a suppressed flip can never be bootstrapped up to
+        pd_min_charge_power; the relay dwell downstream then decides whether the
+        previous battery holds at minimum power or drops to 0.
+        """
+        requested_sign = 1 if new_power > 0 else (-1 if new_power < 0 else 0)
+        if (
+            self.last_output_sign == 0
+            or requested_sign == 0
+            or requested_sign == self.last_output_sign
+        ):
+            self._zero_cross_since = None
+            return new_power
+
+        # Window: at least the fixed floor, stretched for slow actuators (2x
+        # latency ~= command->ramp + telemetry grain; Zendure 3.0 s -> 6 s).
+        latency_s = max(
+            (c.capabilities.actuator_latency_s for c in self.coordinators),
+            default=0.0,
+        )
+        window_s = max(PD_ZERO_CROSS_MIN_HOLD_S, 2.0 * latency_s)
+
+        now = dt_util.utcnow()
+        if self._zero_cross_since is None:
+            self._zero_cross_since = now
+        held_s = (now - self._zero_cross_since).total_seconds()
+        if held_s >= window_s:
+            self._zero_cross_since = None
+            _LOGGER.info(
+                "PD zero-cross hold: %s request persisted %.1fs >= %.1fs, allowing direction flip (%.0fW)",
+                "charge" if requested_sign > 0 else "discharge",
+                held_s, window_s, new_power,
+            )
+            return new_power
+        _LOGGER.info(
+            "PD zero-cross hold: suppressing %s->%s flip (%.0fW, error=%.0fW) while actuator settles (%.1fs/%.1fs)",
+            "charge" if self.last_output_sign > 0 else "discharge",
+            "charge" if requested_sign > 0 else "discharge",
+            new_power, error, held_s, window_s,
+        )
+        return 0
+
     async def _run_control_cycle(self, now=None):
         """Update the charge/discharge power of the batteries."""
         if DEBUG_CONTROL_LOOP_DETAIL:
@@ -4499,6 +4567,10 @@ class ChargeDischargeController:
             # over one sample (a derivative kick). Drop the filtered derivative too.
             self.previous_error = sensor_actual - active_target
             self.derivative_filtered = 0.0
+            # Drop any armed zero-cross timer: reaching the deadband ends the flip
+            # streak, so a much later flip must start its own settle window instead
+            # of inheriting a stale timestamp that would let it pass instantly.
+            self._zero_cross_since = None
             # NOTE: Do NOT clear load sharing state here. Batteries keep executing
             # their last command during deadband, so the active battery lists must
             # remain accurate for the diagnostic sensor.
@@ -4680,6 +4752,12 @@ class ChargeDischargeController:
             new_power = self._compute_pd_new_power(
                 error, sensor_elapsed_s, stale_safety_recalc
             )
+        # ZERO-CROSS HOLD: a charge<->discharge flip must survive the actuator
+        # settle window before it becomes a real opposite-direction command (see
+        # _apply_zero_cross_hold). Must run before _apply_min_power so a clamped
+        # flip cannot be raised to the minimum charge power.
+        new_power = self._apply_zero_cross_hold(new_power, error)
+
         # Final commanded direction (feeds last_output_sign at end of cycle). In the
         # PD path the hysteresis inside _compute_pd_new_power already zeroed new_power
         # for a suppressed direction change, so recomputing from new_power matches.

--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -244,6 +244,16 @@ FEEDFORWARD_CANDIDATE_MAX_AGE_S = 5.0 # s: candidate expires if not checked in t
 FEEDFORWARD_COOLDOWN_S = 10.0         # s: min spacing between fires (covers actuator ramp 3-6s)
 FEEDFORWARD_PULSE_GUARD_S = 30.0      # s: opposite-sign step this soon after a fire = pulsing load, skip
 
+# Zero-cross hold (direction-flip dwell): minimum seconds an opposite-direction
+# (charge<->discharge) request must persist before the PD is allowed to flip.
+# During a downward load step the grid shows a transient export while the
+# discharging battery is still ramping down (actuator settle 3-6 s measured), so
+# the incremental PD crosses zero and would command a real charge on another
+# battery, zeroing the discharger (5-40 s dips, ping-pong every 1-3 min). The
+# effective window is max(this, 2 * slowest actuator_latency_s) — see
+# _apply_zero_cross_hold. Legitimate sustained surplus flips after the window.
+PD_ZERO_CROSS_MIN_HOLD_S = 5.0
+
 # An actuator at or below this latency (seconds, DriverCapabilities.actuator_latency_s)
 # reaches its setpoint and reflects it in telemetry within one poll. Such drivers do
 # the hot-path readback and use the measured-power feedforward; slower ones (Zendure

--- a/tests/test_pd_zero_cross.py
+++ b/tests/test_pd_zero_cross.py
@@ -1,0 +1,152 @@
+"""Tests for ``_apply_zero_cross_hold`` — the charge<->discharge flip dwell.
+
+Diagnosed 2026-07-13: on a downward load step the discharging battery keeps
+delivering its old setpoint for the actuator settle time (~3-6 s), so the grid
+shows a transient export of hundreds of watts. The incremental PD crosses zero
+on that transient and emits a real charge command (min-power floored to ~200 W)
+on another battery while the assignment loop zeroes the discharger — 0 W
+discharge dips of 5-40 s and ping-pong every 1-3 min. The direction hysteresis
+(magnitude-based, 60 W) cannot stop a -500/-1500 W transient and the relay
+dwell only gates active->idle, not direction flips.
+
+The hold clamps the FIRST opposite-direction request to 0 and arms a timer; the
+flip only passes once the request has persisted past the settle window, so a
+transient export never becomes a charge order but sustained solar surplus still
+flips (a few seconds late).
+
+The method is exercised unbound with a ``SimpleNamespace`` stub, matching
+``test_relay_dwell.py``. Timestamps are shifted backwards instead of sleeping.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.omnibattery import ChargeDischargeController
+from custom_components.omnibattery.const import PD_ZERO_CROSS_MIN_HOLD_S
+
+
+def _coord(latency_s=0.8):
+    return SimpleNamespace(capabilities=SimpleNamespace(actuator_latency_s=latency_s))
+
+
+def _ctrl(
+    last_output_sign,
+    *,
+    zero_cross_since=None,
+    latencies=(0.8,),
+):
+    return SimpleNamespace(
+        last_output_sign=last_output_sign,
+        _zero_cross_since=zero_cross_since,
+        coordinators=[_coord(lat) for lat in latencies],
+    )
+
+
+def _hold(ctrl, new_power, error=0.0):
+    return ChargeDischargeController._apply_zero_cross_hold(ctrl, new_power, error)
+
+
+def test_first_flip_request_clamped_to_zero():
+    # Discharging (sign -1), transient export makes the PD request +250W charge.
+    # The flip is clamped to 0 (no charge order) and the settle timer is armed.
+    ctrl = _ctrl(last_output_sign=-1)
+    out = _hold(ctrl, new_power=250, error=-800)
+    assert out == 0
+    assert ctrl._zero_cross_since is not None
+
+
+def test_flip_still_clamped_within_window():
+    since = dt_util.utcnow() - timedelta(seconds=2)
+    ctrl = _ctrl(last_output_sign=-1, zero_cross_since=since)
+    out = _hold(ctrl, new_power=400, error=-900)
+    assert out == 0
+    assert ctrl._zero_cross_since == since
+
+
+def test_sustained_flip_allowed_after_window():
+    # Real sustained surplus: the charge request persisted past the window,
+    # so the flip goes through and the timer re-arms for next time.
+    since = dt_util.utcnow() - timedelta(seconds=PD_ZERO_CROSS_MIN_HOLD_S + 1)
+    ctrl = _ctrl(last_output_sign=-1, zero_cross_since=since)
+    out = _hold(ctrl, new_power=400, error=-900)
+    assert out == 400
+    assert ctrl._zero_cross_since is None
+
+
+def test_return_to_previous_direction_resets_timer():
+    # Import came back within the window: discharge resumes untouched and the
+    # streak timer clears — the next transient starts its own window.
+    ctrl = _ctrl(last_output_sign=-1, zero_cross_since=dt_util.utcnow())
+    out = _hold(ctrl, new_power=-300, error=400)
+    assert out == -300
+    assert ctrl._zero_cross_since is None
+
+
+def test_zero_request_resets_timer():
+    ctrl = _ctrl(last_output_sign=-1, zero_cross_since=dt_util.utcnow())
+    out = _hold(ctrl, new_power=0, error=10)
+    assert out == 0
+    assert ctrl._zero_cross_since is None
+
+
+def test_idle_to_active_not_gated():
+    # No previous direction (sign 0): engaging from idle is not a flip.
+    ctrl = _ctrl(last_output_sign=0)
+    out = _hold(ctrl, new_power=250, error=-300)
+    assert out == 250
+    assert ctrl._zero_cross_since is None
+
+
+def test_charge_to_discharge_flip_also_gated():
+    ctrl = _ctrl(last_output_sign=1)
+    out = _hold(ctrl, new_power=-350, error=500)
+    assert out == 0
+    assert ctrl._zero_cross_since is not None
+
+
+def test_window_stretches_for_slow_actuators():
+    # Zendure/ESPHome fleet (latency 4.0s): window = 2*4 = 8s, so a request
+    # 6s old is still clamped; the same age passes on a fast Marstek fleet.
+    since = dt_util.utcnow() - timedelta(seconds=6)
+    slow = _ctrl(last_output_sign=-1, zero_cross_since=since, latencies=(0.8, 4.0))
+    assert _hold(slow, new_power=400, error=-900) == 0
+    fast = _ctrl(last_output_sign=-1, zero_cross_since=since, latencies=(0.8,))
+    assert _hold(fast, new_power=400, error=-900) == 400
+
+
+def test_transient_export_never_emits_charge_order():
+    """Diagnosed scenario end to end through the _run_control_cycle chain.
+
+    Steady 300W discharge; an induction hob pulse drops the load and the grid
+    exports for 3 cycles while the actuator ramps down. Chain the helpers in
+    the same order as _run_control_cycle (zero-cross -> min power -> relay
+    dwell) and assert the final command is NEVER positive: no charge order,
+    so the assignment loop never selects another battery for charging.
+    """
+    ctrl = SimpleNamespace(
+        last_output_sign=-1,
+        _zero_cross_since=None,
+        coordinators=[_coord()],
+        # _apply_min_power / _apply_relay_dwell fields
+        min_charge_power=200,
+        min_discharge_power=50,
+        deadband=40,
+        previous_power=-300,
+        _relay_cooldown_s=30,
+        _relay_shutoff_since=None,
+    )
+    # 3 cycles of transient export: PD requests a charge flip each time.
+    for requested, error in ((250, -800), (400, -1200), (150, -500)):
+        power = ChargeDischargeController._apply_zero_cross_hold(ctrl, requested, error)
+        power = ChargeDischargeController._apply_min_power(ctrl, power, error)
+        power = ChargeDischargeController._apply_relay_dwell(ctrl, power, error)
+        assert power <= 0, f"charge order {power}W emitted during transient"
+        ctrl.previous_power = power
+
+    # Import returns: discharge resumes immediately, no window applies.
+    power = ChargeDischargeController._apply_zero_cross_hold(ctrl, -350, 400)
+    assert power == -350
+    assert ctrl._zero_cross_since is None


### PR DESCRIPTION
On a downward load step the discharging battery keeps delivering its old setpoint for the actuator settle time (~3-6s), so the grid shows a transient export of hundreds of watts. The incremental PD crosses zero on that transient and, when charging is allowed, emits a real charge command (min-power floored to ~200W) assigned to another battery while the assignment loop zeroes the discharger: 0W discharge dips of 5-40s with the house importing, then the PD swings back - ping-pong every 1-3 min. The magnitude-based direction hysteresis (60W) cannot stop a -500/-1500W transient and the relay dwell only gates active->idle, not flips.

New zero-cross hold (direction-flip dwell): the first cycle requesting the opposite direction is clamped to 0 and arms a timer; the flip only passes once the opposite request has persisted past the settle window (max(5s, 2x slowest actuator_latency_s)). Runs on all control paths (PD, feedforward, no-PD) before the min-power floor so a suppressed flip can never be bootstrapped up to pd_min_charge_power. The timer clears on any same-direction/zero request and on the deadband return, so a later flip cannot inherit a stale timestamp. Legitimate sustained surplus still flips after the window (a few seconds' delay).