### PR TITLE
fix: rework queued Modbus gateway compatibility to kill tid mismatch flood (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.1b4] - 2026-07-18
+
+### Fixed
+- **Queued Modbus gateway compatibility reworked** (#77): the opt-in now sends each request once with a widened response window and no transaction-ID resend at any layer (both the transport and the control-loop retry send once), and re-asserts the setpoint each control cycle so a dropped write self-heals like the legacy MVEM path — fixing the transaction-ID mismatch flood on shared TCP-to-RTU gateways.
+
 ## [1.0.1b3] - 2026-07-18
 
 ### Fixed

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -3261,7 +3261,15 @@ class ChargeDischargeController:
         # drops and we fall through to a real write so the tracker keeps seeing it.
         data = coordinator.data or {}
         current_net = coordinator.driver.net_power_from_data(data)
-        if not force_write and current_net is not None and current_net == net_power:
+        # Queued-gateway mode re-asserts the setpoint every cycle (skip disabled)
+        # so a dropped write on a lossy queueing gateway self-heals next cycle the
+        # way the legacy MVEM path did; skip-if-unchanged would starve it (#77).
+        if (
+            not force_write
+            and not coordinator.queued_gateway_compatibility
+            and current_net is not None
+            and current_net == net_power
+        ):
             skip_write = True
             if net_power == 0:
                 # Commanded idle but the battery is actually discharging means it
@@ -3379,16 +3387,21 @@ class ChargeDischargeController:
         # Attempt the setpoint + verify, with one retry on failure.
         # last_fail_reason carries the most specific failure category seen across
         # both attempts so the non-responsive tracker can surface *why*.
+        # Queued-gateway mode uses a single attempt: an immediate resend re-issues
+        # the write under fresh transaction IDs and re-creates the orphan late-reply
+        # mismatch the transport layer avoids (#77). Recovery is left to the next
+        # control cycle, which re-asserts because skip-if-unchanged is disabled here.
         last_fail_reason: str | None = None
-        for attempt in range(2):
+        max_attempts = 1 if coordinator.queued_gateway_compatibility else 2
+        for attempt in range(max_attempts):
             result = await coordinator.apply_power(net_power, read_back=read_back)
 
             if not result.ok:
                 last_fail_reason = result.failure_reason or "comm_failure"
                 if not coordinator._is_shutting_down:
                     _LOGGER.warning(
-                        "[%s] Power write/feedback failed (attempt %d/2, reason=%s)",
-                        coordinator.name, attempt + 1, last_fail_reason
+                        "[%s] Power write/feedback failed (attempt %d/%d, reason=%s)",
+                        coordinator.name, attempt + 1, max_attempts, last_fail_reason
                     )
                 continue
 
@@ -3458,7 +3471,7 @@ class ChargeDischargeController:
             # Readback happened but the set-points did not match (mismatch), or the
             # confirmation read never followed (feedback_timeout). Both retryable.
             last_fail_reason = result.failure_reason or "ack_mismatch"
-            if attempt == 0:
+            if attempt + 1 < max_attempts:
                 # On a driver whose readback lags the write (Zendure HTTP echoes the
                 # previous limit for ~2 s), a first-attempt mismatch is expected
                 # echo/engage latency that the retry resolves — log it at debug, not
@@ -3498,9 +3511,9 @@ class ChargeDischargeController:
                 coordinator, last_fail_reason or "comm_failure"
             )
             _LOGGER.error(
-                "[%s] Power command failed after 2 attempts (reason=%s). "
+                "[%s] Power command failed after %d attempt(s) (reason=%s). "
                 "Battery may not have received command.",
-                coordinator.name, last_fail_reason or "comm_failure"
+                coordinator.name, max_attempts, last_fail_reason or "comm_failure"
             )
         return False
 

--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -41,9 +41,10 @@ SERIAL_BAUDRATE = 115200
 
 # Experimental per-battery compatibility for queued Modbus TCP-to-RTU
 # gateways. Disabled by default: ordinary v2 connections keep pymodbus's
-# internal same-transaction-id retries. When enabled on v2/TCP, it restores the
-# legacy MVEM route: one send per transaction ID and up to three wrapper attempts
-# with a new transaction ID after a failed response.
+# internal same-transaction-id retries. When enabled on v2/TCP, each request is
+# sent once with a widened response window (no resend under a new transaction id,
+# which orphaned late gateway replies) and the control loop re-asserts the
+# setpoint every cycle so a dropped write self-heals (issue #77).
 CONF_QUEUED_GATEWAY_COMPATIBILITY = "queued_gateway_compatibility"
 
 # Maximum power (W) per battery version — used by config_flow to set slider limits

--- a/custom_components/omnibattery/drivers/marstek.py
+++ b/custom_components/omnibattery/drivers/marstek.py
@@ -274,6 +274,11 @@ class MarstekModbusDriver(BatteryDriver):
     def capabilities(self) -> DriverCapabilities:
         return self._capabilities
 
+    @property
+    def queued_gateway_compatibility(self) -> bool:
+        """Whether the transport client runs in narrowed queued-gateway mode."""
+        return self._client.queued_gateway_compatibility
+
     _MODEL_LABELS: dict[str, str] = {
         "v2": "Venus E v2",
         "v3": "Venus E v3",

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -258,6 +258,16 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 queued_gateway_compatibility=queued_gateway_compatibility,
             )
 
