### PR TITLE
fix: tolerate ramping set-point echo in power ACK (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - **Discharge dropped to 0 W for 5-40 s on downward load steps**: the transient grid export while the discharging battery ramped down made the incremental PD cross zero and emit a charge order on another battery, zeroing the discharger (ping-pong every 1-3 min). A charge↔discharge flip must now persist past the actuator settle window (~5 s) before it goes through; transients collapse back to discharge, sustained solar surplus still flips. [`__init__.py`](custom_components/omnibattery/__init__.py).
 - **Battery reporting a 0 W power limit crashed the control cycle**: a Venus D whose `max_discharge_power` register reads 0 hit a division by zero in the load-sharing selector, aborting the whole cycle and leaving batteries idle. Zero-limit batteries are now skipped. [`control/power_distribution.py`](custom_components/omnibattery/control/power_distribution.py).
+- **False `ack_mismatch` errors and 5-min pool exclusions on delivering batteries** (#77): the post-write set-point echo is now accepted within a tolerance (10%, 100 W floor; `force_mode` stays exact) instead of requiring exact equality 0.2 s after the write. Exact settled verification is deferred to the poll comparison; a persistent tolerance-only streak logs a warning pointing at the RS485 bridge serial config. [`drivers/marstek.py`](custom_components/omnibattery/drivers/marstek.py).
 
 ## [1.0.0b6] - 2026-07-04
 

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -133,6 +133,7 @@ from .const import (
     NORMAL_BALANCE_RECAL_INVERTER_STANDBY,
     BMS_DISCHARGE_CUTOFF_SOC,
     PD_READBACK_EVERY_N_WRITES,
+    ACK_INEXACT_STREAK_WARN,
     FEEDFORWARD_STEP_FLOOR_W,
     FEEDFORWARD_CONFIRM_RATIO,
     FEEDFORWARD_CANDIDATE_MAX_AGE_S,
@@ -3309,6 +3310,10 @@ class ChargeDischargeController:
                         coordinator, abs(net_power), float(batt_power), attempt=0,
                     )
             if skip_write:
+                # Polled set-points match the commanded values exactly — this is
+                # the deferred settled verification a tolerance-only ACK left
+                # pending (see the readback branch below).
+                coordinator._ack_inexact_streak = 0
                 _LOGGER.debug(
                     "[%s] Power write skipped - already at force=%d charge=%dW "
                     "discharge=%dW",
@@ -3368,6 +3373,25 @@ class ChargeDischargeController:
                 return True
 
             if result.confirmed:
+                # Deferred exact verification: a tolerance-only ACK (exact=False)
+                # means the echo was still ramping when read. Settled state is
+                # proven by an exact echo here or by the poll comparison in the
+                # skip-write block above (both reset the streak). A long streak
+                # of tolerance-only ACKs with neither means the write chain lags
+                # beyond what the settle window ever covers — surface it once.
+                if result.exact:
+                    coordinator._ack_inexact_streak = 0
+                else:
+                    streak = getattr(coordinator, "_ack_inexact_streak", 0) + 1
+                    coordinator._ack_inexact_streak = streak
+                    if streak == ACK_INEXACT_STREAK_WARN:
+                        _LOGGER.warning(
+                            "[%s] %d consecutive power ACKs confirmed only within "
+                            "tolerance — the set-point echo keeps lagging the "
+                            "write. Commands are being delivered, but check the "
+                            "RS485 bridge serial settings (baud, packing/gap time).",
+                            coordinator.name, streak,
+                        )
                 actual_power = result.battery_power_w
                 _LOGGER.debug(
                     "[%s] Power ACK: force=%d charge=%dW discharge=%dW battery=%dW",

--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -222,6 +222,15 @@ BMS_DISCHARGE_CUTOFF_SOC = 20                  # %: below this, refused discharg
 # delivering are caught up to N writes later instead of immediately.
 PD_READBACK_EVERY_N_WRITES = 5
 
+# Deferred exact-ACK verification: a readback may confirm within the driver's
+# echo tolerance while the battery is still ramping toward the set-point (see
+# _ACK_TOLERANCE_* in drivers/marstek.py). The exact settled check happens
+# later — an exact readback echo or the poll-time skip-write comparison. If
+# this many consecutive readback cycles confirm only by tolerance without an
+# exact match in between, warn once: the write chain (RS485-ETH bridge serial
+# config, firmware) lags more than the settle window ever covers.
+ACK_INEXACT_STREAK_WARN = 5
+
 # Transient burst poll: right after a REAL power command change, the delivered-
 # power reading (ac_power / battery_power) is polled at this cadence instead of
 # its normal "high" scan interval, so _measured_battery_power() isn't stale

--- a/custom_components/omnibattery/drivers/base.py
+++ b/custom_components/omnibattery/drivers/base.py
@@ -124,6 +124,12 @@ class SetpointResult:
     # Brief machine-readable reason when ``ok`` is False (e.g. "write_failed",
     # "not_connected", "feedback_timeout"). None on success.
     failure_reason: Optional[str] = None
+    # True when a confirmed readback echoed the written set-points exactly;
+    # False when confirmation relied on the driver's echo tolerance (the battery
+    # is still ramping / the bridge lagged the write). Only meaningful when
+    # ``confirmed`` is True — the control layer uses it to defer the exact
+    # settled-state verification to the poll comparison.
+    exact: bool = True
     # Measured delivered power (signed W, +charge / -discharge) read back from the
     # hardware on a confirmation cycle; None on the write-only fast path
     # (``read_back=False``). Universal telemetry the control layer uses for

--- a/custom_components/omnibattery/drivers/marstek.py
+++ b/custom_components/omnibattery/drivers/marstek.py
@@ -48,6 +48,16 @@ _FORCE_DISCHARGE = 2
 _RS485_ENABLE = 21930   # 0x55AA
 _RS485_DISABLE = 21947  # 0x55BB
 
+# Set-point echo tolerance for the post-write readback. The battery applies
+# writes asynchronously and an RS485-ETH bridge adds latency, so the readback
+# 0.2 s after the write can still catch the previous/ramping value. Exact
+# equality here produced false ack_mismatch failures (and 5-min pool
+# exclusions) on batteries that were delivering the requested power — issue
+# #77. Mirrors the non-responsive tracker's 10% delivery tolerance, with a
+# floor for small set-points. force_mode is always compared exactly.
+_ACK_TOLERANCE_PCT = 0.10
+_ACK_TOLERANCE_FLOOR_W = 100
+
 
 def _load_definitions(version: str) -> dict[str, list[dict]]:
     """Return this Marstek version's per-platform entity definitions.
@@ -487,7 +497,15 @@ class MarstekModbusDriver(BatteryDriver):
                 ok=True, net_power_w=applied_net, confirmed=False, failure_reason="feedback_timeout",
             )
 
-        confirmed = force_fb == force_mode and charge_fb == charge and discharge_fb == discharge
+        tolerance = max(
+            _ACK_TOLERANCE_FLOOR_W, int(_ACK_TOLERANCE_PCT * max(charge, discharge))
+        )
+        exact = force_fb == force_mode and charge_fb == charge and discharge_fb == discharge
+        confirmed = (
+            force_fb == force_mode
+            and abs(charge_fb - charge) <= tolerance
+            and abs(discharge_fb - discharge) <= tolerance
+        )
         applied = {
             "force_mode": force_fb,
             "set_charge_power": charge_fb,
@@ -495,7 +513,7 @@ class MarstekModbusDriver(BatteryDriver):
             "battery_power": power_fb,
         }
         return SetpointResult(
-            ok=True, net_power_w=applied_net, confirmed=confirmed,
+            ok=True, net_power_w=applied_net, confirmed=confirmed, exact=exact,
             battery_power_w=power_fb, applied=applied,
         )
 

--- a/tests/test_marstek_driver.py
+++ b/tests/test_marstek_driver.py
@@ -366,6 +366,7 @@ async def test_apply_setpoint_confirms_on_matching_readback():
     res = await drv.apply_setpoint(600, read_back=True)
 
     assert res.ok is True and res.confirmed is True
+    assert res.exact is True
     # delivered power surfaced for non-delivery detection + telemetry echo
     assert res.battery_power_w == 590
     assert res.applied == {
@@ -376,15 +377,54 @@ async def test_apply_setpoint_confirms_on_matching_readback():
 
 async def test_apply_setpoint_unconfirmed_on_mismatched_readback():
     client = _fake_client()
-    client.async_read_register = AsyncMock(side_effect=[1, 500, 0, 480])  # charge != 600
+    # charge echo 300 vs 600 requested: outside the max(100 W, 10%) tolerance
+    client.async_read_register = AsyncMock(side_effect=[1, 300, 0, 280])
     drv = _driver("v3", client=client)
 
     res = await drv.apply_setpoint(600, read_back=True)
 
     assert res.ok is True and res.confirmed is False
     # echo carries the *readback* values, not the commanded ones
-    assert res.applied["set_charge_power"] == 500
-    assert res.battery_power_w == 480
+    assert res.applied["set_charge_power"] == 300
+    assert res.battery_power_w == 280
+
+
+async def test_apply_setpoint_confirms_within_echo_tolerance():
+    client = _fake_client()
+    # charge echo 550 vs 600 requested: within tolerance (battery still ramping /
+    # bridge lagging the write, issue #77) — confirmed, but not exact
+    client.async_read_register = AsyncMock(side_effect=[1, 550, 0, 530])
+    drv = _driver("v3", client=client)
+
+    res = await drv.apply_setpoint(600, read_back=True)
+
+    assert res.ok is True and res.confirmed is True
+    assert res.exact is False
+
+
+async def test_apply_setpoint_force_mode_mismatch_never_confirmed():
+    client = _fake_client()
+    # set-points echo within tolerance but force_mode did not take: no tolerance
+    # for the mode bit — must retry
+    client.async_read_register = AsyncMock(side_effect=[0, 600, 0, 590])
+    drv = _driver("v3", client=client)
+
+    res = await drv.apply_setpoint(600, read_back=True)
+
+    assert res.ok is True and res.confirmed is False
+
+
+async def test_apply_setpoint_idle_confirms_with_residual_echo():
+    client = _fake_client()
+    # idle command: force echoed 0, charge register still draining (80 W residual
+    # within the 100 W floor) — confirmed, not exact
+    client.async_read_register = AsyncMock(side_effect=[0, 80, 0, 10])
+    drv = _driver("v3", client=client)
+
+    res = await drv.apply_setpoint(0, read_back=True)
+
+    assert res.ok is True and res.confirmed is True
+    assert res.exact is False
 
 
 async def test_apply_setpoint_feedback_timeout_when_readback_fails():


### PR DESCRIPTION
The post-write readback compared the set-point echo with exact equality 0.2 s after the write. A laggy write chain (RS485-ETH bridge packing time + async register application) makes the readback catch the previous/ramping value, so batteries that were delivering the requested power failed ack_mismatch and got 5-min pool exclusions. Made worse by the skip-if-unchanged/readback-throttle change (9c22133): every readback now lands right after a set-point change, so a stale echo never matches.

- drivers/marstek.py: confirm within max(100 W, 10%) tolerance; force_mode stays exact (safety bit).
- SetpointResult.exact: True only on an exact echo, so the control layer can defer the settled verification.
- __init__.py: exact settled verification is deferred to the skip-write poll comparison (already exact); 5 consecutive tolerance-only ACKs without an exact match warn once, pointing at the bridge serial config.