### PR TITLE
fix: restore MVEM retry path for queued gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.1b2] - 2026-07-17
+
+### Fixed
+- **Queued Modbus gateway compatibility now restores the proven MVEM retry path** (#77): the per-battery opt-in sends each request once per transaction ID with the normal response timeout, then retries failed, timed-out or incomplete transactions up to three times with a fresh ID. This keeps same-ID resends out of queued TCP-to-RTU gateways without giving up MVEM's recovery from occasional short or missing replies.
+
 ## [1.0.1b1] - 2026-07-17
 
 ### Added

--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -41,8 +41,9 @@ SERIAL_BAUDRATE = 115200
 
 # Experimental per-battery compatibility for queued Modbus TCP-to-RTU
 # gateways. Disabled by default: ordinary v2 connections keep pymodbus's
-# internal same-transaction-id retries. When enabled on v2/TCP, each transaction
-# is sent only once while preserving the standard total response window.
+# internal same-transaction-id retries. When enabled on v2/TCP, it restores the
+# legacy MVEM route: one send per transaction ID and up to three wrapper attempts
+# with a new transaction ID after a failed response.
 CONF_QUEUED_GATEWAY_COMPATIBILITY = "queued_gateway_compatibility"
 
 # Maximum power (W) per battery version — used by config_flow to set slider limits

--- a/custom_components/omnibattery/infra/modbus_client.py
+++ b/custom_components/omnibattery/infra/modbus_client.py
@@ -20,7 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 # Standard policy for every model. Since pymodbus 3.8, internal retries reuse
 # the same transaction_id, so late replies still match the outstanding request.
 _PYMODBUS_RETRIES = 2
-_RESPONSE_WINDOW_ATTEMPTS = _PYMODBUS_RETRIES + 1
+_STANDARD_WRAPPER_ATTEMPTS = 1
+_MVEM_WRAPPER_ATTEMPTS = 3
 
 
 def _backoff_jitter(delay: float) -> float:
@@ -144,8 +145,10 @@ class MarstekModbusClient:
                 TCP and ``host``/``port`` are ignored for the link (discussion
                 #350). None = Modbus TCP (default, unchanged behaviour).
             queued_gateway_compatibility (bool): Experimental v2/TCP mode that
-                sends each transaction only once. Intended for gateways that
-                queue pymodbus's same-ID resends as independent RTU requests.
+                restores MVEM's legacy retry path: each transaction is sent once
+                and a failed attempt is retried as a new transaction. Intended
+                for gateways that queue same-ID resends as independent RTU
+                requests.
         """
         self.host = host
         self.port = port
@@ -170,14 +173,17 @@ class MarstekModbusClient:
         self._pymodbus_retries = (
             0 if self._queued_gateway_compatibility else _PYMODBUS_RETRIES
         )
-        # The opt-in sends once but keeps the standard policy's total response
-        # window open. A slow reply therefore completes the pending request
-        # instead of arriving later as an orphan PDU.
-        self._pymodbus_timeout = (
-            timeout * _RESPONSE_WINDOW_ATTEMPTS
+        # MVEM used three wrapper attempts. Preserve that proven gateway path
+        # deliberately: pymodbus sends once per transaction, while a timeout,
+        # short read or other communication failure starts a new transaction ID.
+        # Standard clients keep one wrapper attempt because their retries live
+        # inside pymodbus and reuse the same transaction ID.
+        self._wrapper_attempts = (
+            _MVEM_WRAPPER_ATTEMPTS
             if self._queued_gateway_compatibility
-            else timeout
+            else _STANDARD_WRAPPER_ATTEMPTS
         )
+        self._pymodbus_timeout = timeout
         # Outer safety-net timeout for one request: must cover all pymodbus
         # internal attempts ((retries+1) x per-attempt timeout) plus margin.
         # Cancelling pymodbus mid-transaction orphans an already-sent request,
@@ -210,8 +216,9 @@ class MarstekModbusClient:
         fresh client instances, which avoids pymodbus's internal reconnect_delay
         growing up to 300s. Standard clients retry inside pymodbus (same
         transaction_id since 3.8), so a late reply is consumed by the
-        outstanding request. The experimental queued-gateway mode sends a v2
-        TCP request only once while keeping the same total response window.
+        outstanding request. The experimental queued-gateway mode restores the
+        MVEM path: one wire send per transaction and up to three wrapper attempts,
+        each with a new transaction ID.
 
         Serial uses RTU framing at a fixed 115200 8N1 — the rate Marstek's RS485
         link runs at (discussion #350); these are hardware-fixed, not tunable.
@@ -337,7 +344,7 @@ class MarstekModbusClient:
         self,
         register: int,
         count: int,
-        max_retries: int = 1,
+        max_retries: Optional[int] = None,
         retry_delay: float = 0.1,
         sensor_key: Optional[str] = None,
     ) -> Optional[list]:
@@ -347,11 +354,10 @@ class MarstekModbusClient:
         Returns the list of register words (length ``count``) or None on
         failure. Callers decode the words with :func:`decode_registers`.
 
-        Default is a single wrapper attempt. Retries are pymodbus-internal (same
-        transaction_id per re-send), so late replies match and are consumed.
-        The queued-gateway opt-in disables those internal resends. Looping here
-        would mint a new tid per attempt and turn every late reply into a
-        discarded "transaction_id mismatch".
+        Standard clients use one wrapper attempt and retry inside pymodbus with
+        the same transaction ID. The queued-gateway opt-in instead restores
+        MVEM's three wrapper attempts with pymodbus retries disabled, so every
+        failed attempt is retried as a new transaction ID.
         """
         if not (0 <= register <= 0xFFFF):
             _LOGGER.error(
@@ -368,10 +374,11 @@ class MarstekModbusClient:
             )
             return None
 
+        attempt_limit = self._wrapper_attempts if max_retries is None else max_retries
         attempt = 0
         current_retry_delay = retry_delay
 
-        while attempt < max_retries:
+        while attempt < attempt_limit:
             # Skip connection check - let pymodbus handle connection issues
             # This avoids problems with incorrect connection state reporting
 
@@ -437,7 +444,7 @@ class MarstekModbusClient:
                 return None
 
             attempt += 1
-            if attempt < max_retries:
+            if attempt < attempt_limit:
                 # Exponential backoff with jitter
                 await asyncio.sleep(current_retry_delay + _backoff_jitter(current_retry_delay))
                 current_retry_delay = min(current_retry_delay * 2, 5.0)  # Cap at 5 seconds
@@ -446,7 +453,7 @@ class MarstekModbusClient:
             "Failed to read register %d (0x%04X) after %d attempts",
             register,
             register,
-            max_retries,
+            attempt_limit,
         )
         return None
 
@@ -457,7 +464,7 @@ class MarstekModbusClient:
         count: Optional[int] = None,
         bit_index: Optional[int] = None,
         sensor_key: Optional[str] = None,
-        max_retries: int = 1,
+        max_retries: Optional[int] = None,
         retry_delay: float = 0.1,
     ):
         """
@@ -493,7 +500,7 @@ class MarstekModbusClient:
         self,
         start: int,
         count: int,
-        max_retries: int = 1,
+        max_retries: Optional[int] = None,
         retry_delay: float = 0.1,
         block_key: Optional[str] = None,
     ) -> Optional[list]:
@@ -512,13 +519,14 @@ class MarstekModbusClient:
             sensor_key=block_key,
         )
 
-    async def async_write_register(self, register: int, value: int, max_retries: int = 1, retry_delay: float = 0.1) -> bool:
+    async def async_write_register(self, register: int, value: int, max_retries: Optional[int] = None, retry_delay: float = 0.1) -> bool:
         """
         Write a single value to a Modbus holding register asynchronously.
 