+        # Effective queued-gateway mode (mirrors the transport client's own
+        # narrowing: Marstek Modbus TCP only — v3-family and serial are excluded;
+        # non-Marstek drivers expose no such flag). Drives the control loop's
+        # re-assert-every-cycle so a dropped write on a lossy queueing gateway
+        # self-heals like the legacy MVEM path instead of skip-if-unchanged
+        # starving it (issue #77).
+        self.queued_gateway_compatibility = bool(
+            getattr(self.driver, "queued_gateway_compatibility", False)
+        )
+
         # Fast key -> definition lookup so the poll loop can scale each raw value by
         # its definition's scale/precision/state_class. The driver returns raw
         # decoded telemetry and owns the register layout / block grouping (see

--- a/custom_components/omnibattery/infra/modbus_client.py
+++ b/custom_components/omnibattery/infra/modbus_client.py
@@ -21,7 +21,11 @@ _LOGGER = logging.getLogger(__name__)
 # the same transaction_id, so late replies still match the outstanding request.
 _PYMODBUS_RETRIES = 2
 _STANDARD_WRAPPER_ATTEMPTS = 1
-_MVEM_WRAPPER_ATTEMPTS = 3
+# Queued-gateway mode sends once but keeps the full standard response window
+# open, so a slow gateway reply completes the pending request instead of
+# arriving under a new transaction id as an orphan PDU (the tid-mismatch flood,
+# issue #77).
+_RESPONSE_WINDOW_ATTEMPTS = _PYMODBUS_RETRIES + 1
 
 
 def _backoff_jitter(delay: float) -> float:
