### PR TITLE
Run control cycles as background tasks to avoid blocking HA startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.1b3] - 2026-07-18
+
+### Fixed
+- **Slow Modbus gateways no longer block Home Assistant startup**: control cycles now run as background tasks, so a cycle stuck in gateway retries can't delay the rest of the boot ("Something is blocking Home Assistant from wrapping up the start up phase").
+
 ## [1.0.1b2] - 2026-07-17
 
 ### Fixed

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -3823,6 +3823,23 @@ class ChargeDischargeController:
                 self._grid_filter_ema += alpha * (sensor_raw - self._grid_filter_ema)
         return self._grid_filter_ema
 
+    @callback
+    def schedule_control_cycle(self, now=None):
+        """Launch a control cycle as a config-entry background task.
+
+        Timer and state-change trackers run their callbacks as HA-tracked
+        tasks, and HA startup waits for tracked tasks before wrapping up. A
+        cycle stuck in Modbus retries against a slow gateway would block the
+        whole bootstrap ("Something is blocking Home Assistant..."), delaying
+        every integration set up after this one. Background tasks are exempt
+        from the startup gate and are still cancelled on entry unload.
+        """
+        self.config_entry.async_create_background_task(
+            self.hass,
+            self.async_update_charge_discharge(now),
+            "omnibattery_control_cycle",
+        )
+
     async def async_update_charge_discharge(self, now=None):
         """Run one control cycle, guarded against overlapping triggers.
 
@@ -3875,9 +3892,23 @@ class ChargeDischargeController:
             self.hass, self._no_pd_command_delay, self._fire_no_pd_debounced_run
         )
 
-    async def _fire_no_pd_debounced_run(self, _now):
-        """Run the deferred no-PD control cycle (called by async_call_later)."""
+    @callback
+    def _fire_no_pd_debounced_run(self, _now):
+        """Launch the deferred no-PD control cycle (called by async_call_later).
+
+        Sync callback + background task for the same reason as
+        schedule_control_cycle: async_call_later would otherwise run the cycle
+        as a startup-tracked task.
+        """
         self._no_pd_debounce_unsub = None
+        self.config_entry.async_create_background_task(
+            self.hass,
+            self._run_no_pd_debounced_cycle(),
+            "omnibattery_no_pd_cycle",
+        )
+
+    async def _run_no_pd_debounced_cycle(self):
+        """Run the deferred no-PD control cycle."""
         if self._control_lock.locked():
             return
         async with self._control_lock:
@@ -5702,7 +5733,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return _wrapped
 
     unsub_control = _call_once(async_track_time_interval(
-        hass, controller.async_update_charge_discharge, timedelta(seconds=2.0)
+        hass, controller.schedule_control_cycle, timedelta(seconds=2.0)
     ))
     entry.async_on_unload(unsub_control)
 
@@ -5725,9 +5756,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # timer above stays as a watchdog (runs the time-based subsystems and forces
     # a safety recalculation if the sensor goes silent). Overlapping triggers
     # are serialized by the controller's _control_lock.
-    async def _on_consumption_changed(event):
+    @callback
+    def _on_consumption_changed(event):
         # Do not forward the Event as `now`; the handler expects datetime|None.
-        await controller.async_update_charge_discharge()
+        controller.schedule_control_cycle()
 
     unsub_consumption = _call_once(async_track_state_change_event(
         hass, [controller.consumption_sensor], _on_consumption_changed

--- a/custom_components/omnibattery/manifest.json
+++ b/custom_components/omnibattery/manifest.json
@@ -22,7 +22,7 @@
     "pymodbus>=3.8.0",
     "pyserial>=3.5"
   ],
-  "version": "1.0.1b2",
+  "version": "1.0.1b3",
   "zeroconf": [
     "_modbus._tcp.local."
   ]

--- a/tests/test_control_cycle_scheduling.py
+++ b/tests/test_control_cycle_scheduling.py
@@ -1,0 +1,51 @@
+"""Control cycles must launch as config-entry background tasks.
+
+Timer/state-change trackers run their callbacks as HA-tracked tasks, and HA
+startup waits for tracked tasks. A cycle stuck in Modbus retries against a slow
+gateway blocked the whole bootstrap ("Something is blocking Home Assistant...")
+and delayed every integration set up after this one. Background tasks are
+exempt from the startup gate; entry unload still cancels them.
+
+Exercised unbound with light stubs (same pattern as test_no_pd_tracking).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.omnibattery import ChargeDischargeController
+
+
+def _stub_controller(calls):
+    def _bg(hass, coro, name):
+        calls.append((hass, coro, name))
+        coro.close()  # never awaited in this test
+
+    async def _cycle(now=None):
+        pass
+
+    return SimpleNamespace(
+        hass=object(),
+        config_entry=SimpleNamespace(async_create_background_task=_bg),
+        async_update_charge_discharge=_cycle,
+        _run_no_pd_debounced_cycle=_cycle,
+        _no_pd_debounce_unsub=object(),
+    )
+
+
+def test_schedule_control_cycle_launches_background_task():
+    calls = []
+    ctl = _stub_controller(calls)
+    ChargeDischargeController.schedule_control_cycle(ctl, now=None)
+    assert len(calls) == 1
+    hass, _coro, name = calls[0]
+    assert hass is ctl.hass
+    assert name == "omnibattery_control_cycle"
+
+
+def test_no_pd_debounce_fire_launches_background_task():
+    calls = []
+    ctl = _stub_controller(calls)
+    ChargeDischargeController._fire_no_pd_debounced_run(ctl, None)
+    assert ctl._no_pd_debounce_unsub is None
+    assert len(calls) == 1
+    assert calls[0][2] == "omnibattery_no_pd_cycle"


### PR DESCRIPTION
Timer and state-change callbacks ran the control cycle as HA-tracked tasks, so a cycle stuck in Modbus retries against a slow gateway could delay the whole startup. Fire them via async_create_background_task instead, which is exempt from the startup gate but still cancelled on entry unload.