-        Default is a single attempt; retries are pymodbus-internal with the
-        same transaction_id (see ``_read_raw``). Re-sending a single-register
-        write is idempotent, so a duplicate delivery is harmless.
+        Standard clients use one wrapper attempt and retry inside pymodbus. The
+        queued-gateway opt-in restores MVEM's three wrapper attempts with a new
+        transaction ID per attempt (see ``_read_raw``). Re-sending a
+        single-register write is idempotent.
 
         Args:
             register (int): Register address to write to.
@@ -527,10 +535,11 @@ class MarstekModbusClient:
         Returns:
             bool: True if write was successful, False otherwise.
         """
+        attempt_limit = self._wrapper_attempts if max_retries is None else max_retries
         attempt = 0
         current_retry_delay = retry_delay
         
-        while attempt < max_retries:
+        while attempt < attempt_limit:
             # Skip connection check for write operations too
             # Let pymodbus handle connection issues
 
@@ -566,7 +575,7 @@ class MarstekModbusClient:
                 return False
 
             attempt += 1
-            if attempt < max_retries:
+            if attempt < attempt_limit:
                 # Exponential backoff with jitter
                 await asyncio.sleep(current_retry_delay + _backoff_jitter(current_retry_delay))
                 current_retry_delay = min(current_retry_delay * 2, 5.0)  # Cap at 5 seconds
@@ -575,6 +584,6 @@ class MarstekModbusClient:
             "Failed to write register %d (0x%04X) after %d attempts",
             register,
             register,
-            max_retries,
+            attempt_limit,
         )
         return False

--- a/custom_components/omnibattery/manifest.json
+++ b/custom_components/omnibattery/manifest.json
@@ -22,7 +22,7 @@
     "pymodbus>=3.8.0",
     "pyserial>=3.5"
   ],
-  "version": "1.0.1b1",
+  "version": "1.0.1b2",
   "zeroconf": [
     "_modbus._tcp.local."
   ]

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -50,7 +50,7 @@
           "slave_id": "Modbus Slave ID",
           "battery_version": "Battery Model",
           "serial_port": "Serial port (Modbus RTU)",
-          "queued_gateway_compatibility": "Queued Modbus gateway compatibility (experimental)"
+          "queued_gateway_compatibility": "Legacy MVEM Modbus compatibility (experimental)"
         },
         "data_description": {
           "name": "Descriptive name to identify this battery",
@@ -59,7 +59,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version. Ev2 for older models, Ev3 for newer models with updated register map, A (Venus A) or D (Venus D) for hybrid inverter models",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Sends each transaction once to test gateways that may queue retries as separate RTU requests. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "battery_connection_zendure": {
@@ -451,7 +451,7 @@
           "slave_id": "Modbus Slave ID",
           "battery_version": "Battery Model",
           "serial_port": "Serial port (Modbus RTU)",
-          "queued_gateway_compatibility": "Queued Modbus gateway compatibility (experimental)"
+          "queued_gateway_compatibility": "Legacy MVEM Modbus compatibility (experimental)"
         },
         "data_description": {
           "name": "Descriptive name to identify this battery",
@@ -460,7 +460,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Sends each transaction once to test gateways that may queue retries as separate RTU requests. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "reconfigure_battery_zendure": {
@@ -583,7 +583,7 @@
           "slave_id": "Modbus Slave ID",
           "battery_version": "Battery Model",
           "serial_port": "Serial port (Modbus RTU)",
-          "queued_gateway_compatibility": "Queued Modbus gateway compatibility (experimental)"
+          "queued_gateway_compatibility": "Legacy MVEM Modbus compatibility (experimental)"
         },
         "data_description": {
           "name": "Descriptive name to identify this battery",
@@ -592,7 +592,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version. Ev2 for older models, Ev3 for newer models with updated register map, A (Venus A) or D (Venus D) for hybrid inverter models",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Sends each transaction once to test gateways that may queue retries as separate RTU requests. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -50,7 +50,7 @@
           "slave_id": "ID d'esclau Modbus",
           "battery_version": "Model de bateria",
           "serial_port": "Port sèrie (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibilitat amb passarel·la Modbus amb cua (experimental)"
+          "queued_gateway_compatibility": "Compatibilitat Modbus heretada de MVEM (experimental)"
         },
         "data_description": {
           "name": "Nom descriptiu per identificar aquesta bateria",
@@ -59,7 +59,7 @@
           "slave_id": "ID d'esclau/unitat Modbus (per defecte 1). Canvia'l només si un proxy Modbus exposa diverses bateries a una mateixa IP:port amb IDs d'esclau diferents.",
           "battery_version": "Selecciona la versió del model de la teva bateria. Ev2 per a models antics, Ev3 per a models nous amb mapa de registres actualitzat, A (Venus A) o D (Venus D) per a models amb inversor híbrid",
           "serial_port": "Ruta de l'adaptador USB-RS485, p. ex. /dev/ttyUSB0 o COM3. Omple-ho en lloc de l'adreça IP per utilitzar Modbus RTU per sèrie; deixa-ho buit per a TCP.",
-          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Envia cada transacció una sola vegada per provar passarel·les que poden posar els reintents a la cua com a sol·licituds RTU independents. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
+          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Restaura la via de reintents de MVEM: un enviament per ID de transacció i fins a tres intents amb un ID nou després d'una resposta fallida, esgotada o incompleta. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
         }
       },
       "battery_connection_zendure": {
@@ -459,7 +459,7 @@
           "slave_id": "ID d'esclau Modbus",
           "battery_version": "Model de bateria",
           "serial_port": "Port sèrie (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibilitat amb passarel·la Modbus amb cua (experimental)"
+          "queued_gateway_compatibility": "Compatibilitat Modbus heretada de MVEM (experimental)"
         },
         "data_description": {
           "name": "Nom descriptiu per identificar aquesta bateria",
@@ -468,7 +468,7 @@
           "slave_id": "ID d'esclau/unitat Modbus (per defecte 1). Canvia'l només si un proxy Modbus exposa diverses bateries a una mateixa IP:port amb IDs d'esclau diferents.",
           "battery_version": "Selecciona la versió del teu model de bateria",
           "serial_port": "Ruta de l'adaptador USB-RS485, p. ex. /dev/ttyUSB0 o COM3. Omple-ho en lloc de l'adreça IP per utilitzar Modbus RTU per sèrie; deixa-ho buit per a TCP.",
-          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Envia cada transacció una sola vegada per provar passarel·les que poden posar els reintents a la cua com a sol·licituds RTU independents. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
+          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Restaura la via de reintents de MVEM: un enviament per ID de transacció i fins a tres intents amb un ID nou després d'una resposta fallida, esgotada o incompleta. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
         }
       },
       "reconfigure_battery_zendure": {
@@ -592,7 +592,7 @@
           "slave_id": "ID d'esclau Modbus",
           "battery_version": "Model de bateria",
           "serial_port": "Port sèrie (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibilitat amb passarel·la Modbus amb cua (experimental)"
+          "queued_gateway_compatibility": "Compatibilitat Modbus heretada de MVEM (experimental)"
         },
         "data_description": {
           "name": "Nom descriptiu per identificar aquesta bateria",
@@ -601,7 +601,7 @@
           "slave_id": "ID d'esclau/unitat Modbus (per defecte 1). Canvia'l només si un proxy Modbus exposa diverses bateries a una mateixa IP:port amb IDs d'esclau diferents.",
           "battery_version": "Selecciona la versió del model de la teva bateria. Ev2 per a models antics, Ev3 per a models nous amb mapa de registres actualitzat, A (Venus A) o D (Venus D) per a models d'inversor híbrid",
           "serial_port": "Ruta de l'adaptador USB-RS485, p. ex. /dev/ttyUSB0 o COM3. Omple-ho en lloc de l'adreça IP per utilitzar Modbus RTU per sèrie; deixa-ho buit per a TCP.",
-          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Envia cada transacció una sola vegada per provar passarel·les que poden posar els reintents a la cua com a sol·licituds RTU independents. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
+          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Restaura la via de reintents de MVEM: un enviament per ID de transacció i fins a tres intents amb un ID nou després d'una resposta fallida, esgotada o incompleta. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -50,7 +50,7 @@
           "battery_version": "Batteriemodell",
           "slave_id": "Modbus-Slave-ID",
           "serial_port": "Serieller Port (Modbus RTU)",
-          "queued_gateway_compatibility": "Kompatibilität mit Modbus-Gateways mit Warteschlange (experimentell)"
+          "queued_gateway_compatibility": "Legacy-MVEM-Modbus-Kompatibilität (experimentell)"
         },
         "data_description": {
           "name": "Beschreibender Name zur Identifizierung dieser Batterie",
@@ -59,7 +59,7 @@
           "battery_version": "Wählen Sie die Modellversion Ihrer Batterie. Ev2 für ältere Modelle, Ev3 für neuere Modelle mit aktualisierter Registerkarte, A (Venus A) oder D (Venus D) für Hybrid-Wechselrichter-Modelle",
           "slave_id": "Modbus Slave-/Unit-ID (Standard 1). Nur ändern, wenn ein Modbus-Proxy mehrere Batterien über dieselbe IP:Port mit unterschiedlichen Slave-IDs abbildet.",
           "serial_port": "Pfad des USB-RS485-Adapters, z. B. /dev/ttyUSB0 oder COM3. Statt der IP-Adresse ausfüllen, um Modbus RTU über die serielle Schnittstelle zu nutzen; für TCP leer lassen.",
-          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Sendet jede Transaktion einmal, um Gateways zu testen, die Wiederholungen als separate RTU-Anfragen einreihen. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
+          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Stellt den MVEM-Wiederholungspfad wieder her: eine Sendung pro Transaktions-ID und bis zu drei Versuche mit einer neuen ID nach einer fehlgeschlagenen, abgelaufenen oder unvollständigen Antwort. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
         }
       },
       "battery_connection_zendure": {
@@ -459,7 +459,7 @@
           "battery_version": "Batteriemodell",
           "slave_id": "Modbus-Slave-ID",
           "serial_port": "Serieller Port (Modbus RTU)",
-          "queued_gateway_compatibility": "Kompatibilität mit Modbus-Gateways mit Warteschlange (experimentell)"
+          "queued_gateway_compatibility": "Legacy-MVEM-Modbus-Kompatibilität (experimentell)"
         },
         "data_description": {
           "name": "Beschreibender Name zur Identifikation dieser Batterie",
@@ -468,7 +468,7 @@
           "battery_version": "Wählen Sie Ihre Batteriemodellversion",
           "slave_id": "Modbus Slave-/Unit-ID (Standard 1). Nur ändern, wenn ein Modbus-Proxy mehrere Batterien über dieselbe IP:Port mit unterschiedlichen Slave-IDs abbildet.",
           "serial_port": "Pfad des USB-RS485-Adapters, z. B. /dev/ttyUSB0 oder COM3. Statt der IP-Adresse ausfüllen, um Modbus RTU über die serielle Schnittstelle zu nutzen; für TCP leer lassen.",
-          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Sendet jede Transaktion einmal, um Gateways zu testen, die Wiederholungen als separate RTU-Anfragen einreihen. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
+          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Stellt den MVEM-Wiederholungspfad wieder her: eine Sendung pro Transaktions-ID und bis zu drei Versuche mit einer neuen ID nach einer fehlgeschlagenen, abgelaufenen oder unvollständigen Antwort. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
         }
       },
       "reconfigure_battery_zendure": {
@@ -592,7 +592,7 @@
           "battery_version": "Batteriemodell",
           "slave_id": "Modbus-Slave-ID",
           "serial_port": "Serieller Port (Modbus RTU)",
-          "queued_gateway_compatibility": "Kompatibilität mit Modbus-Gateways mit Warteschlange (experimentell)"
+          "queued_gateway_compatibility": "Legacy-MVEM-Modbus-Kompatibilität (experimentell)"
         },
         "data_description": {
           "name": "Beschreibender Name zur Identifizierung dieser Batterie",
@@ -601,7 +601,7 @@
           "battery_version": "Wählen Sie die Modellversion Ihrer Batterie. Ev2 für ältere Modelle, Ev3 für neuere Modelle mit aktualisierter Registerkarte, A (Venus A) oder D (Venus D) für Hybrid-Wechselrichter-Modelle",
           "slave_id": "Modbus Slave-/Unit-ID (Standard 1). Nur ändern, wenn ein Modbus-Proxy mehrere Batterien über dieselbe IP:Port mit unterschiedlichen Slave-IDs abbildet.",
           "serial_port": "Pfad des USB-RS485-Adapters, z. B. /dev/ttyUSB0 oder COM3. Statt der IP-Adresse ausfüllen, um Modbus RTU über die serielle Schnittstelle zu nutzen; für TCP leer lassen.",
-          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Sendet jede Transaktion einmal, um Gateways zu testen, die Wiederholungen als separate RTU-Anfragen einreihen. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
+          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Stellt den MVEM-Wiederholungspfad wieder her: eine Sendung pro Transaktions-ID und bis zu drei Versuche mit einer neuen ID nach einer fehlgeschlagenen, abgelaufenen oder unvollständigen Antwort. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -50,7 +50,7 @@
           "slave_id": "Modbus Slave ID",
           "battery_version": "Battery Model",
           "serial_port": "Serial port (Modbus RTU)",
-          "queued_gateway_compatibility": "Queued Modbus gateway compatibility (experimental)"
+          "queued_gateway_compatibility": "Legacy MVEM Modbus compatibility (experimental)"
         },
         "data_description": {
           "name": "Descriptive name to identify this battery",
@@ -59,7 +59,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version. Ev2 for older models, Ev3 for newer models with updated register map, A (Venus A) or D (Venus D) for hybrid inverter models",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Sends each transaction once to test gateways that may queue retries as separate RTU requests. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "battery_connection_zendure": {
@@ -453,7 +453,7 @@
           "slave_id": "Modbus Slave ID",
           "battery_version": "Battery Model",
           "serial_port": "Serial port (Modbus RTU)",
-          "queued_gateway_compatibility": "Queued Modbus gateway compatibility (experimental)"
+          "queued_gateway_compatibility": "Legacy MVEM Modbus compatibility (experimental)"
         },
         "data_description": {
           "name": "Descriptive name to identify this battery",
@@ -462,7 +462,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Sends each transaction once to test gateways that may queue retries as separate RTU requests. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "reconfigure_battery_zendure": {
@@ -586,7 +586,7 @@
           "slave_id": "Modbus Slave ID",
           "battery_version": "Battery Model",
           "serial_port": "Serial port (Modbus RTU)",
-          "queued_gateway_compatibility": "Queued Modbus gateway compatibility (experimental)"
+          "queued_gateway_compatibility": "Legacy MVEM Modbus compatibility (experimental)"
         },
         "data_description": {
           "name": "Descriptive name to identify this battery",
@@ -595,7 +595,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version. Ev2 for older models, Ev3 for newer models with updated register map, A (Venus A) or D (Venus D) for hybrid inverter models",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Sends each transaction once to test gateways that may queue retries as separate RTU requests. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -50,7 +50,7 @@
           "slave_id": "ID de esclavo Modbus",
           "battery_version": "Modelo de batería",
           "serial_port": "Puerto serie (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibilidad con gateway Modbus con cola (experimental)"
+          "queued_gateway_compatibility": "Compatibilidad Modbus heredada de MVEM (experimental)"
         },
         "data_description": {
           "name": "Nombre descriptivo para identificar esta batería",
@@ -59,7 +59,7 @@
           "slave_id": "ID de esclavo/unidad Modbus (por defecto 1). Cámbialo solo si un proxy Modbus expone varias baterías en una misma IP:puerto con ids de esclavo distintos.",
           "battery_version": "Selecciona la versión del modelo de tu batería. Ev2 para modelos antiguos, Ev3 para modelos nuevos con mapa de registros actualizado, A (Venus A) o D (Venus D) para modelos de inversor híbrido",
           "serial_port": "Ruta del adaptador USB-RS485, p. ej. /dev/ttyUSB0 o COM3. Complétalo en lugar de la dirección IP para usar Modbus RTU por serie; déjalo vacío para TCP.",
-          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Envía cada transacción una sola vez para probar gateways que puedan encolar los reintentos como solicitudes RTU independientes. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
+          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Restaura la vía de reintentos de MVEM: un envío por ID de transacción y hasta tres intentos con un ID nuevo tras una respuesta fallida, agotada o incompleta. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
         }
       },
       "battery_connection_zendure": {
@@ -459,7 +459,7 @@
           "slave_id": "ID de esclavo Modbus",
           "battery_version": "Modelo de batería",
           "serial_port": "Puerto serie (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibilidad con gateway Modbus con cola (experimental)"
+          "queued_gateway_compatibility": "Compatibilidad Modbus heredada de MVEM (experimental)"
         },
         "data_description": {
           "name": "Nombre descriptivo para identificar esta batería",
@@ -468,7 +468,7 @@
           "slave_id": "ID de esclavo/unidad Modbus (por defecto 1). Cámbialo solo si un proxy Modbus expone varias baterías en una misma IP:puerto con ids de esclavo distintos.",
           "battery_version": "Selecciona la versión de tu modelo de batería",
           "serial_port": "Ruta del adaptador USB-RS485, p. ej. /dev/ttyUSB0 o COM3. Complétalo en lugar de la dirección IP para usar Modbus RTU por serie; déjalo vacío para TCP.",
-          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Envía cada transacción una sola vez para probar gateways que puedan encolar los reintentos como solicitudes RTU independientes. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
+          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Restaura la vía de reintentos de MVEM: un envío por ID de transacción y hasta tres intentos con un ID nuevo tras una respuesta fallida, agotada o incompleta. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
         }
       },
       "reconfigure_battery_zendure": {
@@ -592,7 +592,7 @@
           "slave_id": "ID de esclavo Modbus",
           "battery_version": "Modelo de batería",
           "serial_port": "Puerto serie (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibilidad con gateway Modbus con cola (experimental)"
+          "queued_gateway_compatibility": "Compatibilidad Modbus heredada de MVEM (experimental)"
         },
         "data_description": {
           "name": "Nombre descriptivo para identificar esta batería",
@@ -601,7 +601,7 @@
           "slave_id": "ID de esclavo/unidad Modbus (por defecto 1). Cámbialo solo si un proxy Modbus expone varias baterías en una misma IP:puerto con ids de esclavo distintos.",
           "battery_version": "Selecciona la versión del modelo de tu batería. Ev2 para modelos antiguos, Ev3 para modelos nuevos con mapa de registros actualizado, A (Venus A) o D (Venus D) para modelos de inversor híbrido",
           "serial_port": "Ruta del adaptador USB-RS485, p. ej. /dev/ttyUSB0 o COM3. Complétalo en lugar de la dirección IP para usar Modbus RTU por serie; déjalo vacío para TCP.",
-          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Envía cada transacción una sola vez para probar gateways que puedan encolar los reintentos como solicitudes RTU independientes. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
+          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Restaura la vía de reintentos de MVEM: un envío por ID de transacción y hasta tres intentos con un ID nuevo tras una respuesta fallida, agotada o incompleta. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -50,7 +50,7 @@
           "battery_version": "Modèle de batterie",
           "slave_id": "ID d'esclave Modbus",
           "serial_port": "Port série (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibilité avec les passerelles Modbus à file d'attente (expérimental)"
+          "queued_gateway_compatibility": "Compatibilité Modbus MVEM historique (expérimental)"
         },
         "data_description": {
           "name": "Nom descriptif pour identifier cette batterie",
@@ -59,7 +59,7 @@
           "battery_version": "Sélectionnez la version du modèle de votre batterie. Ev2 pour les anciens modèles, Ev3 pour les nouveaux modèles avec cartographie mise à jour, A (Venus A) ou D (Venus D) pour les onduleurs hybrides",
           "slave_id": "ID d'esclave/unité Modbus (par défaut 1). À modifier uniquement lorsqu'un proxy Modbus expose plusieurs batteries sur une même IP:port avec des ID d'esclave distincts.",
           "serial_port": "Chemin de l'adaptateur USB-RS485, p. ex. /dev/ttyUSB0 ou COM3. Renseignez-le à la place de l'adresse IP pour utiliser Modbus RTU en série ; laissez vide pour le TCP.",
-          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Envoie chaque transaction une seule fois afin de tester les passerelles susceptibles de mettre les nouvelles tentatives en file comme requêtes RTU indépendantes. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
+          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Restaure la voie de nouvelle tentative de MVEM : un envoi par identifiant de transaction et jusqu'à trois tentatives avec un nouvel identifiant après une réponse échouée, expirée ou incomplète. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
         }
       },
       "battery_connection_zendure": {
@@ -459,7 +459,7 @@
           "battery_version": "Modèle de batterie",
           "slave_id": "ID d'esclave Modbus",
           "serial_port": "Port série (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibilité avec les passerelles Modbus à file d'attente (expérimental)"
+          "queued_gateway_compatibility": "Compatibilité Modbus MVEM historique (expérimental)"
         },
         "data_description": {
           "name": "Nom descriptif pour identifier cette batterie",
@@ -468,7 +468,7 @@
           "battery_version": "Sélectionnez la version de votre modèle de batterie",
           "slave_id": "ID d'esclave/unité Modbus (par défaut 1). À modifier uniquement lorsqu'un proxy Modbus expose plusieurs batteries sur une même IP:port avec des ID d'esclave distincts.",
           "serial_port": "Chemin de l'adaptateur USB-RS485, p. ex. /dev/ttyUSB0 ou COM3. Renseignez-le à la place de l'adresse IP pour utiliser Modbus RTU en série ; laissez vide pour le TCP.",
-          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Envoie chaque transaction une seule fois afin de tester les passerelles susceptibles de mettre les nouvelles tentatives en file comme requêtes RTU indépendantes. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
+          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Restaure la voie de nouvelle tentative de MVEM : un envoi par identifiant de transaction et jusqu'à trois tentatives avec un nouvel identifiant après une réponse échouée, expirée ou incomplète. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
         }
       },
       "reconfigure_battery_zendure": {
@@ -592,7 +592,7 @@
           "battery_version": "Modèle de batterie",
           "slave_id": "ID d'esclave Modbus",
           "serial_port": "Port série (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibilité avec les passerelles Modbus à file d'attente (expérimental)"
+          "queued_gateway_compatibility": "Compatibilité Modbus MVEM historique (expérimental)"
         },
         "data_description": {
           "name": "Nom descriptif pour identifier cette batterie",
@@ -601,7 +601,7 @@
           "battery_version": "Sélectionnez la version du modèle de votre batterie. Ev2 pour les anciens modèles, Ev3 pour les nouveaux modèles avec cartographie mise à jour, A (Venus A) ou D (Venus D) pour les onduleurs hybrides",
           "slave_id": "ID d'esclave/unité Modbus (par défaut 1). À modifier uniquement lorsqu'un proxy Modbus expose plusieurs batteries sur une même IP:port avec des ID d'esclave distincts.",
           "serial_port": "Chemin de l'adaptateur USB-RS485, p. ex. /dev/ttyUSB0 ou COM3. Renseignez-le à la place de l'adresse IP pour utiliser Modbus RTU en série ; laissez vide pour le TCP.",
-          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Envoie chaque transaction une seule fois afin de tester les passerelles susceptibles de mettre les nouvelles tentatives en file comme requêtes RTU indépendantes. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
+          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Restaure la voie de nouvelle tentative de MVEM : un envoi par identifiant de transaction et jusqu'à trois tentatives avec un nouvel identifiant après une réponse échouée, expirée ou incomplète. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -50,7 +50,7 @@
           "battery_version": "Batterijmodel",
           "slave_id": "Modbus slave-ID",
           "serial_port": "Seriële poort (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibiliteit met Modbus-gateway met wachtrij (experimenteel)"
+          "queued_gateway_compatibility": "Compatibiliteit met verouderde MVEM-Modbusroute (experimenteel)"
         },
         "data_description": {
           "name": "Beschrijvende naam om deze batterij te identificeren",
@@ -59,7 +59,7 @@
           "battery_version": "Selecteer de modelversie van uw batterij. Ev2 voor oudere modellen, Ev3 voor nieuwere modellen met bijgewerkte registerkaart, A (Venus A) of D (Venus D) voor hybride omvormermodellen",
           "slave_id": "Modbus slave-/unit-id (standaard 1). Wijzig dit alleen wanneer een Modbus-proxy meerdere batterijen op één IP:poort koppelt met verschillende slave-id's.",
           "serial_port": "Pad van de USB-RS485-adapter, bijv. /dev/ttyUSB0 of COM3. Vul dit in plaats van het IP-adres in om Modbus RTU via serieel te gebruiken; laat leeg voor TCP.",
-          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Verzendt elke transactie één keer om gateways te testen die nieuwe pogingen als afzonderlijke RTU-verzoeken in de wachtrij plaatsen. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
+          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Herstelt de MVEM-route voor nieuwe pogingen: één verzending per transactie-ID en maximaal drie pogingen met een nieuwe ID na een mislukt, verlopen of onvolledig antwoord. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
         }
       },
       "battery_connection_zendure": {
@@ -459,7 +459,7 @@
           "battery_version": "Batterijmodel",
           "slave_id": "Modbus slave-ID",
           "serial_port": "Seriële poort (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibiliteit met Modbus-gateway met wachtrij (experimenteel)"
+          "queued_gateway_compatibility": "Compatibiliteit met verouderde MVEM-Modbusroute (experimenteel)"
         },
         "data_description": {
           "name": "Beschrijvende naam om deze batterij te identificeren",
@@ -468,7 +468,7 @@
           "battery_version": "Selecteer uw batterijmodelversie",
           "slave_id": "Modbus slave-/unit-id (standaard 1). Wijzig dit alleen wanneer een Modbus-proxy meerdere batterijen op één IP:poort koppelt met verschillende slave-id's.",
           "serial_port": "Pad van de USB-RS485-adapter, bijv. /dev/ttyUSB0 of COM3. Vul dit in plaats van het IP-adres in om Modbus RTU via serieel te gebruiken; laat leeg voor TCP.",
-          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Verzendt elke transactie één keer om gateways te testen die nieuwe pogingen als afzonderlijke RTU-verzoeken in de wachtrij plaatsen. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
+          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Herstelt de MVEM-route voor nieuwe pogingen: één verzending per transactie-ID en maximaal drie pogingen met een nieuwe ID na een mislukt, verlopen of onvolledig antwoord. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
         }
       },
       "reconfigure_battery_zendure": {
@@ -592,7 +592,7 @@
           "battery_version": "Batterijmodel",
           "slave_id": "Modbus slave-ID",
           "serial_port": "Seriële poort (Modbus RTU)",
-          "queued_gateway_compatibility": "Compatibiliteit met Modbus-gateway met wachtrij (experimenteel)"
+          "queued_gateway_compatibility": "Compatibiliteit met verouderde MVEM-Modbusroute (experimenteel)"
         },
         "data_description": {
           "name": "Beschrijvende naam om deze batterij te identificeren",
@@ -601,7 +601,7 @@
           "battery_version": "Selecteer de modelversie van uw batterij. Ev2 voor oudere modellen, Ev3 voor nieuwere modellen met bijgewerkte registerkaart, A (Venus A) of D (Venus D) voor hybride omvormermodellen",
           "slave_id": "Modbus slave-/unit-id (standaard 1). Wijzig dit alleen wanneer een Modbus-proxy meerdere batterijen op één IP:poort koppelt met verschillende slave-id's.",
           "serial_port": "Pad van de USB-RS485-adapter, bijv. /dev/ttyUSB0 of COM3. Vul dit in plaats van het IP-adres in om Modbus RTU via serieel te gebruiken; laat leeg voor TCP.",
-          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Verzendt elke transactie één keer om gateways te testen die nieuwe pogingen als afzonderlijke RTU-verzoeken in de wachtrij plaatsen. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
+          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Herstelt de MVEM-route voor nieuwe pogingen: één verzending per transactie-ID en maximaal drie pogingen met een nieuwe ID na een mislukt, verlopen of onvolledig antwoord. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
         }
       },
       "battery_connection_zendure": {

--- a/tests/test_modbus_client.py
+++ b/tests/test_modbus_client.py
@@ -205,13 +205,14 @@ def test_v2_tcp_keeps_standard_retries_by_default():
     assert c._queued_gateway_compatibility is False
     assert c._pymodbus_retries == 2
     assert c.client.ctx.retries == 2
+    assert c._wrapper_attempts == 1
     assert c._pymodbus_timeout == c._timeout
     assert c.client.ctx.comm_params.timeout_connect == c._timeout
     assert c._request_timeout == c._timeout * 3 + 2
 
 
-def test_v2_queued_gateway_mode_sends_once_with_full_response_window():
-    """The experimental opt-in changes only the selected v2/TCP client."""
+def test_v2_queued_gateway_mode_restores_mvem_retry_profile():
+    """The opt-in sends once per TID and retries through the wrapper."""
     c = _make_client(
         host="192.168.1.50",
         port=502,
@@ -221,9 +222,10 @@ def test_v2_queued_gateway_mode_sends_once_with_full_response_window():
     assert c._queued_gateway_compatibility is True
     assert c._pymodbus_retries == 0
     assert c.client.ctx.retries == 0
-    assert c._pymodbus_timeout == c._timeout * 3
-    assert c.client.ctx.comm_params.timeout_connect == c._timeout * 3
-    assert c._request_timeout == c._timeout * 3 + 2
+    assert c._wrapper_attempts == 3
+    assert c._pymodbus_timeout == c._timeout
+    assert c.client.ctx.comm_params.timeout_connect == c._timeout
+    assert c._request_timeout == c._timeout + 2
 
 
 def test_v3_tcp_keeps_internal_same_tid_retries():
@@ -231,6 +233,7 @@ def test_v3_tcp_keeps_internal_same_tid_retries():
     c = _make_client(host="192.168.1.50", port=502, is_v3=True)
     assert c._pymodbus_retries == 2
     assert c.client.ctx.retries == 2
+    assert c._wrapper_attempts == 1
     assert c._pymodbus_timeout == c._timeout
     assert c.client.ctx.comm_params.timeout_connect == c._timeout
     assert c._request_timeout == c._timeout * 3 + 2
@@ -240,7 +243,7 @@ def test_v3_tcp_keeps_internal_same_tid_retries():
     "is_v3, compatibility, expected_retries, expected_timeout",
     [
         (False, False, 2, 10),
-        (False, True, 0, 30),
+        (False, True, 0, 10),
         (True, True, 2, 10),
     ],
 )
@@ -312,6 +315,7 @@ def test_serial_ignores_queued_tcp_gateway_mode():
     assert c._queued_gateway_compatibility is False
     assert c._pymodbus_retries == 2
     assert c.client.ctx.retries == 2
+    assert c._wrapper_attempts == 1
 
 
 def test_serial_skips_v3_packet_correction():

--- a/tests/test_modbus_client_retry.py
+++ b/tests/test_modbus_client_retry.py
@@ -2,12 +2,11 @@
 
 Exercises ``_read_raw`` and ``async_write_register`` against a scripted fake
 pymodbus client (no hardware, no HA). These pin three deliberate properties:
-the default is a SINGLE wrapper attempt (standard retries are
-pymodbus-internal and reuse the same transaction_id; the queued-gateway opt-in
-sends once), the same-connection retry loop still works for callers that opt
-in, and a connection error does NOT trigger a reconnect from inside the loop
-(the coordinator owns reconnection; reconnecting here would storm the v3
-single TCP slot, issue #361).
+the standard profile uses a single wrapper attempt with pymodbus-internal
+same-transaction-ID retries; the queued-gateway opt-in restores MVEM's three
+wrapper attempts with one wire send per transaction ID; and failures do not
+reconnect from inside the loop (the coordinator owns reconnection; reconnecting
+here would storm the v3 single TCP slot, issue #361).
 
 ``retry_delay=0`` keeps the backoff sleeps at zero so the tests run instantly.
 """