@@ -144,11 +148,11 @@ class MarstekModbusClient:
                 When set, communication uses Modbus RTU over serial instead of
                 TCP and ``host``/``port`` are ignored for the link (discussion
                 #350). None = Modbus TCP (default, unchanged behaviour).
-            queued_gateway_compatibility (bool): Experimental v2/TCP mode that
-                restores MVEM's legacy retry path: each transaction is sent once
-                and a failed attempt is retried as a new transaction. Intended
-                for gateways that queue same-ID resends as independent RTU
-                requests.
+            queued_gateway_compatibility (bool): Experimental v2/TCP mode for
+                gateways that queue requests and reply late. Each transaction is
+                sent once (no resend under a new transaction id) with a widened
+                response window, so a slow reply completes the pending request
+                instead of arriving as an orphan PDU (issue #77).
         """
         self.host = host
         self.port = port
@@ -173,17 +177,20 @@ class MarstekModbusClient:
         self._pymodbus_retries = (
             0 if self._queued_gateway_compatibility else _PYMODBUS_RETRIES
         )
-        # MVEM used three wrapper attempts. Preserve that proven gateway path
-        # deliberately: pymodbus sends once per transaction, while a timeout,
-        # short read or other communication failure starts a new transaction ID.
-        # Standard clients keep one wrapper attempt because their retries live
-        # inside pymodbus and reuse the same transaction ID.
-        self._wrapper_attempts = (
-            _MVEM_WRAPPER_ATTEMPTS
+        # Both paths use a single wrapper attempt. Standard clients retry inside
+        # pymodbus (same transaction id since 3.8). The queued-gateway opt-in
+        # sends once and never resends under a new transaction id: a re-send
+        # abandons the first tid, and the gateway's late reply then arrives as an
+        # orphan PDU that pymodbus's framer rejects and desyncs on (issue #77).
+        # Instead it widens the response window (below) so even a slow reply lands
+        # within the single attempt; a dropped write self-heals via the control
+        # loop's re-assert-every-cycle (queued mode disables skip-if-unchanged).
+        self._wrapper_attempts = _STANDARD_WRAPPER_ATTEMPTS
+        self._pymodbus_timeout = (
+            timeout * _RESPONSE_WINDOW_ATTEMPTS
             if self._queued_gateway_compatibility
-            else _STANDARD_WRAPPER_ATTEMPTS
+            else timeout
         )
-        self._pymodbus_timeout = timeout
         # Outer safety-net timeout for one request: must cover all pymodbus
         # internal attempts ((retries+1) x per-attempt timeout) plus margin.
         # Cancelling pymodbus mid-transaction orphans an already-sent request,
@@ -216,9 +223,10 @@ class MarstekModbusClient:
         fresh client instances, which avoids pymodbus's internal reconnect_delay
         growing up to 300s. Standard clients retry inside pymodbus (same
         transaction_id since 3.8), so a late reply is consumed by the
-        outstanding request. The experimental queued-gateway mode restores the
-        MVEM path: one wire send per transaction and up to three wrapper attempts,
-        each with a new transaction ID.
+        outstanding request. The experimental queued-gateway mode sends once per
+        transaction with the response window widened, so a slow gateway reply
+        still completes the request instead of orphaning under a new transaction
+        ID (issue #77).
 
         Serial uses RTU framing at a fixed 115200 8N1 — the rate Marstek's RS485
         link runs at (discussion #350); these are hardware-fixed, not tunable.
@@ -255,6 +263,16 @@ class MarstekModbusClient:
     def connected(self) -> bool:
         """Return whether the client is currently connected."""
         return self.client is not None and self.client.connected
+
+    @property
+    def queued_gateway_compatibility(self) -> bool:
+        """Whether the narrowed queued-gateway opt-in is active for this client.
+
+        Reflects the constructor's narrowing (Marstek Modbus TCP only; v3-family
+        and serial RTU are excluded), so callers can mirror the transport policy
+        without re-deriving the guard.
+        """
+        return self._queued_gateway_compatibility
 
     async def async_connect(self) -> bool:
         """
@@ -355,9 +373,10 @@ class MarstekModbusClient:
         failure. Callers decode the words with :func:`decode_registers`.
 
         Standard clients use one wrapper attempt and retry inside pymodbus with
-        the same transaction ID. The queued-gateway opt-in instead restores
-        MVEM's three wrapper attempts with pymodbus retries disabled, so every
-        failed attempt is retried as a new transaction ID.
+        the same transaction ID. The queued-gateway opt-in also uses one wrapper
+        attempt but disables pymodbus's internal retries and widens the response
+        window, so a slow reply completes the single attempt instead of being
+        resent under a new transaction ID (issue #77).
         """
         if not (0 <= register <= 0xFFFF):
             _LOGGER.error(
@@ -524,9 +543,9 @@ class MarstekModbusClient:
         Write a single value to a Modbus holding register asynchronously.
 
         Standard clients use one wrapper attempt and retry inside pymodbus. The
-        queued-gateway opt-in restores MVEM's three wrapper attempts with a new
-        transaction ID per attempt (see ``_read_raw``). Re-sending a
-        single-register write is idempotent.
+        queued-gateway opt-in also sends the write once, disabling pymodbus's
+        internal retries and widening the response window instead of resending
+        under a new transaction ID (see ``_read_raw``, issue #77).
 
         Args:
             register (int): Register address to write to.

--- a/custom_components/omnibattery/manifest.json
+++ b/custom_components/omnibattery/manifest.json
@@ -22,7 +22,7 @@
     "pymodbus>=3.8.0",
     "pyserial>=3.5"
   ],
-  "version": "1.0.1b3",
+  "version": "1.0.1b4",
   "zeroconf": [
     "_modbus._tcp.local."
   ]

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -59,7 +59,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version. Ev2 for older models, Ev3 for newer models with updated register map, A (Venus A) or D (Venus D) for hybrid inverter models",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. For gateways that queue requests and reply late: sends each request once with a wider response window (no resend under a new transaction ID) and re-asserts the setpoint on each control cycle so a dropped write self-heals. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "battery_connection_zendure": {
@@ -460,7 +460,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. For gateways that queue requests and reply late: sends each request once with a wider response window (no resend under a new transaction ID) and re-asserts the setpoint on each control cycle so a dropped write self-heals. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "reconfigure_battery_zendure": {
@@ -592,7 +592,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version. Ev2 for older models, Ev3 for newer models with updated register map, A (Venus A) or D (Venus D) for hybrid inverter models",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. For gateways that queue requests and reply late: sends each request once with a wider response window (no resend under a new transaction ID) and re-asserts the setpoint on each control cycle so a dropped write self-heals. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -59,7 +59,7 @@
           "slave_id": "ID d'esclau/unitat Modbus (per defecte 1). Canvia'l només si un proxy Modbus exposa diverses bateries a una mateixa IP:port amb IDs d'esclau diferents.",
           "battery_version": "Selecciona la versió del model de la teva bateria. Ev2 per a models antics, Ev3 per a models nous amb mapa de registres actualitzat, A (Venus A) o D (Venus D) per a models amb inversor híbrid",
           "serial_port": "Ruta de l'adaptador USB-RS485, p. ex. /dev/ttyUSB0 o COM3. Omple-ho en lloc de l'adreça IP per utilitzar Modbus RTU per sèrie; deixa-ho buit per a TCP.",
-          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Restaura la via de reintents de MVEM: un enviament per ID de transacció i fins a tres intents amb un ID nou després d'una resposta fallida, esgotada o incompleta. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
+          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Per a passarel·les que encuen les peticions i responen amb retard: envia cada petició una sola vegada amb una finestra de resposta més àmplia (sense reenviament amb un ID de transacció nou) i reafirma la consigna a cada cicle de control perquè una escriptura perduda es recuperi sola. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
         }
       },
       "battery_connection_zendure": {
@@ -468,7 +468,7 @@
           "slave_id": "ID d'esclau/unitat Modbus (per defecte 1). Canvia'l només si un proxy Modbus exposa diverses bateries a una mateixa IP:port amb IDs d'esclau diferents.",
           "battery_version": "Selecciona la versió del teu model de bateria",
           "serial_port": "Ruta de l'adaptador USB-RS485, p. ex. /dev/ttyUSB0 o COM3. Omple-ho en lloc de l'adreça IP per utilitzar Modbus RTU per sèrie; deixa-ho buit per a TCP.",
-          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Restaura la via de reintents de MVEM: un enviament per ID de transacció i fins a tres intents amb un ID nou després d'una resposta fallida, esgotada o incompleta. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
+          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Per a passarel·les que encuen les peticions i responen amb retard: envia cada petició una sola vegada amb una finestra de resposta més àmplia (sense reenviament amb un ID de transacció nou) i reafirma la consigna a cada cicle de control perquè una escriptura perduda es recuperi sola. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
         }
       },
       "reconfigure_battery_zendure": {
@@ -601,7 +601,7 @@
           "slave_id": "ID d'esclau/unitat Modbus (per defecte 1). Canvia'l només si un proxy Modbus exposa diverses bateries a una mateixa IP:port amb IDs d'esclau diferents.",
           "battery_version": "Selecciona la versió del model de la teva bateria. Ev2 per a models antics, Ev3 per a models nous amb mapa de registres actualitzat, A (Venus A) o D (Venus D) per a models d'inversor híbrid",
           "serial_port": "Ruta de l'adaptador USB-RS485, p. ex. /dev/ttyUSB0 o COM3. Omple-ho en lloc de l'adreça IP per utilitzar Modbus RTU per sèrie; deixa-ho buit per a TCP.",
-          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Restaura la via de reintents de MVEM: un enviament per ID de transacció i fins a tres intents amb un ID nou després d'una resposta fallida, esgotada o incompleta. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
+          "queued_gateway_compatibility": "Només per a Venus v2 mitjançant Modbus TCP. Per a passarel·les que encuen les peticions i responen amb retard: envia cada petició una sola vegada amb una finestra de resposta més àmplia (sense reenviament amb un ID de transacció nou) i reafirma la consigna a cada cicle de control perquè una escriptura perduda es recuperi sola. Deixa-ho desactivat per a connexions directes, Elfin EW11, RTU sèrie i passarel·les normals."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -59,7 +59,7 @@
           "battery_version": "Wählen Sie die Modellversion Ihrer Batterie. Ev2 für ältere Modelle, Ev3 für neuere Modelle mit aktualisierter Registerkarte, A (Venus A) oder D (Venus D) für Hybrid-Wechselrichter-Modelle",
           "slave_id": "Modbus Slave-/Unit-ID (Standard 1). Nur ändern, wenn ein Modbus-Proxy mehrere Batterien über dieselbe IP:Port mit unterschiedlichen Slave-IDs abbildet.",
           "serial_port": "Pfad des USB-RS485-Adapters, z. B. /dev/ttyUSB0 oder COM3. Statt der IP-Adresse ausfüllen, um Modbus RTU über die serielle Schnittstelle zu nutzen; für TCP leer lassen.",
-          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Stellt den MVEM-Wiederholungspfad wieder her: eine Sendung pro Transaktions-ID und bis zu drei Versuche mit einer neuen ID nach einer fehlgeschlagenen, abgelaufenen oder unvollständigen Antwort. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
+          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Für Gateways, die Anfragen in eine Warteschlange stellen und verzögert antworten: sendet jede Anfrage einmal mit einem größeren Antwortfenster (kein erneutes Senden mit neuer Transaktions-ID) und setzt den Sollwert in jedem Regelzyklus erneut, sodass sich ein verlorener Schreibvorgang selbst behebt. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
         }
       },
       "battery_connection_zendure": {
@@ -468,7 +468,7 @@
           "battery_version": "Wählen Sie Ihre Batteriemodellversion",
           "slave_id": "Modbus Slave-/Unit-ID (Standard 1). Nur ändern, wenn ein Modbus-Proxy mehrere Batterien über dieselbe IP:Port mit unterschiedlichen Slave-IDs abbildet.",
           "serial_port": "Pfad des USB-RS485-Adapters, z. B. /dev/ttyUSB0 oder COM3. Statt der IP-Adresse ausfüllen, um Modbus RTU über die serielle Schnittstelle zu nutzen; für TCP leer lassen.",
-          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Stellt den MVEM-Wiederholungspfad wieder her: eine Sendung pro Transaktions-ID und bis zu drei Versuche mit einer neuen ID nach einer fehlgeschlagenen, abgelaufenen oder unvollständigen Antwort. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
+          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Für Gateways, die Anfragen in eine Warteschlange stellen und verzögert antworten: sendet jede Anfrage einmal mit einem größeren Antwortfenster (kein erneutes Senden mit neuer Transaktions-ID) und setzt den Sollwert in jedem Regelzyklus erneut, sodass sich ein verlorener Schreibvorgang selbst behebt. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
         }
       },
       "reconfigure_battery_zendure": {
@@ -601,7 +601,7 @@
           "battery_version": "Wählen Sie die Modellversion Ihrer Batterie. Ev2 für ältere Modelle, Ev3 für neuere Modelle mit aktualisierter Registerkarte, A (Venus A) oder D (Venus D) für Hybrid-Wechselrichter-Modelle",
           "slave_id": "Modbus Slave-/Unit-ID (Standard 1). Nur ändern, wenn ein Modbus-Proxy mehrere Batterien über dieselbe IP:Port mit unterschiedlichen Slave-IDs abbildet.",
           "serial_port": "Pfad des USB-RS485-Adapters, z. B. /dev/ttyUSB0 oder COM3. Statt der IP-Adresse ausfüllen, um Modbus RTU über die serielle Schnittstelle zu nutzen; für TCP leer lassen.",
-          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Stellt den MVEM-Wiederholungspfad wieder her: eine Sendung pro Transaktions-ID und bis zu drei Versuche mit einer neuen ID nach einer fehlgeschlagenen, abgelaufenen oder unvollständigen Antwort. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
+          "queued_gateway_compatibility": "Nur für Venus v2 über Modbus TCP. Für Gateways, die Anfragen in eine Warteschlange stellen und verzögert antworten: sendet jede Anfrage einmal mit einem größeren Antwortfenster (kein erneutes Senden mit neuer Transaktions-ID) und setzt den Sollwert in jedem Regelzyklus erneut, sodass sich ein verlorener Schreibvorgang selbst behebt. Für Direktverbindungen, Elfin EW11, serielles RTU und normale Gateways deaktiviert lassen."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -59,7 +59,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version. Ev2 for older models, Ev3 for newer models with updated register map, A (Venus A) or D (Venus D) for hybrid inverter models",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. For gateways that queue requests and reply late: sends each request once with a wider response window (no resend under a new transaction ID) and re-asserts the setpoint on each control cycle so a dropped write self-heals. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "battery_connection_zendure": {
@@ -462,7 +462,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. For gateways that queue requests and reply late: sends each request once with a wider response window (no resend under a new transaction ID) and re-asserts the setpoint on each control cycle so a dropped write self-heals. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "reconfigure_battery_zendure": {
@@ -595,7 +595,7 @@
           "slave_id": "Modbus slave/unit id (default 1). Change only when a Modbus proxy maps several batteries to one IP:port using distinct slave ids.",
           "battery_version": "Select your battery model version. Ev2 for older models, Ev3 for newer models with updated register map, A (Venus A) or D (Venus D) for hybrid inverter models",
           "serial_port": "USB-RS485 adapter path, e.g. /dev/ttyUSB0 or COM3. Fill this instead of the IP address to use Modbus RTU over serial; leave empty for TCP.",
-          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. Restores MVEM's retry path: one send per transaction ID and up to three attempts with a fresh ID after a failed, timed-out or incomplete response. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
+          "queued_gateway_compatibility": "For Venus v2 over Modbus TCP only. For gateways that queue requests and reply late: sends each request once with a wider response window (no resend under a new transaction ID) and re-asserts the setpoint on each control cycle so a dropped write self-heals. Leave disabled for direct connections, Elfin EW11, serial RTU and normal gateways."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -59,7 +59,7 @@
           "slave_id": "ID de esclavo/unidad Modbus (por defecto 1). Cámbialo solo si un proxy Modbus expone varias baterías en una misma IP:puerto con ids de esclavo distintos.",
           "battery_version": "Selecciona la versión del modelo de tu batería. Ev2 para modelos antiguos, Ev3 para modelos nuevos con mapa de registros actualizado, A (Venus A) o D (Venus D) para modelos de inversor híbrido",
           "serial_port": "Ruta del adaptador USB-RS485, p. ej. /dev/ttyUSB0 o COM3. Complétalo en lugar de la dirección IP para usar Modbus RTU por serie; déjalo vacío para TCP.",
-          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Restaura la vía de reintentos de MVEM: un envío por ID de transacción y hasta tres intentos con un ID nuevo tras una respuesta fallida, agotada o incompleta. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
+          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Para gateways que encolan peticiones y responden con retraso: envía cada petición una sola vez con una ventana de respuesta más amplia (sin reenvío con un ID de transacción nuevo) y reafirma la consigna en cada ciclo de control para que una escritura perdida se recupere sola. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
         }
       },
       "battery_connection_zendure": {
@@ -468,7 +468,7 @@
           "slave_id": "ID de esclavo/unidad Modbus (por defecto 1). Cámbialo solo si un proxy Modbus expone varias baterías en una misma IP:puerto con ids de esclavo distintos.",
           "battery_version": "Selecciona la versión de tu modelo de batería",
           "serial_port": "Ruta del adaptador USB-RS485, p. ej. /dev/ttyUSB0 o COM3. Complétalo en lugar de la dirección IP para usar Modbus RTU por serie; déjalo vacío para TCP.",
-          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Restaura la vía de reintentos de MVEM: un envío por ID de transacción y hasta tres intentos con un ID nuevo tras una respuesta fallida, agotada o incompleta. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
+          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Para gateways que encolan peticiones y responden con retraso: envía cada petición una sola vez con una ventana de respuesta más amplia (sin reenvío con un ID de transacción nuevo) y reafirma la consigna en cada ciclo de control para que una escritura perdida se recupere sola. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
         }
       },
       "reconfigure_battery_zendure": {
@@ -601,7 +601,7 @@
           "slave_id": "ID de esclavo/unidad Modbus (por defecto 1). Cámbialo solo si un proxy Modbus expone varias baterías en una misma IP:puerto con ids de esclavo distintos.",
           "battery_version": "Selecciona la versión del modelo de tu batería. Ev2 para modelos antiguos, Ev3 para modelos nuevos con mapa de registros actualizado, A (Venus A) o D (Venus D) para modelos de inversor híbrido",
           "serial_port": "Ruta del adaptador USB-RS485, p. ej. /dev/ttyUSB0 o COM3. Complétalo en lugar de la dirección IP para usar Modbus RTU por serie; déjalo vacío para TCP.",
-          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Restaura la vía de reintentos de MVEM: un envío por ID de transacción y hasta tres intentos con un ID nuevo tras una respuesta fallida, agotada o incompleta. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
+          "queued_gateway_compatibility": "Solo para Venus v2 mediante Modbus TCP. Para gateways que encolan peticiones y responden con retraso: envía cada petición una sola vez con una ventana de respuesta más amplia (sin reenvío con un ID de transacción nuevo) y reafirma la consigna en cada ciclo de control para que una escritura perdida se recupere sola. Déjalo desactivado para conexiones directas, Elfin EW11, RTU serie y gateways normales."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -59,7 +59,7 @@
           "battery_version": "Sélectionnez la version du modèle de votre batterie. Ev2 pour les anciens modèles, Ev3 pour les nouveaux modèles avec cartographie mise à jour, A (Venus A) ou D (Venus D) pour les onduleurs hybrides",
           "slave_id": "ID d'esclave/unité Modbus (par défaut 1). À modifier uniquement lorsqu'un proxy Modbus expose plusieurs batteries sur une même IP:port avec des ID d'esclave distincts.",
           "serial_port": "Chemin de l'adaptateur USB-RS485, p. ex. /dev/ttyUSB0 ou COM3. Renseignez-le à la place de l'adresse IP pour utiliser Modbus RTU en série ; laissez vide pour le TCP.",
-          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Restaure la voie de nouvelle tentative de MVEM : un envoi par identifiant de transaction et jusqu'à trois tentatives avec un nouvel identifiant après une réponse échouée, expirée ou incomplète. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
+          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Pour les passerelles qui mettent les requêtes en file d'attente et répondent tardivement : envoie chaque requête une seule fois avec une fenêtre de réponse élargie (pas de renvoi avec un nouvel identifiant de transaction) et réaffirme la consigne à chaque cycle de contrôle afin qu'une écriture perdue se rétablisse d'elle-même. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
         }
       },
       "battery_connection_zendure": {
@@ -468,7 +468,7 @@
           "battery_version": "Sélectionnez la version de votre modèle de batterie",
           "slave_id": "ID d'esclave/unité Modbus (par défaut 1). À modifier uniquement lorsqu'un proxy Modbus expose plusieurs batteries sur une même IP:port avec des ID d'esclave distincts.",
           "serial_port": "Chemin de l'adaptateur USB-RS485, p. ex. /dev/ttyUSB0 ou COM3. Renseignez-le à la place de l'adresse IP pour utiliser Modbus RTU en série ; laissez vide pour le TCP.",
-          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Restaure la voie de nouvelle tentative de MVEM : un envoi par identifiant de transaction et jusqu'à trois tentatives avec un nouvel identifiant après une réponse échouée, expirée ou incomplète. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
+          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Pour les passerelles qui mettent les requêtes en file d'attente et répondent tardivement : envoie chaque requête une seule fois avec une fenêtre de réponse élargie (pas de renvoi avec un nouvel identifiant de transaction) et réaffirme la consigne à chaque cycle de contrôle afin qu'une écriture perdue se rétablisse d'elle-même. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
         }
       },
       "reconfigure_battery_zendure": {
@@ -601,7 +601,7 @@
           "battery_version": "Sélectionnez la version du modèle de votre batterie. Ev2 pour les anciens modèles, Ev3 pour les nouveaux modèles avec cartographie mise à jour, A (Venus A) ou D (Venus D) pour les onduleurs hybrides",
           "slave_id": "ID d'esclave/unité Modbus (par défaut 1). À modifier uniquement lorsqu'un proxy Modbus expose plusieurs batteries sur une même IP:port avec des ID d'esclave distincts.",
           "serial_port": "Chemin de l'adaptateur USB-RS485, p. ex. /dev/ttyUSB0 ou COM3. Renseignez-le à la place de l'adresse IP pour utiliser Modbus RTU en série ; laissez vide pour le TCP.",
-          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Restaure la voie de nouvelle tentative de MVEM : un envoi par identifiant de transaction et jusqu'à trois tentatives avec un nouvel identifiant après une réponse échouée, expirée ou incomplète. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
+          "queued_gateway_compatibility": "Uniquement pour Venus v2 via Modbus TCP. Pour les passerelles qui mettent les requêtes en file d'attente et répondent tardivement : envoie chaque requête une seule fois avec une fenêtre de réponse élargie (pas de renvoi avec un nouvel identifiant de transaction) et réaffirme la consigne à chaque cycle de contrôle afin qu'une écriture perdue se rétablisse d'elle-même. Laissez désactivé pour les connexions directes, Elfin EW11, RTU série et les passerelles normales."
         }
       },
       "battery_connection_zendure": {

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -59,7 +59,7 @@
           "battery_version": "Selecteer de modelversie van uw batterij. Ev2 voor oudere modellen, Ev3 voor nieuwere modellen met bijgewerkte registerkaart, A (Venus A) of D (Venus D) voor hybride omvormermodellen",
           "slave_id": "Modbus slave-/unit-id (standaard 1). Wijzig dit alleen wanneer een Modbus-proxy meerdere batterijen op één IP:poort koppelt met verschillende slave-id's.",
           "serial_port": "Pad van de USB-RS485-adapter, bijv. /dev/ttyUSB0 of COM3. Vul dit in plaats van het IP-adres in om Modbus RTU via serieel te gebruiken; laat leeg voor TCP.",
-          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Herstelt de MVEM-route voor nieuwe pogingen: één verzending per transactie-ID en maximaal drie pogingen met een nieuwe ID na een mislukt, verlopen of onvolledig antwoord. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
+          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Voor gateways die verzoeken in een wachtrij plaatsen en vertraagd antwoorden: verzendt elk verzoek één keer met een breder antwoordvenster (geen nieuwe verzending met een nieuw transactie-ID) en herbevestigt het instelpunt bij elke regelcyclus zodat een verloren schrijfopdracht zichzelf herstelt. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
         }
       },
       "battery_connection_zendure": {
@@ -468,7 +468,7 @@
           "battery_version": "Selecteer uw batterijmodelversie",
           "slave_id": "Modbus slave-/unit-id (standaard 1). Wijzig dit alleen wanneer een Modbus-proxy meerdere batterijen op één IP:poort koppelt met verschillende slave-id's.",
           "serial_port": "Pad van de USB-RS485-adapter, bijv. /dev/ttyUSB0 of COM3. Vul dit in plaats van het IP-adres in om Modbus RTU via serieel te gebruiken; laat leeg voor TCP.",
-          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Herstelt de MVEM-route voor nieuwe pogingen: één verzending per transactie-ID en maximaal drie pogingen met een nieuwe ID na een mislukt, verlopen of onvolledig antwoord. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
+          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Voor gateways die verzoeken in een wachtrij plaatsen en vertraagd antwoorden: verzendt elk verzoek één keer met een breder antwoordvenster (geen nieuwe verzending met een nieuw transactie-ID) en herbevestigt het instelpunt bij elke regelcyclus zodat een verloren schrijfopdracht zichzelf herstelt. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
         }
       },
       "reconfigure_battery_zendure": {
@@ -601,7 +601,7 @@
           "battery_version": "Selecteer de modelversie van uw batterij. Ev2 voor oudere modellen, Ev3 voor nieuwere modellen met bijgewerkte registerkaart, A (Venus A) of D (Venus D) voor hybride omvormermodellen",
           "slave_id": "Modbus slave-/unit-id (standaard 1). Wijzig dit alleen wanneer een Modbus-proxy meerdere batterijen op één IP:poort koppelt met verschillende slave-id's.",
           "serial_port": "Pad van de USB-RS485-adapter, bijv. /dev/ttyUSB0 of COM3. Vul dit in plaats van het IP-adres in om Modbus RTU via serieel te gebruiken; laat leeg voor TCP.",
-          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Herstelt de MVEM-route voor nieuwe pogingen: één verzending per transactie-ID en maximaal drie pogingen met een nieuwe ID na een mislukt, verlopen of onvolledig antwoord. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
+          "queued_gateway_compatibility": "Alleen voor Venus v2 via Modbus TCP. Voor gateways die verzoeken in een wachtrij plaatsen en vertraagd antwoorden: verzendt elk verzoek één keer met een breder antwoordvenster (geen nieuwe verzending met een nieuw transactie-ID) en herbevestigt het instelpunt bij elke regelcyclus zodat een verloren schrijfopdracht zichzelf herstelt. Laat uitgeschakeld voor directe verbindingen, Elfin EW11, seriële RTU en normale gateways."
         }
       },
       "battery_connection_zendure": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,7 @@ class FakeCoordinator:
         "max_soc": 80,
         "min_soc": 10,
         "commanded_charge_power": 0,
+        "queued_gateway_compatibility": False,
         "rs485_user_disabled": False,
         "balance_hold": False,
         "apply_power": None,

--- a/tests/test_modbus_client.py
+++ b/tests/test_modbus_client.py
@@ -211,8 +211,8 @@ def test_v2_tcp_keeps_standard_retries_by_default():
     assert c._request_timeout == c._timeout * 3 + 2
 
 
-def test_v2_queued_gateway_mode_restores_mvem_retry_profile():
-    """The opt-in sends once per TID and retries through the wrapper."""
+def test_v2_queued_gateway_mode_widens_response_window():
+    """The opt-in sends once per TID with the full response window, no resend."""
     c = _make_client(
         host="192.168.1.50",
         port=502,
@@ -220,12 +220,13 @@ def test_v2_queued_gateway_mode_restores_mvem_retry_profile():
         queued_gateway_compatibility=True,
     )
     assert c._queued_gateway_compatibility is True
+    assert c.queued_gateway_compatibility is True
     assert c._pymodbus_retries == 0
     assert c.client.ctx.retries == 0
-    assert c._wrapper_attempts == 3
-    assert c._pymodbus_timeout == c._timeout
-    assert c.client.ctx.comm_params.timeout_connect == c._timeout
-    assert c._request_timeout == c._timeout + 2
+    assert c._wrapper_attempts == 1
+    assert c._pymodbus_timeout == c._timeout * 3
+    assert c.client.ctx.comm_params.timeout_connect == c._timeout * 3
+    assert c._request_timeout == c._timeout * 3 + 2
 
 
 def test_v3_tcp_keeps_internal_same_tid_retries():
@@ -243,7 +244,7 @@ def test_v3_tcp_keeps_internal_same_tid_retries():
     "is_v3, compatibility, expected_retries, expected_timeout",
     [
         (False, False, 2, 10),
-        (False, True, 0, 10),
+        (False, True, 0, 30),
         (True, True, 2, 10),
     ],
 )

--- a/tests/test_modbus_client_retry.py
+++ b/tests/test_modbus_client_retry.py
@@ -3,10 +3,10 @@
 Exercises ``_read_raw`` and ``async_write_register`` against a scripted fake
 pymodbus client (no hardware, no HA). These pin three deliberate properties:
 the standard profile uses a single wrapper attempt with pymodbus-internal
-same-transaction-ID retries; the queued-gateway opt-in restores MVEM's three
-wrapper attempts with one wire send per transaction ID; and failures do not
-reconnect from inside the loop (the coordinator owns reconnection; reconnecting
-here would storm the v3 single TCP slot, issue #361).
+same-transaction-ID retries; the queued-gateway opt-in also sends once per
+transaction ID (no resend under a new tid, widened response window instead,
+issue #77); and failures do not reconnect from inside the loop (the coordinator
+owns reconnection; reconnecting here would storm the v3 single TCP slot, #361).
 
 ``retry_delay=0`` keeps the backoff sleeps at zero so the tests run instantly.
 """
@@ -92,15 +92,13 @@ def test_read_default_is_single_attempt():
     assert fake.read_calls == 1
 
 
-def test_queued_gateway_default_retries_short_read_via_mvem_wrapper():
-    """The opt-in retries incomplete data as a fresh wrapper transaction."""
-    fake = _FakeClient(
-        read_results=[_Result([1]), _Result([1]), _Result([1, 2])]
-    )
+def test_queued_gateway_single_attempt_no_resend_on_short_read():
+    """The opt-in sends once per TID: a short read is not resent (#77)."""
+    fake = _FakeClient(read_results=[_Result([1])])
     c = _client_with_fake(fake, queued_gateway_compatibility=True)
     regs = asyncio.run(c._read_raw(0x0010, 2, retry_delay=0))
-    assert regs == [1, 2]
-    assert fake.read_calls == 3
+    assert regs is None
+    assert fake.read_calls == 1
 
 
 def test_read_retries_on_connection_error_then_succeeds():
@@ -192,14 +190,12 @@ def test_write_default_is_single_attempt():
     assert fake.write_calls == 1
 
 
-def test_queued_gateway_default_retries_write_via_mvem_wrapper():
-    """The opt-in retries a communication failure with a new transaction."""
-    fake = _FakeClient(
-        write_results=[asyncio.TimeoutError(), _Result(error=False)]
-    )
+def test_queued_gateway_single_attempt_no_resend_on_write_timeout():
+    """The opt-in sends the write once: a timeout is not resent under a new tid (#77)."""
+    fake = _FakeClient(write_results=[asyncio.TimeoutError()])
     c = _client_with_fake(fake, queued_gateway_compatibility=True)
-    assert asyncio.run(c.async_write_register(0x2000, 1, retry_delay=0)) is True
-    assert fake.write_calls == 2
+    assert asyncio.run(c.async_write_register(0x2000, 1, retry_delay=0)) is False
+    assert fake.write_calls == 1
 
 
 def test_write_retries_on_connection_error_then_succeeds():

--- a/tests/test_set_battery_power_skip.py
+++ b/tests/test_set_battery_power_skip.py
@@ -85,6 +85,7 @@ def _controller():
         _idle_commanded_started={},
         _non_responsive=SimpleNamespace(
             record_non_delivery=lambda *a, **k: False,
+            record_comm_failure=lambda *a, **k: None,
             clear=lambda c: None,
             set_wake_attempted=lambda *a, **k: None,
         ),
@@ -245,6 +246,41 @@ async def test_skip_when_charge_unchanged():
 
     assert result is True
     coord.apply_power.assert_not_called()
+
+
+async def test_queued_gateway_reasserts_unchanged_setpoint():
+    """Queued-gateway mode disables skip-if-unchanged: the setpoint is re-written
+    every cycle so a dropped write on a lossy gateway self-heals (#77)."""
+    coord = _Coord({"force_mode": 1, "set_charge_power": 500, "set_discharge_power": 0})
+    coord.queued_gateway_compatibility = True
+    coord.apply_power = AsyncMock(return_value=_ok(500, battery_power_w=500))
+    ctrl = _controller()
+
+    result = await ChargeDischargeController._set_battery_power(ctrl, coord, 500, 0)
+
+    assert result is True
+    coord.apply_power.assert_called_once()
+
+
+async def test_queued_gateway_no_resend_on_failure():
+    """Queued mode sends the write once on failure — no immediate resend under a
+    fresh transaction ID (would orphan late gateway replies); recovery is left to
+    the next control cycle (#77). Standard mode still retries twice."""
+    coord = _Coord({"force_mode": 2, "set_charge_power": 0, "set_discharge_power": 300})
+    coord.queued_gateway_compatibility = True
+    coord._is_shutting_down = False
+    coord.apply_power = AsyncMock(
+        return_value=SetpointResult(
+            ok=False, net_power_w=-300, confirmed=False,
+            failure_reason="feedback_timeout",
+        )
+    )
+    ctrl = _controller()
+
+    result = await ChargeDischargeController._set_battery_power(ctrl, coord, 0, 300)
+
+    assert result is False
+    coord.apply_power.assert_called_once()
 
 
 async def test_no_skip_when_discharge_unchanged_but_not_delivering():


### PR DESCRIPTION
## Problem (#77)

3× Venus E v2 behind one shared Waveshare 4-ch RS485-to-ETH gateway saw a persistent `transaction_id mismatch` flood (tens of thousands of lines) plus batteries losing their commanded state → house falling to grid.

Root cause: the beta **b2** queued-gateway path resent failed transactions under **fresh transaction IDs** — both at the client wrapper (3 attempts) and the control-loop retry (`for attempt in range(2)`). On a slow/queueing gateway the late reply arrives as an orphan PDU that pymodbus's strict framer (≥3.8) rejects and desyncs on. Beta **b1** (single send, wide window) had produced **zero** mismatches, confirming the mechanism.

## Change (three layers)

- **Transport** ([modbus_client.py](../blob/fix/issue-77-queued-gateway-window-reassert/custom_components/omnibattery/infra/modbus_client.py)): restore b1 semantics for the opt-in — single wrapper attempt, pymodbus internal retries disabled, response window widened (`timeout × 3`) so a slow reply completes the pending request instead of orphaning under a new tid.
- **Control** ([__init__.py](../blob/fix/issue-77-queued-gateway-window-reassert/custom_components/omnibattery/__init__.py)): single `apply_power` attempt in queued mode (no immediate resend), and disable skip-if-unchanged so the setpoint is re-asserted when the control loop acts — a dropped write self-heals like the legacy MVEM path instead of leaving the battery uncommanded.
- **Wiring**: effective flag flows client → driver → coordinator; UI strings (strings.json + 6 translations) and the const comment that still described the removed 3-attempt resend are updated; manifest bumped to **1.0.1b4** (b3 already released).

## Tests

`705 passed, 10 skipped`. Updated the transport tests that pinned b2 semantics to b1; added controller-level tests that queued mode (a) re-asserts an unchanged setpoint and (b) does **not** resend on failure.

## Known follow-up (not in this PR)

Unload/teardown can wait up to ~32 s per write on a dead gateway (same worst-case as the long-standing standard v2 path, `timeout × (retries+1) + 2`). Pre-existing/latent; fixing it means cancelling the active control task before `standby()` and bounding the teardown timeout — orthogonal to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)