@@ -91,6 +90,17 @@ def test_read_default_is_single_attempt():
     regs = asyncio.run(c._read_raw(0x0010, 1, retry_delay=0))
     assert regs is None
     assert fake.read_calls == 1
+
+
+def test_queued_gateway_default_retries_short_read_via_mvem_wrapper():
+    """The opt-in retries incomplete data as a fresh wrapper transaction."""
+    fake = _FakeClient(
+        read_results=[_Result([1]), _Result([1]), _Result([1, 2])]
+    )
+    c = _client_with_fake(fake, queued_gateway_compatibility=True)
+    regs = asyncio.run(c._read_raw(0x0010, 2, retry_delay=0))
+    assert regs == [1, 2]
+    assert fake.read_calls == 3
 
 
 def test_read_retries_on_connection_error_then_succeeds():
@@ -180,6 +190,16 @@ def test_write_default_is_single_attempt():
     c = _client_with_fake(fake)
     assert asyncio.run(c.async_write_register(0x2000, 1, retry_delay=0)) is False
     assert fake.write_calls == 1
+
+
+def test_queued_gateway_default_retries_write_via_mvem_wrapper():
+    """The opt-in retries a communication failure with a new transaction."""
+    fake = _FakeClient(
+        write_results=[asyncio.TimeoutError(), _Result(error=False)]
+    )
+    c = _client_with_fake(fake, queued_gateway_compatibility=True)
+    assert asyncio.run(c.async_write_register(0x2000, 1, retry_delay=0)) is True
+    assert fake.write_calls == 2
 
 
 def test_write_retries_on_connection_error_then_succeeds():


### PR DESCRIPTION
Make the per-battery compatibility option disable pymodbus same-ID retries and use the normal timeout with three wrapper attempts, giving each retry a fresh transaction ID.

Cover incomplete reads and failed writes, refresh the translated option text and changelog, and bump the beta version to 1.0.1b2.