### PR TITLE
feat: add Anker Solarbank Max AC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 **Omnibattery** is your one stop Home Assistant integration designed to monitor and control pluggable solar batteries, as of today, the following ones are supported:
 
 - Marstek Venus E and C (v2 and v3), Venus D and Venus A via Modbus TCP
-- Zendure Solarflow 2400 AC+, Solarflow 2400 Pro (Local API) 
+- Zendure Solarflow 2400 AC+, Solarflow 2400 Pro (Local API)
+- Anker SOLIX Solarbank Max AC via Modbus TCP
 
 It provides advanced energy management features including predictive grid charging, customizable time slots for discharge control, and device load exclusion logic.
 
@@ -51,8 +52,8 @@ Full documentation (configuration, features, entities, troubleshooting) is avail
 
 | Requirement | Details |
 |---|---|
-| Battery | Marstek Venus E v2/v3, Venus A, Venus D, Zendure Solarflow 2400 AC+, Solarflow 2400 Pro |
-| Modbus bridge | Elfin-EW11 or compatible RS485-to-TCP converter. Venus E v3, Venus A and Venus D can also be connected via Ethernet with native Modbus TCP support. |
+| Battery | Marstek Venus E v2/v3, Venus A, Venus D, Zendure Solarflow 2400 AC+, Solarflow 2400 Pro, Anker SOLIX Solarbank Max AC |
+| Modbus bridge | Elfin-EW11 or compatible RS485-to-TCP converter. Venus E v3, Venus A and Venus D can also be connected via Ethernet with native Modbus TCP support. Anker Solarbank Max AC uses native Modbus TCP (enable in the Anker app under Third-Party Control; only one Modbus client at a time). |
 | Wireless connection | Required for Zendure Solarflow 2400 AC+ and Solarflow 2400 Pro |
 | Grid sensor | HA sensor measuring total grid consumption (e.g. Shelly EM3, Neurio, smart meter) |
 | Network | Battery reachable by IP from Home Assistant |

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -5571,6 +5571,11 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _device_owns_initial_config(brand: str) -> bool:
+    """Return whether setup must preserve configuration stored by the device."""
+    return brand == "zendure"
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Omnibattery from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -5748,7 +5753,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 # device-set values on every restart and re-arm the full-charge
                 # taper/hysteresis machinery. The device is the source of truth and
                 # the coordinator syncs soc_set/min_soc back from the poll.
-                if coordinator.needs_software_manual_control:
+                if _device_owns_initial_config(coordinator.brand):
                     _LOGGER.info("Skipping initial SOC config write for %s (registerless driver; device flash holds the user values)",
                                battery_config[CONF_NAME])
                 else:

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -3438,21 +3438,21 @@ class ChargeDischargeController:
                         )
                 actual_power = result.battery_power_w
                 _LOGGER.debug(
-                    "[%s] Power ACK: force=%d charge=%dW discharge=%dW battery=%dW",
+                    "[%s] Power ACK: force=%d charge=%dW discharge=%dW battery=%sW",
                     coordinator.name,
                     expected_force_mode,
                     int(charge_power),
                     int(discharge_power),
                     actual_power,
                 )
-                if charge_power > 0:
+                if charge_power > 0 and actual_power is not None:
                     self._log_low_power_delivery(
                         coordinator,
                         command="charge",
                         commanded_power=charge_power,
                         actual_power=actual_power,
                     )
-                elif discharge_power > 0:
+                elif discharge_power > 0 and actual_power is not None:
                     self._log_low_power_delivery(
                         coordinator,
                         command="discharge",
@@ -3462,7 +3462,13 @@ class ChargeDischargeController:
                 # Detect non-responsive battery: ACK ok but not delivering discharge
                 # power. Register drivers reach this only on a readback cycle; slow
                 # actuators run the same judgment at poll time (see skip-write block).
-                if discharge_power >= 100 and charge_power == 0:
+                # Skip when delivered power is unknown (e.g. Anker write ACK without
+                # a successful battery_power sample).
+                if (
+                    discharge_power >= 100
+                    and charge_power == 0
+                    and actual_power is not None
+                ):
                     await self._check_non_delivery(
                         coordinator, discharge_power, actual_power, attempt=attempt,
                     )

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -5592,6 +5592,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator.user_max_charge_power = battery_config.get(
             "user_max_charge_power", coordinator.max_charge_power
         )
+        coordinator.user_max_discharge_power = battery_config.get(
+            "user_max_discharge_power", coordinator.max_discharge_power
+        )
         coordinator.active_balance_mode_started_ts = battery_config.get("active_balance_mode_started_ts")
         coordinator.active_balance_mode_run_date = battery_config.get("active_balance_mode_run_date")
         coordinator.active_balance_mode_phase = battery_config.get("active_balance_mode_phase")

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -498,7 +498,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             result, _ = await ZendureLocalDriver.probe(host, port)
         elif brand == "anker":
             _LOGGER.info("Probing Anker Solarbank at %s:%s slave %s", host, port, slave_id)
-            result = await AnkerModbusDriver.probe(host, port, slave_id)
+            result, _ = await AnkerModbusDriver.probe(host, port, slave_id)
         elif serial_port:
             _LOGGER.info("Probing Marstek %s over serial %s slave %s", version, serial_port, slave_id)
             result = await MarstekModbusDriver.probe(
@@ -853,7 +853,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             host = user_input[CONF_HOST]
             port = int(user_input.get(CONF_PORT, 502))
             slave_id = int(user_input.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID))
-            ok = await AnkerModbusDriver.probe(host, port, slave_id)
+            ok, caps = await AnkerModbusDriver.probe(host, port, slave_id)
             if not ok:
                 errors["base"] = "cannot_connect"
             else:
@@ -864,6 +864,10 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                     CONF_SLAVE_ID: slave_id,
                     "brand": "anker",
                 })
+                if "max_charge_power" in caps:
+                    self._current_battery_data["max_charge_power"] = caps["max_charge_power"]
+                if "max_discharge_power" in caps:
+                    self._current_battery_data["max_discharge_power"] = caps["max_discharge_power"]
                 return await self.async_step_battery_limits()
 
         return self.async_show_form(
@@ -930,10 +934,19 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 return await self.async_step_time_slots()
             return await self.async_step_battery_brand()
 
+        # Anker: prefer power caps read during probe (10036/10038).
+        default_charge = max(
+            100,
+            min(max_power, int(self._current_battery_data.get("max_charge_power", max_power))),
+        )
+        default_discharge = max(
+            100,
+            min(max_power, int(self._current_battery_data.get("max_discharge_power", max_power))),
+        )
         _schema: dict = {
-            vol.Required("max_charge_power", default=max_power):
+            vol.Required("max_charge_power", default=default_charge):
                 NumberSelector(NumberSelectorConfig(min=100, max=max_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
-            vol.Required("max_discharge_power", default=max_power):
+            vol.Required("max_discharge_power", default=default_discharge):
                 NumberSelector(NumberSelectorConfig(min=100, max=max_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
             vol.Required("max_soc", default=100):
                 NumberSelector(NumberSelectorConfig(min=80, max=100, step=1, mode=NumberSelectorMode.SLIDER)),
@@ -1839,7 +1852,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             new_host = user_input[CONF_HOST]
             new_port = int(user_input.get(CONF_PORT, 502))
             slave_id = int(user_input.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID))
-            ok = await AnkerModbusDriver.probe(new_host, new_port, slave_id)
+            ok, _ = await AnkerModbusDriver.probe(new_host, new_port, slave_id)
             if not ok:
                 errors["base"] = "cannot_connect"
             else:
@@ -1934,7 +1947,8 @@ class OptionsFlowHandler(OptionsFlow):
 
         if brand == "anker":
             _LOGGER.info("Probing Anker Solarbank at %s:%s slave %s", host, port, slave_id)
-            return await AnkerModbusDriver.probe(host, port, slave_id)
+            ok, _ = await AnkerModbusDriver.probe(host, port, slave_id)
+            return ok
 
         # Marstek: handle single-connection-slot constraint.
         entry_data = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id, {})
@@ -2364,7 +2378,7 @@ class OptionsFlowHandler(OptionsFlow):
                 host = user_input[CONF_HOST]
                 port = int(user_input.get(CONF_PORT, 502))
                 slave_id = int(user_input.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID))
-                ok = await AnkerModbusDriver.probe(host, port, slave_id)
+                ok, caps = await AnkerModbusDriver.probe(host, port, slave_id)
                 if not ok:
                     errors["base"] = "cannot_connect"
                 else:
@@ -2375,6 +2389,10 @@ class OptionsFlowHandler(OptionsFlow):
                         CONF_SLAVE_ID: slave_id,
                         "brand": "anker",
                     })
+                    if "max_charge_power" in caps:
+                        self._current_battery_data["max_charge_power"] = caps["max_charge_power"]
+                    if "max_discharge_power" in caps:
+                        self._current_battery_data["max_discharge_power"] = caps["max_discharge_power"]
                     return await self.async_step_battery_limits()
 
             if self.battery_index < len(current_batteries):
@@ -2486,8 +2504,20 @@ class OptionsFlowHandler(OptionsFlow):
                 }
             else:
                 defaults = {
-                    "max_charge_power": max_power,
-                    "max_discharge_power": max_power,
+                    "max_charge_power": max(
+                        100,
+                        min(
+                            max_power,
+                            int(self._current_battery_data.get("max_charge_power", max_power)),
+                        ),
+                    ),
+                    "max_discharge_power": max(
+                        100,
+                        min(
+                            max_power,
+                            int(self._current_battery_data.get("max_discharge_power", max_power)),
+                        ),
+                    ),
                     "max_soc": 100,
                     "min_soc": 10 if brand == "anker" else 12,
                     "charge_hysteresis_percent": DEFAULT_CHARGE_HYSTERESIS_PERCENT,

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -103,8 +103,10 @@ from .const import (
 from .drivers.esphome import EsphomeEntityDriver
 from .drivers.marstek import MarstekModbusDriver
 from .drivers.zendure import ZendureLocalDriver, detect_model as _detect_zendure_model
+from .drivers.anker import AnkerModbusDriver
 
 _ZENDURE_MAX_POWER_W = 2400
+_ANKER_MAX_POWER_W = 3500
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -494,6 +496,9 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         if brand == "zendure":
             _LOGGER.info("Probing Zendure device at %s:%s", host, port)
             result, _ = await ZendureLocalDriver.probe(host, port)
+        elif brand == "anker":
+            _LOGGER.info("Probing Anker Solarbank at %s:%s slave %s", host, port, slave_id)
+            result = await AnkerModbusDriver.probe(host, port, slave_id)
         elif serial_port:
             _LOGGER.info("Probing Marstek %s over serial %s slave %s", version, serial_port, slave_id)
             result = await MarstekModbusDriver.probe(
@@ -657,6 +662,8 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 return await self.async_step_battery_connection_zendure()
             if brand == "esphome":
                 return await self.async_step_battery_connection_esphome()
+            if brand == "anker":
+                return await self.async_step_battery_connection_anker()
             return await self.async_step_battery_connection()
 
         return self.async_show_form(
@@ -669,6 +676,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                                 {"value": "marstek", "label": "Marstek Venus"},
                                 {"value": "zendure", "label": "Zendure SolarFlow"},
                                 {"value": "esphome", "label": "Marstek via LilyGo RS485 (ESPHome)"},
+                                {"value": "anker", "label": "Anker SOLIX Solarbank Max AC"},
                             ],
                             mode=SelectSelectorMode.DROPDOWN,
                         )),
@@ -833,6 +841,46 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             description_placeholders=placeholders,
         )
 
+
+    async def async_step_battery_connection_anker(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 3b (Anker): Connection details for Solarbank Max AC."""
+        errors = {}
+        battery_num = self.battery_index + 1
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            port = int(user_input.get(CONF_PORT, 502))
+            slave_id = int(user_input.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID))
+            ok = await AnkerModbusDriver.probe(host, port, slave_id)
+            if not ok:
+                errors["base"] = "cannot_connect"
+            else:
+                self._current_battery_data.update({
+                    CONF_NAME: user_input[CONF_NAME],
+                    CONF_HOST: host,
+                    CONF_PORT: port,
+                    CONF_SLAVE_ID: slave_id,
+                    "brand": "anker",
+                })
+                return await self.async_step_battery_limits()
+
+        return self.async_show_form(
+            step_id="battery_connection_anker",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default=f"Anker Solarbank {battery_num}"): str,
+                    vol.Required(CONF_HOST): str,
+                    vol.Optional(CONF_PORT, default=502): int,
+                    vol.Required(CONF_SLAVE_ID, default=DEFAULT_SLAVE_ID):
+                        vol.All(NumberSelector(NumberSelectorConfig(min=1, max=247, step=1, mode=NumberSelectorMode.BOX)), vol.Coerce(int)),
+                }
+            ),
+            errors=errors,
+            description_placeholders={"battery_num": str(battery_num)},
+        )
+
     async def async_step_battery_limits(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -841,11 +889,19 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         brand = self._current_battery_data.get("brand", "marstek")
         if brand == "zendure":
             max_power = _ZENDURE_MAX_POWER_W
+        elif brand == "anker":
+            max_power = _ANKER_MAX_POWER_W
         else:
             battery_version = self._current_battery_data.get(CONF_BATTERY_VERSION, DEFAULT_VERSION)
             max_power = MAX_POWER_BY_VERSION.get(battery_version, 2500)
-        # Zendure's minSoc accepts 5–50 %; Marstek's discharge floor is 12–30 %.
-        soc_min_lo, soc_min_hi = (5, 50) if brand == "zendure" else (12, 30)
+        # Zendure's minSoc accepts 5–50 %; Anker discharge limit is 0–20 %;
+        # Marstek's discharge floor is 12–30 %.
+        if brand == "zendure":
+            soc_min_lo, soc_min_hi = 5, 50
+        elif brand == "anker":
+            soc_min_lo, soc_min_hi = 0, 20
+        else:
+            soc_min_lo, soc_min_hi = 12, 30
 
         if user_input is not None:
             merged = dict(self._current_battery_data)
@@ -861,7 +917,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             )
             merged["backup_offgrid_threshold"] = int(user_input.get("backup_offgrid_threshold", 50))
             merged[CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED] = (
-                False if brand == "zendure"
+                False if brand in ("zendure", "anker")
                 else user_input.get(CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED, DEFAULT_FULL_CHARGE_VOLTAGE_TAPER_ENABLED)
             )
             if brand == "zendure":
@@ -881,14 +937,14 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 NumberSelector(NumberSelectorConfig(min=100, max=max_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
             vol.Required("max_soc", default=100):
                 NumberSelector(NumberSelectorConfig(min=80, max=100, step=1, mode=NumberSelectorMode.SLIDER)),
-            vol.Required("min_soc", default=12):
+            vol.Required("min_soc", default=12 if brand != "anker" else 10):
                 NumberSelector(NumberSelectorConfig(min=soc_min_lo, max=soc_min_hi, step=1, mode=NumberSelectorMode.SLIDER)),
             vol.Required("charge_hysteresis_percent", default=DEFAULT_CHARGE_HYSTERESIS_PERCENT):
                 NumberSelector(NumberSelectorConfig(min=MIN_CHARGE_HYSTERESIS_PERCENT, max=MAX_CHARGE_HYSTERESIS_PERCENT, step=1, mode=NumberSelectorMode.SLIDER)),
             vol.Required("backup_offgrid_threshold", default=50):
                 NumberSelector(NumberSelectorConfig(min=0, max=500, step=10, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
         }
-        if brand != "zendure":
+        if brand not in ("zendure", "anker"):
             _schema[vol.Required(CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED, default=DEFAULT_FULL_CHARGE_VOLTAGE_TAPER_ENABLED)] = bool
         if brand == "zendure":
             _schema[vol.Optional("battery_capacity_kwh", default=0.0)] = NumberSelector(
@@ -1528,6 +1584,8 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             return await self.async_step_reconfigure_battery_zendure(user_input)
         if current.get("brand", "marstek") == "esphome":
             return await self.async_step_reconfigure_battery_esphome(user_input)
+        if current.get("brand", "marstek") == "anker":
+            return await self.async_step_reconfigure_battery_anker(user_input)
 
         errors = {}
 
@@ -1762,6 +1820,75 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             description_placeholders=placeholders,
         )
 
+
+    async def async_step_reconfigure_battery_anker(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Update connection settings for an Anker battery during reconfiguration."""
+        entry = self._get_reconfigure_entry()
+        current_batteries = entry.data.get("batteries", [])
+        battery_num = self.battery_index + 1
+        current = (
+            current_batteries[self.battery_index]
+            if self.battery_index < len(current_batteries)
+            else {}
+        )
+        errors = {}
+
+        if user_input is not None:
+            new_host = user_input[CONF_HOST]
+            new_port = int(user_input.get(CONF_PORT, 502))
+            slave_id = int(user_input.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID))
+            ok = await AnkerModbusDriver.probe(new_host, new_port, slave_id)
+            if not ok:
+                errors["base"] = "cannot_connect"
+            else:
+                old_host = current.get(CONF_HOST)
+                old_port = current.get(CONF_PORT)
+
+                if old_host and old_port and (old_host != new_host or old_port != new_port):
+                    self._migrate_battery_registry_ids(
+                        entry, old_host, old_port, new_host, new_port
+                    )
+
+                updated = dict(current)
+                updated[CONF_NAME] = user_input[CONF_NAME]
+                updated[CONF_HOST] = new_host
+                updated[CONF_PORT] = new_port
+                updated[CONF_SLAVE_ID] = slave_id
+                updated["brand"] = "anker"
+                self._reconfigure_batteries.append(updated)
+                self.battery_index += 1
+
+                if self.battery_index >= len(current_batteries):
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        data_updates={"batteries": self._reconfigure_batteries},
+                    )
+                return await self.async_step_reconfigure_battery()
+
+        defaults = {
+            CONF_NAME: current.get(CONF_NAME, f"Anker Solarbank {battery_num}"),
+            CONF_HOST: current.get(CONF_HOST, ""),
+            CONF_PORT: current.get(CONF_PORT, 502),
+            CONF_SLAVE_ID: current.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID),
+        }
+
+        return self.async_show_form(
+            step_id="reconfigure_battery_anker",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default=defaults[CONF_NAME]): str,
+                    vol.Required(CONF_HOST, default=defaults[CONF_HOST]): str,
+                    vol.Required(CONF_PORT, default=defaults[CONF_PORT]): int,
+                    vol.Required(CONF_SLAVE_ID, default=defaults[CONF_SLAVE_ID]):
+                        vol.All(NumberSelector(NumberSelectorConfig(min=1, max=247, step=1, mode=NumberSelectorMode.BOX)), vol.Coerce(int)),
+                }
+            ),
+            errors=errors,
+            description_placeholders={"battery_num": str(battery_num)},
+        )
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
@@ -1781,6 +1908,7 @@ class OptionsFlowHandler(OptionsFlow):
         self._current_battery_data = {}  # Stores connection data between battery steps
         self._pending_slot_step_a: dict | None = None  # Buffer between slot step A and step B
         _LOGGER.info("OptionsFlowHandler initialized successfully for entry: %s", config_entry.entry_id)
+
 
     async def _test_connection(
         self,
@@ -1803,6 +1931,10 @@ class OptionsFlowHandler(OptionsFlow):
             _LOGGER.info("Probing Zendure device at %s:%s", host, port)
             ok, _ = await ZendureLocalDriver.probe(host, port)
             return ok
+
+        if brand == "anker":
+            _LOGGER.info("Probing Anker Solarbank at %s:%s slave %s", host, port, slave_id)
+            return await AnkerModbusDriver.probe(host, port, slave_id)
 
         # Marstek: handle single-connection-slot constraint.
         entry_data = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id, {})
@@ -1981,6 +2113,8 @@ class OptionsFlowHandler(OptionsFlow):
                 return await self.async_step_battery_connection_zendure()
             if brand == "esphome":
                 return await self.async_step_battery_connection_esphome()
+            if brand == "anker":
+                return await self.async_step_battery_connection_anker()
             return await self.async_step_battery_connection()
 
         return self.async_show_form(
@@ -1993,6 +2127,7 @@ class OptionsFlowHandler(OptionsFlow):
                                 {"value": "marstek", "label": "Marstek Venus"},
                                 {"value": "zendure", "label": "Zendure SolarFlow"},
                                 {"value": "esphome", "label": "Marstek via LilyGo RS485 (ESPHome)"},
+                                {"value": "anker", "label": "Anker SOLIX Solarbank Max AC"},
                             ],
                             mode=SelectSelectorMode.DROPDOWN,
                         )),
@@ -2216,6 +2351,66 @@ class OptionsFlowHandler(OptionsFlow):
             description_placeholders=placeholders,
         )
 
+
+    async def async_step_battery_connection_anker(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Configure connection details for an Anker Solarbank Max AC."""
+        errors = {}
+
+        try:
+            battery_num = self.battery_index + 1
+            current_batteries = self.config_entry.data.get("batteries", [])
+
+            if user_input is not None:
+                host = user_input[CONF_HOST]
+                port = int(user_input.get(CONF_PORT, 502))
+                slave_id = int(user_input.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID))
+                ok = await AnkerModbusDriver.probe(host, port, slave_id)
+                if not ok:
+                    errors["base"] = "cannot_connect"
+                else:
+                    self._current_battery_data.update({
+                        CONF_NAME: user_input[CONF_NAME],
+                        CONF_HOST: host,
+                        CONF_PORT: port,
+                        CONF_SLAVE_ID: slave_id,
+                        "brand": "anker",
+                    })
+                    return await self.async_step_battery_limits()
+
+            if self.battery_index < len(current_batteries):
+                current_battery = current_batteries[self.battery_index]
+                defaults = {
+                    CONF_NAME: current_battery.get(CONF_NAME, f"Anker Solarbank {battery_num}"),
+                    CONF_HOST: current_battery.get(CONF_HOST, ""),
+                    CONF_PORT: current_battery.get(CONF_PORT, 502),
+                    CONF_SLAVE_ID: current_battery.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID),
+                }
+            else:
+                defaults = {
+                    CONF_NAME: f"Anker Solarbank {battery_num}",
+                    CONF_HOST: "",
+                    CONF_PORT: 502,
+                    CONF_SLAVE_ID: DEFAULT_SLAVE_ID,
+                }
+        except Exception as e:
+            _LOGGER.error("Error in options flow battery_connection_anker step: %s", e, exc_info=True)
+            return self.async_abort(reason="unknown_error")
+
+        return self.async_show_form(
+            step_id="battery_connection_anker",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default=defaults[CONF_NAME]): str,
+                    vol.Required(CONF_HOST, default=defaults[CONF_HOST]): str,
+                    vol.Optional(CONF_PORT, default=defaults[CONF_PORT]): int,
+                    vol.Required(CONF_SLAVE_ID, default=defaults[CONF_SLAVE_ID]):
+                        vol.All(NumberSelector(NumberSelectorConfig(min=1, max=247, step=1, mode=NumberSelectorMode.BOX)), vol.Coerce(int)),
+                }
+            ),
+            errors=errors,
+            description_placeholders={"battery_num": str(battery_num)},
+        )
+
     async def async_step_battery_limits(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Configure power and SOC limits for the current battery."""
         try:
@@ -2223,11 +2418,19 @@ class OptionsFlowHandler(OptionsFlow):
             brand = self._current_battery_data.get("brand", "marstek")
             if brand == "zendure":
                 max_power = _ZENDURE_MAX_POWER_W
+            elif brand == "anker":
+                max_power = _ANKER_MAX_POWER_W
             else:
                 battery_version = self._current_battery_data.get(CONF_BATTERY_VERSION, DEFAULT_VERSION)
                 max_power = MAX_POWER_BY_VERSION.get(battery_version, 2500)
-            # Zendure's minSoc accepts 5–50 %; Marstek's discharge floor is 12–30 %.
-            soc_min_lo, soc_min_hi = (5, 50) if brand == "zendure" else (12, 30)
+            # Zendure's minSoc accepts 5–50 %; Anker discharge limit is 0–20 %;
+            # Marstek's discharge floor is 12–30 %.
+            if brand == "zendure":
+                soc_min_lo, soc_min_hi = 5, 50
+            elif brand == "anker":
+                soc_min_lo, soc_min_hi = 0, 20
+            else:
+                soc_min_lo, soc_min_hi = 12, 30
             current_batteries = self.config_entry.data.get("batteries", [])
 
             if user_input is not None:
@@ -2249,7 +2452,7 @@ class OptionsFlowHandler(OptionsFlow):
                 )
                 merged["backup_offgrid_threshold"] = int(user_input.get("backup_offgrid_threshold", 50))
                 merged[CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED] = (
-                    False if brand == "zendure"
+                    False if brand in ("zendure", "anker")
                     else user_input.get(CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED, DEFAULT_FULL_CHARGE_VOLTAGE_TAPER_ENABLED)
                 )
                 if brand == "zendure":
@@ -2269,7 +2472,7 @@ class OptionsFlowHandler(OptionsFlow):
                     "max_charge_power": min(current_battery.get("max_charge_power", max_power), max_power),
                     "max_discharge_power": min(current_battery.get("max_discharge_power", max_power), max_power),
                     "max_soc": current_battery.get("max_soc", 100),
-                    "min_soc": current_battery.get("min_soc", 12),
+                    "min_soc": current_battery.get("min_soc", 12 if brand != "anker" else 10),
                     "charge_hysteresis_percent": max(
                         MIN_CHARGE_HYSTERESIS_PERCENT,
                         int(current_battery.get("charge_hysteresis_percent", DEFAULT_CHARGE_HYSTERESIS_PERCENT)),
@@ -2286,7 +2489,7 @@ class OptionsFlowHandler(OptionsFlow):
                     "max_charge_power": max_power,
                     "max_discharge_power": max_power,
                     "max_soc": 100,
-                    "min_soc": 12,
+                    "min_soc": 10 if brand == "anker" else 12,
                     "charge_hysteresis_percent": DEFAULT_CHARGE_HYSTERESIS_PERCENT,
                     "backup_offgrid_threshold": 50,
                     CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED: DEFAULT_FULL_CHARGE_VOLTAGE_TAPER_ENABLED,
@@ -2310,7 +2513,7 @@ class OptionsFlowHandler(OptionsFlow):
             vol.Required("backup_offgrid_threshold", default=defaults["backup_offgrid_threshold"]):
                 NumberSelector(NumberSelectorConfig(min=0, max=500, step=10, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
         }
-        if brand != "zendure":
+        if brand not in ("zendure", "anker"):
             _schema[vol.Required(CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED, default=defaults[CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED])] = bool
         if brand == "zendure":
             _schema[vol.Optional("battery_capacity_kwh", default=defaults["battery_capacity_kwh"])] = NumberSelector(

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -110,7 +110,7 @@ _ANKER_MAX_POWER_W = 3500
 
 
 def _anker_apply_probe_caps(battery_data: dict, caps: dict) -> None:
-    """Store Anker hardware ceilings from probe (not soft-limit defaults)."""
+    """Store Anker hardware ceilings from probe for config seeding."""
     for src, dst in (
         ("device_max_charge_power", "device_max_charge_power"),
         ("device_max_discharge_power", "device_max_discharge_power"),
@@ -120,7 +120,7 @@ def _anker_apply_probe_caps(battery_data: dict, caps: dict) -> None:
 
 
 def _anker_power_ceilings(battery_data: dict) -> tuple[int, int]:
-    """Slider maxima from probed HW caps, falling back to the static envelope."""
+    """Hardware max charge/discharge from probe, falling back to the static envelope."""
     charge = int(battery_data.get("device_max_charge_power") or _ANKER_MAX_POWER_W)
     discharge = int(battery_data.get("device_max_discharge_power") or _ANKER_MAX_POWER_W)
     return (
@@ -129,39 +129,11 @@ def _anker_power_ceilings(battery_data: dict) -> tuple[int, int]:
     )
 
 
-def _anker_soft_power_defaults(battery_data: dict) -> tuple[int, int]:
-    """Setup soft-limit defaults for Anker.
-
-    Prefer a previously saved software ceiling (``user_max_*``), then the saved
-    Omnibattery limit, then the probed hardware ceiling. Register 10036/10038
-    are Anker-internal HW caps (often 3500 W), not the Anker-app user limit.
-    """
-    charge_ceil, discharge_ceil = _anker_power_ceilings(battery_data)
-
-    def _pick(user_key: str, saved_key: str, ceiling: int) -> int:
-        for key in (user_key, saved_key):
-            raw = battery_data.get(key)
-            if raw is None:
-                continue
-            try:
-                return max(100, min(ceiling, int(raw)))
-            except (TypeError, ValueError):
-                continue
-        return ceiling
-
-    return (
-        _pick("user_max_charge_power", "max_charge_power", charge_ceil),
-        _pick("user_max_discharge_power", "max_discharge_power", discharge_ceil),
-    )
-
-
 def _seed_software_power_limits(merged: dict, brand: str) -> None:
-    """Persist soft-max keys for drivers that clamp against a read-only HW cap."""
-    if brand not in ("anker", "zendure"):
+    """Persist soft-max keys for Zendure (read-only chargeMaxLimit + software ceiling)."""
+    if brand != "zendure":
         return
     merged["user_max_charge_power"] = int(merged["max_charge_power"])
-    if brand == "anker":
-        merged["user_max_discharge_power"] = int(merged["max_discharge_power"])
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -968,8 +940,14 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
 
         if user_input is not None:
             merged = dict(self._current_battery_data)
-            merged["max_charge_power"] = int(user_input["max_charge_power"])
-            merged["max_discharge_power"] = int(user_input["max_discharge_power"])
+            if brand == "anker":
+                # Power caps are device sensors (10036/10038), not setup inputs.
+                charge_w, discharge_w = _anker_power_ceilings(self._current_battery_data)
+                merged["max_charge_power"] = charge_w
+                merged["max_discharge_power"] = discharge_w
+            else:
+                merged["max_charge_power"] = int(user_input["max_charge_power"])
+                merged["max_discharge_power"] = int(user_input["max_discharge_power"])
             merged["max_soc"] = int(user_input["max_soc"])
             merged["min_soc"] = int(user_input["min_soc"])
             _seed_software_power_limits(merged, brand)
@@ -994,11 +972,8 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 return await self.async_step_time_slots()
             return await self.async_step_battery_brand()
 
-        if brand == "anker":
-            default_charge, default_discharge = _anker_soft_power_defaults(
-                self._current_battery_data
-            )
-        else:
+        _schema: dict = {}
+        if brand != "anker":
             default_charge = max(
                 100,
                 min(max_power, int(self._current_battery_data.get("max_charge_power", max_power))),
@@ -1007,11 +982,13 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 100,
                 min(max_power, int(self._current_battery_data.get("max_discharge_power", max_power))),
             )
-        _schema: dict = {
-            vol.Required("max_charge_power", default=default_charge):
-                NumberSelector(NumberSelectorConfig(min=100, max=max_charge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
-            vol.Required("max_discharge_power", default=default_discharge):
-                NumberSelector(NumberSelectorConfig(min=100, max=max_discharge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
+            _schema[vol.Required("max_charge_power", default=default_charge)] = NumberSelector(
+                NumberSelectorConfig(min=100, max=max_charge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)
+            )
+            _schema[vol.Required("max_discharge_power", default=default_discharge)] = NumberSelector(
+                NumberSelectorConfig(min=100, max=max_discharge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)
+            )
+        _schema.update({
             vol.Required("max_soc", default=100):
                 NumberSelector(NumberSelectorConfig(min=80, max=100, step=1, mode=NumberSelectorMode.SLIDER)),
             vol.Required("min_soc", default=12 if brand != "anker" else 10):
@@ -1020,7 +997,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 NumberSelector(NumberSelectorConfig(min=MIN_CHARGE_HYSTERESIS_PERCENT, max=MAX_CHARGE_HYSTERESIS_PERCENT, step=1, mode=NumberSelectorMode.SLIDER)),
             vol.Required("backup_offgrid_threshold", default=50):
                 NumberSelector(NumberSelectorConfig(min=0, max=500, step=10, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
-        }
+        })
         if brand not in ("zendure", "anker"):
             _schema[vol.Required(CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED, default=DEFAULT_FULL_CHARGE_VOLTAGE_TAPER_ENABLED)] = bool
         if brand == "zendure":
@@ -2526,8 +2503,13 @@ class OptionsFlowHandler(OptionsFlow):
                     merged.update(self._current_battery_data)
                 else:
                     merged = dict(self._current_battery_data)
-                merged["max_charge_power"] = int(user_input["max_charge_power"])
-                merged["max_discharge_power"] = int(user_input["max_discharge_power"])
+                if brand == "anker":
+                    charge_w, discharge_w = _anker_power_ceilings(merged)
+                    merged["max_charge_power"] = charge_w
+                    merged["max_discharge_power"] = discharge_w
+                else:
+                    merged["max_charge_power"] = int(user_input["max_charge_power"])
+                    merged["max_discharge_power"] = int(user_input["max_discharge_power"])
                 merged["max_soc"] = int(user_input["max_soc"])
                 merged["min_soc"] = int(user_input["min_soc"])
                 _seed_software_power_limits(merged, brand)
@@ -2555,23 +2537,9 @@ class OptionsFlowHandler(OptionsFlow):
 
             if self.battery_index < len(current_batteries):
                 current_battery = current_batteries[self.battery_index]
-                defaults_src = dict(current_battery)
-                defaults_src.update(
-                    {
-                        k: v
-                        for k, v in self._current_battery_data.items()
-                        if k.startswith("device_max_")
-                    }
-                )
-                if brand == "anker":
-                    default_charge, default_discharge = _anker_soft_power_defaults(defaults_src)
-                    max_charge_power, max_discharge_power = _anker_power_ceilings(defaults_src)
-                else:
-                    default_charge = min(current_battery.get("max_charge_power", max_power), max_power)
-                    default_discharge = min(current_battery.get("max_discharge_power", max_power), max_power)
                 defaults = {
-                    "max_charge_power": default_charge,
-                    "max_discharge_power": default_discharge,
+                    "max_charge_power": min(current_battery.get("max_charge_power", max_power), max_power),
+                    "max_discharge_power": min(current_battery.get("max_discharge_power", max_power), max_power),
                     "max_soc": current_battery.get("max_soc", 100),
                     "min_soc": current_battery.get("min_soc", 12 if brand != "anker" else 10),
                     "charge_hysteresis_percent": max(
@@ -2586,28 +2554,21 @@ class OptionsFlowHandler(OptionsFlow):
                     "battery_capacity_kwh": current_battery.get("battery_capacity_kwh", 0.0),
                 }
             else:
-                if brand == "anker":
-                    default_charge, default_discharge = _anker_soft_power_defaults(
-                        self._current_battery_data
-                    )
-                else:
-                    default_charge = max(
+                defaults = {
+                    "max_charge_power": max(
                         100,
                         min(
                             max_power,
                             int(self._current_battery_data.get("max_charge_power", max_power)),
                         ),
-                    )
-                    default_discharge = max(
+                    ),
+                    "max_discharge_power": max(
                         100,
                         min(
                             max_power,
                             int(self._current_battery_data.get("max_discharge_power", max_power)),
                         ),
-                    )
-                defaults = {
-                    "max_charge_power": default_charge,
-                    "max_discharge_power": default_discharge,
+                    ),
                     "max_soc": 100,
                     "min_soc": 10 if brand == "anker" else 12,
                     "charge_hysteresis_percent": DEFAULT_CHARGE_HYSTERESIS_PERCENT,
@@ -2619,11 +2580,15 @@ class OptionsFlowHandler(OptionsFlow):
             _LOGGER.error("Error in options flow battery_limits step: %s", e, exc_info=True)
             return self.async_abort(reason="unknown_error")
 
-        _schema: dict = {
-            vol.Required("max_charge_power", default=defaults["max_charge_power"]):
-                NumberSelector(NumberSelectorConfig(min=100, max=max_charge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
-            vol.Required("max_discharge_power", default=defaults["max_discharge_power"]):
-                NumberSelector(NumberSelectorConfig(min=100, max=max_discharge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
+        _schema: dict = {}
+        if brand != "anker":
+            _schema[vol.Required("max_charge_power", default=defaults["max_charge_power"])] = NumberSelector(
+                NumberSelectorConfig(min=100, max=max_charge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)
+            )
+            _schema[vol.Required("max_discharge_power", default=defaults["max_discharge_power"])] = NumberSelector(
+                NumberSelectorConfig(min=100, max=max_discharge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)
+            )
+        _schema.update({
             vol.Required("max_soc", default=defaults["max_soc"]):
                 NumberSelector(NumberSelectorConfig(min=80, max=100, step=1, mode=NumberSelectorMode.SLIDER)),
             vol.Required("min_soc", default=max(soc_min_lo, min(soc_min_hi, defaults["min_soc"]))):
@@ -2632,7 +2597,7 @@ class OptionsFlowHandler(OptionsFlow):
                 NumberSelector(NumberSelectorConfig(min=MIN_CHARGE_HYSTERESIS_PERCENT, max=MAX_CHARGE_HYSTERESIS_PERCENT, step=1, mode=NumberSelectorMode.SLIDER)),
             vol.Required("backup_offgrid_threshold", default=defaults["backup_offgrid_threshold"]):
                 NumberSelector(NumberSelectorConfig(min=0, max=500, step=10, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
-        }
+        })
         if brand not in ("zendure", "anker"):
             _schema[vol.Required(CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED, default=defaults[CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED])] = bool
         if brand == "zendure":

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -108,6 +108,61 @@ from .drivers.anker import AnkerModbusDriver
 _ZENDURE_MAX_POWER_W = 2400
 _ANKER_MAX_POWER_W = 3500
 
+
+def _anker_apply_probe_caps(battery_data: dict, caps: dict) -> None:
+    """Store Anker hardware ceilings from probe (not soft-limit defaults)."""
+    for src, dst in (
+        ("device_max_charge_power", "device_max_charge_power"),
+        ("device_max_discharge_power", "device_max_discharge_power"),
+    ):
+        if src in caps:
+            battery_data[dst] = int(caps[src])
+
+
+def _anker_power_ceilings(battery_data: dict) -> tuple[int, int]:
+    """Slider maxima from probed HW caps, falling back to the static envelope."""
+    charge = int(battery_data.get("device_max_charge_power") or _ANKER_MAX_POWER_W)
+    discharge = int(battery_data.get("device_max_discharge_power") or _ANKER_MAX_POWER_W)
+    return (
+        max(100, min(_ANKER_MAX_POWER_W, charge)),
+        max(100, min(_ANKER_MAX_POWER_W, discharge)),
+    )
+
+
+def _anker_soft_power_defaults(battery_data: dict) -> tuple[int, int]:
+    """Setup soft-limit defaults for Anker.
+
+    Prefer a previously saved software ceiling (``user_max_*``), then the saved
+    Omnibattery limit, then the probed hardware ceiling. Register 10036/10038
+    are Anker-internal HW caps (often 3500 W), not the Anker-app user limit.
+    """
+    charge_ceil, discharge_ceil = _anker_power_ceilings(battery_data)
+
+    def _pick(user_key: str, saved_key: str, ceiling: int) -> int:
+        for key in (user_key, saved_key):
+            raw = battery_data.get(key)
+            if raw is None:
+                continue
+            try:
+                return max(100, min(ceiling, int(raw)))
+            except (TypeError, ValueError):
+                continue
+        return ceiling
+
+    return (
+        _pick("user_max_charge_power", "max_charge_power", charge_ceil),
+        _pick("user_max_discharge_power", "max_discharge_power", discharge_ceil),
+    )
+
+
+def _seed_software_power_limits(merged: dict, brand: str) -> None:
+    """Persist soft-max keys for drivers that clamp against a read-only HW cap."""
+    if brand not in ("anker", "zendure"):
+        return
+    merged["user_max_charge_power"] = int(merged["max_charge_power"])
+    if brand == "anker":
+        merged["user_max_discharge_power"] = int(merged["max_discharge_power"])
+
 _LOGGER = logging.getLogger(__name__)
 
 _ALL_WEEKDAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
@@ -864,10 +919,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                     CONF_SLAVE_ID: slave_id,
                     "brand": "anker",
                 })
-                if "max_charge_power" in caps:
-                    self._current_battery_data["max_charge_power"] = caps["max_charge_power"]
-                if "max_discharge_power" in caps:
-                    self._current_battery_data["max_discharge_power"] = caps["max_discharge_power"]
+                _anker_apply_probe_caps(self._current_battery_data, caps)
                 return await self.async_step_battery_limits()
 
         return self.async_show_form(
@@ -893,11 +945,18 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         brand = self._current_battery_data.get("brand", "marstek")
         if brand == "zendure":
             max_power = _ZENDURE_MAX_POWER_W
+            max_charge_power = max_power
+            max_discharge_power = max_power
         elif brand == "anker":
-            max_power = _ANKER_MAX_POWER_W
+            max_charge_power, max_discharge_power = _anker_power_ceilings(
+                self._current_battery_data
+            )
+            max_power = max(max_charge_power, max_discharge_power)
         else:
             battery_version = self._current_battery_data.get(CONF_BATTERY_VERSION, DEFAULT_VERSION)
             max_power = MAX_POWER_BY_VERSION.get(battery_version, 2500)
+            max_charge_power = max_power
+            max_discharge_power = max_power
         # Zendure's minSoc accepts 5–50 %; Anker discharge limit is 0–20 %;
         # Marstek's discharge floor is 12–30 %.
         if brand == "zendure":
@@ -913,6 +972,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             merged["max_discharge_power"] = int(user_input["max_discharge_power"])
             merged["max_soc"] = int(user_input["max_soc"])
             merged["min_soc"] = int(user_input["min_soc"])
+            _seed_software_power_limits(merged, brand)
             # Hysteresis is mandatory; floor the percent against SOC drift.
             merged["enable_charge_hysteresis"] = True
             merged["charge_hysteresis_percent"] = max(
@@ -934,20 +994,24 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 return await self.async_step_time_slots()
             return await self.async_step_battery_brand()
 
-        # Anker: prefer power caps read during probe (10036/10038).
-        default_charge = max(
-            100,
-            min(max_power, int(self._current_battery_data.get("max_charge_power", max_power))),
-        )
-        default_discharge = max(
-            100,
-            min(max_power, int(self._current_battery_data.get("max_discharge_power", max_power))),
-        )
+        if brand == "anker":
+            default_charge, default_discharge = _anker_soft_power_defaults(
+                self._current_battery_data
+            )
+        else:
+            default_charge = max(
+                100,
+                min(max_power, int(self._current_battery_data.get("max_charge_power", max_power))),
+            )
+            default_discharge = max(
+                100,
+                min(max_power, int(self._current_battery_data.get("max_discharge_power", max_power))),
+            )
         _schema: dict = {
             vol.Required("max_charge_power", default=default_charge):
-                NumberSelector(NumberSelectorConfig(min=100, max=max_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
+                NumberSelector(NumberSelectorConfig(min=100, max=max_charge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
             vol.Required("max_discharge_power", default=default_discharge):
-                NumberSelector(NumberSelectorConfig(min=100, max=max_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
+                NumberSelector(NumberSelectorConfig(min=100, max=max_discharge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
             vol.Required("max_soc", default=100):
                 NumberSelector(NumberSelectorConfig(min=80, max=100, step=1, mode=NumberSelectorMode.SLIDER)),
             vol.Required("min_soc", default=12 if brand != "anker" else 10):
@@ -2389,10 +2453,7 @@ class OptionsFlowHandler(OptionsFlow):
                         CONF_SLAVE_ID: slave_id,
                         "brand": "anker",
                     })
-                    if "max_charge_power" in caps:
-                        self._current_battery_data["max_charge_power"] = caps["max_charge_power"]
-                    if "max_discharge_power" in caps:
-                        self._current_battery_data["max_discharge_power"] = caps["max_discharge_power"]
+                    _anker_apply_probe_caps(self._current_battery_data, caps)
                     return await self.async_step_battery_limits()
 
             if self.battery_index < len(current_batteries):
@@ -2436,11 +2497,18 @@ class OptionsFlowHandler(OptionsFlow):
             brand = self._current_battery_data.get("brand", "marstek")
             if brand == "zendure":
                 max_power = _ZENDURE_MAX_POWER_W
+                max_charge_power = max_power
+                max_discharge_power = max_power
             elif brand == "anker":
-                max_power = _ANKER_MAX_POWER_W
+                max_charge_power, max_discharge_power = _anker_power_ceilings(
+                    self._current_battery_data
+                )
+                max_power = max(max_charge_power, max_discharge_power)
             else:
                 battery_version = self._current_battery_data.get(CONF_BATTERY_VERSION, DEFAULT_VERSION)
                 max_power = MAX_POWER_BY_VERSION.get(battery_version, 2500)
+                max_charge_power = max_power
+                max_discharge_power = max_power
             # Zendure's minSoc accepts 5–50 %; Anker discharge limit is 0–20 %;
             # Marstek's discharge floor is 12–30 %.
             if brand == "zendure":
@@ -2462,6 +2530,7 @@ class OptionsFlowHandler(OptionsFlow):
                 merged["max_discharge_power"] = int(user_input["max_discharge_power"])
                 merged["max_soc"] = int(user_input["max_soc"])
                 merged["min_soc"] = int(user_input["min_soc"])
+                _seed_software_power_limits(merged, brand)
                 # Hysteresis is mandatory; floor the percent against SOC drift.
                 merged["enable_charge_hysteresis"] = True
                 merged["charge_hysteresis_percent"] = max(
@@ -2486,9 +2555,23 @@ class OptionsFlowHandler(OptionsFlow):
 
             if self.battery_index < len(current_batteries):
                 current_battery = current_batteries[self.battery_index]
+                defaults_src = dict(current_battery)
+                defaults_src.update(
+                    {
+                        k: v
+                        for k, v in self._current_battery_data.items()
+                        if k.startswith("device_max_")
+                    }
+                )
+                if brand == "anker":
+                    default_charge, default_discharge = _anker_soft_power_defaults(defaults_src)
+                    max_charge_power, max_discharge_power = _anker_power_ceilings(defaults_src)
+                else:
+                    default_charge = min(current_battery.get("max_charge_power", max_power), max_power)
+                    default_discharge = min(current_battery.get("max_discharge_power", max_power), max_power)
                 defaults = {
-                    "max_charge_power": min(current_battery.get("max_charge_power", max_power), max_power),
-                    "max_discharge_power": min(current_battery.get("max_discharge_power", max_power), max_power),
+                    "max_charge_power": default_charge,
+                    "max_discharge_power": default_discharge,
                     "max_soc": current_battery.get("max_soc", 100),
                     "min_soc": current_battery.get("min_soc", 12 if brand != "anker" else 10),
                     "charge_hysteresis_percent": max(
@@ -2503,21 +2586,28 @@ class OptionsFlowHandler(OptionsFlow):
                     "battery_capacity_kwh": current_battery.get("battery_capacity_kwh", 0.0),
                 }
             else:
-                defaults = {
-                    "max_charge_power": max(
+                if brand == "anker":
+                    default_charge, default_discharge = _anker_soft_power_defaults(
+                        self._current_battery_data
+                    )
+                else:
+                    default_charge = max(
                         100,
                         min(
                             max_power,
                             int(self._current_battery_data.get("max_charge_power", max_power)),
                         ),
-                    ),
-                    "max_discharge_power": max(
+                    )
+                    default_discharge = max(
                         100,
                         min(
                             max_power,
                             int(self._current_battery_data.get("max_discharge_power", max_power)),
                         ),
-                    ),
+                    )
+                defaults = {
+                    "max_charge_power": default_charge,
+                    "max_discharge_power": default_discharge,
                     "max_soc": 100,
                     "min_soc": 10 if brand == "anker" else 12,
                     "charge_hysteresis_percent": DEFAULT_CHARGE_HYSTERESIS_PERCENT,
@@ -2531,9 +2621,9 @@ class OptionsFlowHandler(OptionsFlow):
 
         _schema: dict = {
             vol.Required("max_charge_power", default=defaults["max_charge_power"]):
-                NumberSelector(NumberSelectorConfig(min=100, max=max_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
+                NumberSelector(NumberSelectorConfig(min=100, max=max_charge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
             vol.Required("max_discharge_power", default=defaults["max_discharge_power"]):
-                NumberSelector(NumberSelectorConfig(min=100, max=max_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
+                NumberSelector(NumberSelectorConfig(min=100, max=max_discharge_power, step=50, unit_of_measurement="W", mode=NumberSelectorMode.SLIDER)),
             vol.Required("max_soc", default=defaults["max_soc"]):
                 NumberSelector(NumberSelectorConfig(min=80, max=100, step=1, mode=NumberSelectorMode.SLIDER)),
             vol.Required("min_soc", default=max(soc_min_lo, min(soc_min_hi, defaults["min_soc"]))):

--- a/custom_components/omnibattery/drivers/__init__.py
+++ b/custom_components/omnibattery/drivers/__init__.py
@@ -10,6 +10,7 @@ Drivers:
   - ``marstek``: Modbus-TCP, register based, polled (the original hardware).
   - ``zendure``: local HTTP REST, property based, polled (SolarFlow series).
   - ``esphome``: HA-entity based, push (Marstek behind a LilyGo RS485 bridge).
+  - ``anker``: Modbus-TCP, register based, polled (SOLIX Solarbank Max AC).
 
 See ``docs/plans/driver_abstraction.md`` for the phased extraction plan.
 """
@@ -24,6 +25,7 @@ from .base import (
 from .esphome import EsphomeEntityDriver
 from .marstek import MarstekModbusDriver
 from .zendure import ZendureLocalDriver
+from .anker import AnkerModbusDriver
 
 __all__ = [
     "BatteryDriver",
@@ -34,4 +36,5 @@ __all__ = [
     "EsphomeEntityDriver",
     "MarstekModbusDriver",
     "ZendureLocalDriver",
+    "AnkerModbusDriver",
 ]

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -398,12 +398,24 @@ class AnkerModbusDriver(BatteryDriver):
 
         self._last_net_power_w = net
         applied = {"commanded_net_power": net, "operating_mode": _OPERATING_MODE_THIRD_PARTY}
-        # Setpoint register is never_read_device — no confirmation read of 10071.
-        _ = read_back
+        # Register 10071 is never_read_device — Modbus write success is the ACK.
+        # Returning confirmed=False made the control loop treat every readback
+        # cycle as ack_mismatch (Anker is a "fast" actuator so read_back is
+        # periodically True). When read_back is requested, also sample delivered
+        # power from input 10008 for non-delivery detection.
+        battery_power_w: Optional[int] = None
+        if read_back:
+            snap = await self.read_telemetry(["battery_power"])
+            raw = snap.get("battery_power")
+            if raw is not None:
+                battery_power_w = int(raw)
+                applied["battery_power"] = battery_power_w
         return SetpointResult(
             ok=True,
             net_power_w=net,
-            confirmed=False,
+            confirmed=True,
+            exact=True,
+            battery_power_w=battery_power_w,
             applied=applied,
         )
 

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -1,0 +1,481 @@
+"""Anker SOLIX Solarbank Max AC Modbus TCP driver.
+
+Implements :class:`BatteryDriver` for the Solarbank Max AC over Modbus TCP.
+
+Register map source of truth (FC03/FC04 batch ranges and write addresses):
+https://raw.githubusercontent.com/anker-charging/ha-anker-solix-official/refs/heads/main/custom_components/anker_solix_official/config/8fcbb87c685781b1d70d784a79eb923098955df2aaf199095ce7767bb70b913d.yaml
+
+Sign conventions:
+  Omnibattery net power: +charge / −discharge
+  Anker battery power (10008) and setpoint (10071): +discharge / −charge
+  Therefore wire_w = −net_power_w.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from ..infra.anker_modbus_client import AnkerModbusClient
+from ..infra.modbus_client import decode_registers
+from .base import (
+    BatteryDriver,
+    DriverCapabilities,
+    ReadGroup,
+    SetpointResult,
+    TelemetrySnapshot,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Official YAML auto_mode_on_connect / third_party_control
+_OPERATING_MODE_THIRD_PARTY = 3
+_ADDR_OPERATING_MODE = 10064
+_ADDR_POWER_SETPOINT = 10071
+_ADDR_CHARGE_SOC_LIMIT = 60000
+_ADDR_DISCHARGE_SOC_LIMIT = 60001
+_ADDR_BATTERY_SOC = 10014
+
+_HW_MAX_POWER_W = 3500
+_MIN_OPERATING_POWER_W = 100
+
+# Official batch_read_ranges (do not invent other blocks / FCs).
+_BATCH_READ_RANGES: dict[str, list[tuple[int, int]]] = {
+    # FC04 input
+    "input": [
+        (10000, 10050),
+        (10090, 10156),
+        (10208, 10265),
+        (32768, 32774),
+    ],
+    # FC03 holding
+    "holding": [
+        (10060, 10072),
+        (10074, 10081),
+        (60000, 60003),
+    ],
+}
+
+# Fields decoded from batch buffers. register_type must match the YAML range.
+# invert: negate value to Omnibattery +charge/−discharge convention.
+_FIELD_SPECS: list[dict] = [
+    {"key": "battery_status", "address": 10001, "register_type": "input",
+     "data_type": "uint16", "count": 1},
+    {"key": "battery_power", "address": 10008, "register_type": "input",
+     "data_type": "int32", "count": 2, "invert": True},
+    {"key": "grid_power", "address": 10012, "register_type": "input",
+     "data_type": "int32", "count": 2},
+    {"key": "battery_soc", "address": 10014, "register_type": "input",
+     "data_type": "uint16", "count": 1},
+    {"key": "max_charge_power", "address": 10036, "register_type": "input",
+     "data_type": "int32", "count": 2},
+    {"key": "max_discharge_power", "address": 10038, "register_type": "input",
+     "data_type": "int32", "count": 2},
+    {"key": "temperature", "address": 10156, "register_type": "input",
+     "data_type": "int16", "count": 1},
+    {"key": "battery_total_energy", "address": 10250, "register_type": "input",
+     "data_type": "uint32", "count": 2},
+    {"key": "total_charging_energy", "address": 10262, "register_type": "input",
+     "data_type": "uint32", "count": 2},
+    {"key": "total_discharging_energy", "address": 10264, "register_type": "input",
+     "data_type": "uint32", "count": 2},
+    {"key": "operating_mode", "address": 10064, "register_type": "holding",
+     "data_type": "uint16", "count": 1},
+    {"key": "charging_cutoff_capacity", "address": 60000, "register_type": "holding",
+     "data_type": "uint16", "count": 1},
+    {"key": "discharging_cutoff_capacity", "address": 60001, "register_type": "holding",
+     "data_type": "uint16", "count": 1},
+]
+
+SENSOR_DEFINITIONS: list[dict] = [
+    {"key": "battery_soc", "name": "Battery SOC", "unit": "%",
+     "device_class": "battery", "state_class": "measurement", "scale": 1, "precision": 0,
+     "scan_interval": "medium", "enabled_by_default": True},
+    {"key": "battery_power", "name": "Battery Power", "unit": "W",
+     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
+     "scan_interval": "high", "enabled_by_default": True},
+    {"key": "grid_power", "name": "Grid Power", "unit": "W",
+     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
+     "scan_interval": "high", "enabled_by_default": True},
+    {"key": "temperature", "name": "Temperature", "unit": "°C",
+     "device_class": "temperature", "state_class": "measurement", "scale": 1, "precision": 0,
+     "scan_interval": "low", "enabled_by_default": True},
+    {"key": "battery_status", "name": "Battery Status", "unit": None,
+     "device_class": None, "state_class": None, "scale": 1, "precision": 0,
+     "scan_interval": "medium", "enabled_by_default": True},
+    {"key": "operating_mode", "name": "Operating Mode", "unit": None,
+     "device_class": None, "state_class": None, "scale": 1, "precision": 0,
+     "scan_interval": "medium", "enabled_by_default": True},
+    {"key": "max_charge_power", "name": "Max Charge Power", "unit": "W",
+     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
+     "scan_interval": "low", "enabled_by_default": False},
+    {"key": "max_discharge_power", "name": "Max Discharge Power", "unit": "W",
+     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
+     "scan_interval": "low", "enabled_by_default": False},
+    {"key": "battery_total_energy", "name": "Battery Total Energy", "unit": "kWh",
+     "device_class": "energy", "state_class": "total", "scale": 0.1, "precision": 2,
+     "scan_interval": "low", "enabled_by_default": True},
+    {"key": "total_charging_energy", "name": "Total Charging Energy", "unit": "kWh",
+     "device_class": "energy", "state_class": "total_increasing", "scale": 0.1, "precision": 2,
+     "scan_interval": "low", "enabled_by_default": True},
+    {"key": "total_discharging_energy", "name": "Total Discharging Energy", "unit": "kWh",
+     "device_class": "energy", "state_class": "total_increasing", "scale": 0.1, "precision": 2,
+     "scan_interval": "low", "enabled_by_default": True},
+]
+
+NUMBER_DEFINITIONS: list[dict] = [
+    {"key": "charging_cutoff_capacity", "name": "Charging Cutoff Capacity", "unit": "%",
+     "device_class": "battery", "min": 80, "max": 100, "step": 1,
+     "scale": 1, "precision": 0, "scan_interval": "medium", "enabled_by_default": True},
+    {"key": "discharging_cutoff_capacity", "name": "Discharging Cutoff Capacity", "unit": "%",
+     "device_class": "battery", "min": 0, "max": 20, "step": 1,
+     "scale": 1, "precision": 0, "scan_interval": "medium", "enabled_by_default": True},
+]
+
+SELECT_DEFINITIONS: list[dict] = []
+SWITCH_DEFINITIONS: list[dict] = []
+BINARY_SENSOR_DEFINITIONS: list[dict] = []
+BUTTON_DEFINITIONS: list[dict] = []
+
+_WRITE_CONTROL_MAP: dict[str, int] = {
+    "operating_mode": _ADDR_OPERATING_MODE,
+    "charging_cutoff_capacity": _ADDR_CHARGE_SOC_LIMIT,
+    "discharging_cutoff_capacity": _ADDR_DISCHARGE_SOC_LIMIT,
+}
+
+
+def _range_for(address: int, register_type: str) -> tuple[int, int]:
+    for start, end in _BATCH_READ_RANGES[register_type]:
+        if start <= address <= end:
+            return start, end
+    raise ValueError(
+        f"Address {address} is not in official {register_type} batch_read_ranges"
+    )
+
+
+def _clamp_soc(value: float, lo: int, hi: int) -> int:
+    return max(lo, min(hi, int(round(value))))
+
+
+class AnkerModbusDriver(BatteryDriver):
+    """Modbus TCP driver for Anker SOLIX Solarbank Max AC."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 502,
+        slave_id: int = 1,
+        *,
+        client: Optional[AnkerModbusClient] = None,
+        max_charge_power_w: int = _HW_MAX_POWER_W,
+        max_discharge_power_w: int = _HW_MAX_POWER_W,
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._slave_id = slave_id
+        self._client = client or AnkerModbusClient(host, port, slave_id=slave_id)
+        self._last_net_power_w: Optional[int] = None
+        self._dynamic_max_charge_w = _HW_MAX_POWER_W
+        self._dynamic_max_discharge_w = _HW_MAX_POWER_W
+        # User limits are enforced upstream; capability envelope is hardware max.
+        _ = (max_charge_power_w, max_discharge_power_w)
+
+        self._field_by_key = {f["key"]: f for f in _FIELD_SPECS}
+        self._read_groups = self._build_read_groups()
+        self._capabilities = DriverCapabilities(
+            hardware_soc_cutoff=True,
+            has_force_mode=False,
+            push_telemetry=False,
+            max_charge_power_w=_HW_MAX_POWER_W,
+            max_discharge_power_w=_HW_MAX_POWER_W,
+            min_charge_power_w=_MIN_OPERATING_POWER_W,
+            min_discharge_power_w=_MIN_OPERATING_POWER_W,
+            has_mppt_pv=False,
+            has_alarm_registers=False,
+            has_rs485_control=False,
+            has_energy_counters=True,
+            setpoint_confirm_reliable=False,
+            actuator_latency_s=1.0,
+        )
+
+    def _build_read_groups(self) -> list[ReadGroup]:
+        """One ReadGroup per official batch range that contains any mapped field."""
+        groups: list[ReadGroup] = []
+        for register_type, ranges in _BATCH_READ_RANGES.items():
+            for start, end in ranges:
+                keys = tuple(
+                    f["key"]
+                    for f in _FIELD_SPECS
+                    if f["register_type"] == register_type and start <= f["address"] <= end
+                )
+                if not keys:
+                    continue
+                # Prefer high cadence when any power/SOC key is in the group.
+                high_keys = {"battery_power", "grid_power", "battery_soc"}
+                scan = "high" if any(k in high_keys for k in keys) else "medium"
+                if register_type == "holding" and start >= 60000:
+                    scan = "medium"
+                groups.append(ReadGroup(scan_interval=scan, keys=keys))
+        return groups
+
+    # --- identity -----------------------------------------------------------
+
+    @property
+    def capabilities(self) -> DriverCapabilities:
+        return self._capabilities
+
+    @property
+    def model_label(self) -> Optional[str]:
+        return "Solarbank Max AC"
+
+    @property
+    def sensor_definitions(self) -> list[dict]:
+        return SENSOR_DEFINITIONS
+
+    @property
+    def number_definitions(self) -> list[dict]:
+        return NUMBER_DEFINITIONS
+
+    @property
+    def select_definitions(self) -> list[dict]:
+        return SELECT_DEFINITIONS
+
+    @property
+    def switch_definitions(self) -> list[dict]:
+        return SWITCH_DEFINITIONS
+
+    @property
+    def binary_sensor_definitions(self) -> list[dict]:
+        return BINARY_SENSOR_DEFINITIONS
+
+    @property
+    def button_definitions(self) -> list[dict]:
+        return BUTTON_DEFINITIONS
+
+    @property
+    def all_definitions(self) -> list[dict]:
+        return (
+            SENSOR_DEFINITIONS
+            + NUMBER_DEFINITIONS
+            + SELECT_DEFINITIONS
+            + SWITCH_DEFINITIONS
+            + BINARY_SENSOR_DEFINITIONS
+            + BUTTON_DEFINITIONS
+        )
+
+    # --- connection lifecycle ----------------------------------------------
+
+    @property
+    def connected(self) -> bool:
+        return self._client.connected
+
+    async def connect(self) -> bool:
+        ok = await self._client.async_connect()
+        if not ok:
+            return False
+        self._client.unit_id = self._slave_id
+        mode_ok = await self._ensure_third_party_mode()
+        if not mode_ok:
+            _LOGGER.warning(
+                "Anker %s:%s connected but failed to set third_party_control mode",
+                self._host,
+                self._port,
+            )
+        return True
+
+    async def close(self) -> None:
+        await self._client.async_close()
+
+    def set_shutting_down(self, value: bool) -> None:
+        self._client.set_shutting_down(value)
+
+    # --- telemetry ----------------------------------------------------------
+
+    @property
+    def read_groups(self) -> list[ReadGroup]:
+        return self._read_groups
+
+    async def read_telemetry(self, keys: Optional[list[str]] = None) -> TelemetrySnapshot:
+        self._client.unit_id = self._slave_id
+        wanted = set(keys) if keys is not None else set(self._field_by_key)
+        snapshot: TelemetrySnapshot = {}
+
+        # Group wanted fields by the official batch range they belong to.
+        batches: dict[tuple[str, int, int], list[dict]] = {}
+        for key in wanted:
+            field = self._field_by_key.get(key)
+            if field is None:
+                continue
+            start, end = _range_for(field["address"], field["register_type"])
+            batches.setdefault((field["register_type"], start, end), []).append(field)
+
+        for (register_type, start, end), fields in batches.items():
+            count = end - start + 1
+            if register_type == "input":
+                regs = await self._client.async_read_input_block(start, count)
+            else:
+                regs = await self._client.async_read_holding_block(start, count)
+            if regs is None:
+                continue
+            for field in fields:
+                offset = field["address"] - start
+                width = field.get("count", 1)
+                if offset < 0 or offset + width > len(regs):
+                    continue
+                value = decode_registers(regs[offset:offset + width], field["data_type"])
+                if value is None:
+                    continue
+                if field.get("invert"):
+                    value = -int(value)
+                snapshot[field["key"]] = value
+                if field["key"] == "max_charge_power" and isinstance(value, (int, float)):
+                    self._dynamic_max_charge_w = max(0, int(value)) or _HW_MAX_POWER_W
+                if field["key"] == "max_discharge_power" and isinstance(value, (int, float)):
+                    self._dynamic_max_discharge_w = max(0, int(value)) or _HW_MAX_POWER_W
+
+        return snapshot
+
+    # --- control ------------------------------------------------------------
+
+    async def _ensure_third_party_mode(self) -> bool:
+        mode = await self._client.async_read_holding_register(
+            _ADDR_OPERATING_MODE, "uint16"
+        )
+        if mode == _OPERATING_MODE_THIRD_PARTY:
+            return True
+        return await self._client.async_write_register(
+            _ADDR_OPERATING_MODE, _OPERATING_MODE_THIRD_PARTY
+        )
+
+    def _clamp_net_power(self, net_power_w: int) -> int:
+        """Clamp to envelope and snap the forbidden 1–99 W band to 0 or 100."""
+        max_charge = min(_HW_MAX_POWER_W, self._dynamic_max_charge_w)
+        max_discharge = min(_HW_MAX_POWER_W, self._dynamic_max_discharge_w)
+        if net_power_w > 0:
+            net = min(net_power_w, max_charge)
+        elif net_power_w < 0:
+            net = -min(-net_power_w, max_discharge)
+        else:
+            return 0
+        magnitude = abs(net)
+        if 0 < magnitude < _MIN_OPERATING_POWER_W:
+            # Prefer idle over an illegal sub-minimum command.
+            return 0
+        return net
+
+    async def apply_setpoint(
+        self,
+        net_power_w: int,
+        *,
+        mode_hint: Optional[str] = None,
+        read_back: bool = True,
+    ) -> SetpointResult:
+        _ = mode_hint  # unused; sign of net_power_w is authoritative
+        if not self.connected:
+            return SetpointResult(
+                ok=False, net_power_w=0, confirmed=False, failure_reason="not_connected"
+            )
+
+        self._client.unit_id = self._slave_id
+        if not await self._ensure_third_party_mode():
+            return SetpointResult(
+                ok=False,
+                net_power_w=0,
+                confirmed=False,
+                failure_reason="mode_failed",
+            )
+
+        net = self._clamp_net_power(int(net_power_w))
+        wire_w = -net  # Anker: +discharge / −charge
+        ok = await self._client.async_write_registers_int32(_ADDR_POWER_SETPOINT, wire_w)
+        if not ok:
+            return SetpointResult(
+                ok=False,
+                net_power_w=net,
+                confirmed=False,
+                failure_reason="write_failed",
+            )
+
+        self._last_net_power_w = net
+        applied = {"commanded_net_power": net, "operating_mode": _OPERATING_MODE_THIRD_PARTY}
+        # Setpoint register is never_read_device — no confirmation read of 10071.
+        _ = read_back
+        return SetpointResult(
+            ok=True,
+            net_power_w=net,
+            confirmed=False,
+            applied=applied,
+        )
+
+    async def write_control(self, key: str, value: int) -> bool:
+        address = _WRITE_CONTROL_MAP.get(key)
+        if address is None:
+            return False
+        self._client.unit_id = self._slave_id
+        return await self._client.async_write_register(address, int(value))
+
+    def net_power_from_data(self, data: dict) -> Optional[int]:
+        value = data.get("commanded_net_power")
+        if value is None:
+            return self._last_net_power_w
+        return int(round(float(value)))
+
+    @property
+    def control_dependency_keys(self) -> frozenset:
+        return frozenset({
+            "max_charge_power",
+            "max_discharge_power",
+            "charging_cutoff_capacity",
+            "discharging_cutoff_capacity",
+            "operating_mode",
+            "commanded_net_power",
+        })
+
+    async def apply_config(
+        self,
+        *,
+        max_soc_pct: float,
+        min_soc_pct: float,
+        max_charge_power_w: int,
+        max_discharge_power_w: int,
+    ) -> bool:
+        """Write SOC limits to 60000/60001. Power caps are read-only on Anker."""
+        _ = (max_charge_power_w, max_discharge_power_w)
+        self._client.unit_id = self._slave_id
+        charge = _clamp_soc(max_soc_pct, 80, 100)
+        discharge = _clamp_soc(min_soc_pct, 0, 20)
+        ok = await self._client.async_write_register(_ADDR_CHARGE_SOC_LIMIT, charge)
+        ok = await self._client.async_write_register(_ADDR_DISCHARGE_SOC_LIMIT, discharge) and ok
+        return bool(ok)
+
+    async def set_charge_cutoff(self, soc_pct: float) -> bool:
+        """Write only the charge SOC limit (60000)."""
+        self._client.unit_id = self._slave_id
+        value = _clamp_soc(soc_pct, 80, 100)
+        return await self._client.async_write_register(_ADDR_CHARGE_SOC_LIMIT, value)
+
+    async def standby(self) -> bool:
+        """Idle the battery (zero setpoint) for teardown."""
+        self._client.unit_id = self._slave_id
+        ok = await self._client.async_write_registers_int32(_ADDR_POWER_SETPOINT, 0)
+        if ok:
+            self._last_net_power_w = 0
+        return bool(ok)
+
+    @classmethod
+    async def probe(
+        cls,
+        host: str,
+        port: int = 502,
+        slave_id: int = 1,
+    ) -> bool:
+        """Return True if SOC can be read over FC04 from the device."""
+        client = AnkerModbusClient(host, port, slave_id=slave_id, timeout=5.0)
+        try:
+            if not await client.async_connect():
+                return False
+            client.unit_id = slave_id
+            soc = await client.async_read_input_register(_ADDR_BATTERY_SOC, "uint16")
+            return soc is not None
+        finally:
+            await client.async_close()

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -98,7 +98,7 @@ SENSOR_DEFINITIONS: list[dict] = [
      "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
      "scan_interval": "high", "enabled_by_default": True},
     {"key": "temperature", "name": "Temperature", "unit": "°C",
-     "device_class": "temperature", "state_class": "measurement", "scale": 1, "precision": 0,
+     "device_class": "temperature", "state_class": "measurement", "scale": 0.1, "precision": 1,
      "scan_interval": "low", "enabled_by_default": True},
     {"key": "battery_status", "name": "Battery Status", "unit": None,
      "device_class": None, "state_class": None, "scale": 1, "precision": 0,

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -124,13 +124,14 @@ SENSOR_DEFINITIONS: list[dict] = [
          7: "Dynamic Pricing",
      }},
     # Hardware ceilings (official YAML internal:true) — read-only sensors.
-    # Not writable and not configurable in setup; PD uses the polled values.
+    # No device_class: these are capability limits, not live power; POWER would
+    # name them "Vermogen"/"Power" when sensor translations are missing.
     {"key": "max_charge_power", "name": "Max Charge Power", "unit": "W",
-     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
+     "device_class": None, "state_class": None, "scale": 1, "precision": 0,
      "icon": "mdi:battery-charging-high", "scan_interval": "medium",
      "enabled_by_default": True},
     {"key": "max_discharge_power", "name": "Max Discharge Power", "unit": "W",
-     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
+     "device_class": None, "state_class": None, "scale": 1, "precision": 0,
      "icon": "mdi:battery-arrow-down-outline", "scan_interval": "medium",
      "enabled_by_default": True},
     {"key": "battery_total_energy", "name": "Battery Total Energy", "unit": "kWh",
@@ -350,9 +351,16 @@ class AnkerModbusDriver(BatteryDriver):
                     value = -int(value)
                 snapshot[field["key"]] = value
                 if field["key"] == "max_charge_power" and isinstance(value, (int, float)):
-                    self._dynamic_max_charge_w = max(0, int(value)) or _HW_MAX_POWER_W
+                    # Cap at the static envelope so peak/aggregate readings
+                    # (e.g. 7000 W) do not inflate the PD clamp beyond the
+                    # Solarbank Max AC continuous rating.
+                    capped = max(0, min(_HW_MAX_POWER_W, int(value)))
+                    snapshot[field["key"]] = capped or _HW_MAX_POWER_W
+                    self._dynamic_max_charge_w = snapshot[field["key"]]
                 if field["key"] == "max_discharge_power" and isinstance(value, (int, float)):
-                    self._dynamic_max_discharge_w = max(0, int(value)) or _HW_MAX_POWER_W
+                    capped = max(0, min(_HW_MAX_POWER_W, int(value)))
+                    snapshot[field["key"]] = capped or _HW_MAX_POWER_W
+                    self._dynamic_max_discharge_w = snapshot[field["key"]]
 
         return snapshot
 

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -295,6 +295,10 @@ class AnkerModbusDriver(BatteryDriver):
         ok = await self._client.async_connect()
         if not ok:
             return False
+        # Register 10071 is write-only. A new connection may mean the battery
+        # restarted and lost the previous command, so do not expose its stale
+        # in-memory echo as observable device state.
+        self._last_net_power_w = None
         self._client.unit_id = self._slave_id
         mode_ok = await self._ensure_third_party_mode()
         if not mode_ok:
@@ -456,6 +460,12 @@ class AnkerModbusDriver(BatteryDriver):
         return await self._client.async_write_register(address, int(value))
 
     def net_power_from_data(self, data: dict) -> Optional[int]:
+        try:
+            mode = int(round(float(data["operating_mode"])))
+        except (KeyError, TypeError, ValueError):
+            return None
+        if mode != _OPERATING_MODE_THIRD_PARTY or self._last_net_power_w is None:
+            return None
         value = data.get("commanded_net_power")
         if value is None:
             return self._last_net_power_w

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -102,16 +102,32 @@ SENSOR_DEFINITIONS: list[dict] = [
      "scan_interval": "low", "enabled_by_default": True},
     {"key": "battery_status", "name": "Battery Status", "unit": None,
      "device_class": None, "state_class": None, "scale": 1, "precision": 0,
-     "scan_interval": "medium", "enabled_by_default": True},
+     "icon": "mdi:battery", "scan_interval": "medium", "enabled_by_default": True,
+     # Official Anker value_mapping for input 10001
+     "states": {
+         0: "Standby",
+         1: "Charging",
+         2: "Discharging",
+         3: "Sleep",
+     }},
     {"key": "operating_mode", "name": "Operating Mode", "unit": None,
      "device_class": None, "state_class": None, "scale": 1, "precision": 0,
-     "scan_interval": "medium", "enabled_by_default": True},
-    {"key": "max_charge_power", "name": "Max Charge Power", "unit": "W",
-     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
-     "scan_interval": "low", "enabled_by_default": False},
-    {"key": "max_discharge_power", "name": "Max Discharge Power", "unit": "W",
-     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
-     "scan_interval": "low", "enabled_by_default": False},
+     "icon": "mdi:cog", "scan_interval": "medium", "enabled_by_default": True,
+     # Official Anker operating_mode options for holding 10064
+     "states": {
+         0: "Self Consumption",
+         1: "TOU Mode",
+         3: "Third-Party Control",
+         4: "Custom Mode",
+         5: "Socket Overlay Mode",
+         6: "Smart Mode",
+         7: "Dynamic Pricing",
+     }},
+    # max_charge_power / max_discharge_power (10036/10038) stay in _FIELD_SPECS
+    # for telemetry + soft-max clamping only — they are internal device caps in
+    # the official YAML, not user-facing sensors. Exposing them as sensors stole
+    # the unique_id from MarstekSoftMaxChargeNumber and showed the hardware
+    # ceiling (3500 W) instead of the configured user limit.
     {"key": "battery_total_energy", "name": "Battery Total Energy", "unit": "kWh",
      "device_class": "energy", "state_class": "total", "scale": 0.1, "precision": 2,
      "scan_interval": "low", "enabled_by_default": True},

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -123,11 +123,16 @@ SENSOR_DEFINITIONS: list[dict] = [
          6: "Smart Mode",
          7: "Dynamic Pricing",
      }},
-    # max_charge_power / max_discharge_power (10036/10038) stay in _FIELD_SPECS
-    # for telemetry + soft-max clamping only — they are internal device caps in
-    # the official YAML, not user-facing sensors. Exposing them as sensors stole
-    # the unique_id from MarstekSoftMaxChargeNumber and showed the hardware
-    # ceiling (3500 W) instead of the configured user limit.
+    # Hardware ceilings (official YAML internal:true) — read-only sensors.
+    # Not writable and not configurable in setup; PD uses the polled values.
+    {"key": "max_charge_power", "name": "Max Charge Power", "unit": "W",
+     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
+     "icon": "mdi:battery-charging-high", "scan_interval": "medium",
+     "enabled_by_default": True},
+    {"key": "max_discharge_power", "name": "Max Discharge Power", "unit": "W",
+     "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
+     "icon": "mdi:battery-arrow-down-outline", "scan_interval": "medium",
+     "enabled_by_default": True},
     {"key": "battery_total_energy", "name": "Battery Total Energy", "unit": "kWh",
      "device_class": "energy", "state_class": "total", "scale": 0.1, "precision": 2,
      "scan_interval": "low", "enabled_by_default": True},
@@ -501,10 +506,8 @@ class AnkerModbusDriver(BatteryDriver):
 
         Returns ``(ok, caps)`` where ``caps`` may include
         ``device_max_charge_power`` / ``device_max_discharge_power`` from input
-        registers 10036/10038. Those are Anker's internal hardware ceilings
-        (often 3500 W), not a user soft limit from the Anker app — use them to
-        size the setup slider maximum, not as the soft-limit default when a
-        prior ``user_max_*`` exists.
+        registers 10036/10038 (Anker hardware ceilings). Used to seed the
+        battery config envelope; the live values are exposed as sensors.
         """
         client = AnkerModbusClient(host, port, slave_id=slave_id, timeout=5.0)
         try:

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -496,14 +496,29 @@ class AnkerModbusDriver(BatteryDriver):
         host: str,
         port: int = 502,
         slave_id: int = 1,
-    ) -> bool:
-        """Return True if SOC can be read over FC04 from the device."""
+    ) -> tuple[bool, dict[str, int]]:
+        """Probe connectivity and read device power caps when available.
+
+        Returns ``(ok, caps)`` where ``caps`` may include ``max_charge_power`` and
+        ``max_discharge_power`` from input registers 10036/10038 (used to
+        pre-populate the setup limits step).
+        """
         client = AnkerModbusClient(host, port, slave_id=slave_id, timeout=5.0)
         try:
             if not await client.async_connect():
-                return False
+                return False, {}
             client.unit_id = slave_id
-            soc = await client.async_read_input_register(_ADDR_BATTERY_SOC, "uint16")
-            return soc is not None
+            drv = cls(host, port, slave_id, client=client)
+            snap = await drv.read_telemetry(
+                ["battery_soc", "max_charge_power", "max_discharge_power"]
+            )
+            if snap.get("battery_soc") is None:
+                return False, {}
+            caps: dict[str, int] = {}
+            for key in ("max_charge_power", "max_discharge_power"):
+                raw = snap.get(key)
+                if isinstance(raw, (int, float)) and int(raw) > 0:
+                    caps[key] = max(100, min(_HW_MAX_POWER_W, int(raw)))
+            return True, caps
         finally:
             await client.async_close()

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -497,28 +497,36 @@ class AnkerModbusDriver(BatteryDriver):
         port: int = 502,
         slave_id: int = 1,
     ) -> tuple[bool, dict[str, int]]:
-        """Probe connectivity and read device power caps when available.
+        """Probe connectivity and read hardware power caps when available.
 
-        Returns ``(ok, caps)`` where ``caps`` may include ``max_charge_power`` and
-        ``max_discharge_power`` from input registers 10036/10038 (used to
-        pre-populate the setup limits step).
+        Returns ``(ok, caps)`` where ``caps`` may include
+        ``device_max_charge_power`` / ``device_max_discharge_power`` from input
+        registers 10036/10038. Those are Anker's internal hardware ceilings
+        (often 3500 W), not a user soft limit from the Anker app — use them to
+        size the setup slider maximum, not as the soft-limit default when a
+        prior ``user_max_*`` exists.
         """
         client = AnkerModbusClient(host, port, slave_id=slave_id, timeout=5.0)
         try:
             if not await client.async_connect():
                 return False, {}
             client.unit_id = slave_id
-            drv = cls(host, port, slave_id, client=client)
-            snap = await drv.read_telemetry(
-                ["battery_soc", "max_charge_power", "max_discharge_power"]
-            )
-            if snap.get("battery_soc") is None:
+            # Short dedicated reads: a truncated 10000–10050 batch can still
+            # return SOC (offset 14) while missing caps at 10036/10038.
+            soc = await client.async_read_input_register(_ADDR_BATTERY_SOC, "uint16")
+            if soc is None:
                 return False, {}
             caps: dict[str, int] = {}
-            for key in ("max_charge_power", "max_discharge_power"):
-                raw = snap.get(key)
-                if isinstance(raw, (int, float)) and int(raw) > 0:
-                    caps[key] = max(100, min(_HW_MAX_POWER_W, int(raw)))
+            charge = await client.async_read_input_register(10036, "int32")
+            discharge = await client.async_read_input_register(10038, "int32")
+            if isinstance(charge, (int, float)) and int(charge) > 0:
+                caps["device_max_charge_power"] = max(
+                    100, min(_HW_MAX_POWER_W, int(charge))
+                )
+            if isinstance(discharge, (int, float)) and int(discharge) > 0:
+                caps["device_max_discharge_power"] = max(
+                    100, min(_HW_MAX_POWER_W, int(discharge))
+                )
             return True, caps
         finally:
             await client.async_close()

--- a/custom_components/omnibattery/frontend/marstek-panel.js
+++ b/custom_components/omnibattery/frontend/marstek-panel.js
@@ -561,7 +561,7 @@ const BAT_CONTROLS = [
   // the Marstek backup_function switch; only one exists per device.
   { key: "grid_off_mode", domain: "select", lk: "bcOffgridMode", icon: "mdi:transmission-tower-off" },
   // Cell-maintenance switches (Marstek only): 100% charge voltage taper and active
-  // balancing. Both default-enabled per battery; absent on Zendure.
+  // balancing. Both default-enabled per battery; absent on Zendure/Anker.
   { key: "full_charge_voltage_taper", domain: "switch", lk: "bcVoltageTaper", icon: "mdi:battery-clock" },
   { key: "active_balance_mode", domain: "switch", lk: "bcActiveBalance", icon: "mdi:battery-sync" },
 ];

--- a/custom_components/omnibattery/infra/anker_modbus_client.py
+++ b/custom_components/omnibattery/infra/anker_modbus_client.py
@@ -1,0 +1,296 @@
+"""Async Modbus TCP client for Anker SOLIX Solarbank Max AC.
+
+Reads use only FC03 (holding) and FC04 (input) as defined by Anker's official
+``batch_read_ranges``. Writes target holding addresses with FC06 (uint16) and
+FC16 (int32), matching Anker's official HA client.
+
+INT32 word order is big-endian (high word first), same as
+:func:`decode_registers`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from pymodbus.client import AsyncModbusTcpClient
+from pymodbus.exceptions import ConnectionException, ModbusIOException
+
+from .modbus_client import _detect_slave_kwarg, decode_registers
+
+_LOGGER = logging.getLogger(__name__)
+
+_REQUEST_TIMEOUT_S = 10.0
+_MESSAGE_WAIT_S = 0.05
+
+
+def encode_int32(value: int) -> list[int]:
+    """Encode a signed 32-bit value as two Modbus registers (big-endian words)."""
+    if value < 0:
+        value += 0x100000000
+    return [(value >> 16) & 0xFFFF, value & 0xFFFF]
+
+
+class AnkerModbusClient:
+    """Thin async Modbus TCP transport for Anker Solarbank devices."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 502,
+        slave_id: int = 1,
+        timeout: float = _REQUEST_TIMEOUT_S,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.unit_id = slave_id
+        self._timeout = timeout
+        self._client: Optional[AsyncModbusTcpClient] = None
+        self._slave_kwarg = "slave"
+        self._is_shutting_down = False
+
+    @property
+    def connected(self) -> bool:
+        client = self._client
+        return bool(client is not None and getattr(client, "connected", False))
+
+    def set_shutting_down(self, value: bool) -> None:
+        self._is_shutting_down = bool(value)
+
+    async def async_connect(self) -> bool:
+        """Open a fresh TCP connection. Returns True on success."""
+        await self.async_close()
+        client = AsyncModbusTcpClient(
+            host=self.host,
+            port=self.port,
+            timeout=self._timeout,
+        )
+        try:
+            connected = await client.connect()
+        except Exception as err:
+            _LOGGER.error(
+                "Anker Modbus connect failed %s:%s: %s",
+                self.host,
+                self.port,
+                err,
+            )
+            try:
+                close_result = client.close()
+                if asyncio.iscoroutine(close_result):
+                    await close_result
+            except Exception:
+                pass
+            return False
+        if not connected:
+            _LOGGER.error(
+                "Anker Modbus connect refused %s:%s", self.host, self.port
+            )
+            return False
+        self._client = client
+        self._slave_kwarg = _detect_slave_kwarg(client)
+        return True
+
+    async def async_close(self) -> None:
+        """Close the TCP connection if open."""
+        client = self._client
+        self._client = None
+        if client is None:
+            return
+        try:
+            result = client.close()
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as err:
+            _LOGGER.debug("Error closing Anker Modbus connection: %s", err)
+
+    async def _pace(self) -> None:
+        if self._is_shutting_down:
+            return
+        await asyncio.sleep(_MESSAGE_WAIT_S)
+
+    async def _read_raw(
+        self,
+        *,
+        address: int,
+        count: int,
+        register_type: str,
+    ) -> Optional[list[int]]:
+        """Read ``count`` registers via FC03 (holding) or FC04 (input)."""
+        if register_type not in ("holding", "input"):
+            raise ValueError(f"Unsupported register_type: {register_type}")
+        if not (0 <= address <= 0xFFFF) or not (1 <= count <= 125):
+            _LOGGER.error(
+                "Invalid Anker Modbus read address=%s count=%s", address, count
+            )
+            return None
+        if self._client is None or not self.connected:
+            return None
+
+        kwargs = {self._slave_kwarg: self.unit_id}
+        try:
+            try:
+                if register_type == "holding":
+                    result = await asyncio.wait_for(
+                        self._client.read_holding_registers(
+                            address=address, count=count, **kwargs
+                        ),
+                        timeout=self._timeout,
+                    )
+                else:
+                    result = await asyncio.wait_for(
+                        self._client.read_input_registers(
+                            address=address, count=count, **kwargs
+                        ),
+                        timeout=self._timeout,
+                    )
+            finally:
+                await self._pace()
+
+            if result.isError():
+                if not self._is_shutting_down:
+                    _LOGGER.error(
+                        "Anker Modbus %s read error at %d (count=%d)",
+                        register_type,
+                        address,
+                        count,
+                    )
+                return None
+            regs = getattr(result, "registers", None)
+            if regs is None or len(regs) < count:
+                if not self._is_shutting_down:
+                    _LOGGER.warning(
+                        "Anker Modbus incomplete %s read at %d: got %s expected %d",
+                        register_type,
+                        address,
+                        len(regs) if regs else 0,
+                        count,
+                    )
+                return None
+            return list(regs[:count])
+        except (ConnectionException, ModbusIOException, asyncio.TimeoutError):
+            if not self._is_shutting_down:
+                _LOGGER.debug(
+                    "Anker Modbus connection error reading %s %d",
+                    register_type,
+                    address,
+                )
+            return None
+        except Exception as err:
+            if not self._is_shutting_down:
+                _LOGGER.exception(
+                    "Anker Modbus exception reading %s %d: %s",
+                    register_type,
+                    address,
+                    err,
+                )
+            return None
+
+    async def async_read_input_block(
+        self, start: int, count: int
+    ) -> Optional[list[int]]:
+        """FC04: read contiguous input registers."""
+        return await self._read_raw(
+            address=start, count=count, register_type="input"
+        )
+
+    async def async_read_holding_block(
+        self, start: int, count: int
+    ) -> Optional[list[int]]:
+        """FC03: read contiguous holding registers."""
+        return await self._read_raw(
+            address=start, count=count, register_type="holding"
+        )
+
+    async def async_read_input_register(
+        self,
+        address: int,
+        data_type: str = "uint16",
+        count: Optional[int] = None,
+    ):
+        """FC04: read and decode one typed value from input registers."""
+        if count is None:
+            count = 2 if data_type in ("int32", "uint32") else 1
+        regs = await self.async_read_input_block(address, count)
+        if regs is None:
+            return None
+        return decode_registers(regs, data_type)
+
+    async def async_read_holding_register(
+        self,
+        address: int,
+        data_type: str = "uint16",
+        count: Optional[int] = None,
+    ):
+        """FC03: read and decode one typed value from holding registers."""
+        if count is None:
+            count = 2 if data_type in ("int32", "uint32") else 1
+        regs = await self.async_read_holding_block(address, count)
+        if regs is None:
+            return None
+        return decode_registers(regs, data_type)
+
+    async def async_write_register(self, address: int, value: int) -> bool:
+        """FC06: write a single uint16 holding register."""
+        if self._client is None or not self.connected:
+            return False
+        kwargs = {self._slave_kwarg: self.unit_id}
+        try:
+            try:
+                result = await asyncio.wait_for(
+                    self._client.write_register(
+                        address=address,
+                        value=int(value) & 0xFFFF,
+                        **kwargs,
+                    ),
+                    timeout=self._timeout,
+                )
+            finally:
+                await self._pace()
+            return not result.isError()
+        except (ConnectionException, ModbusIOException, asyncio.TimeoutError):
+            if not self._is_shutting_down:
+                _LOGGER.debug(
+                    "Anker Modbus connection error writing register %d", address
+                )
+            return False
+        except Exception as err:
+            if not self._is_shutting_down:
+                _LOGGER.exception(
+                    "Anker Modbus exception writing register %d: %s",
+                    address,
+                    err,
+                )
+            return False
+
+    async def async_write_registers_int32(self, address: int, value: int) -> bool:
+        """FC16: write a signed INT32 as two holding registers (big-endian)."""
+        if self._client is None or not self.connected:
+            return False
+        words = encode_int32(int(value))
+        kwargs = {self._slave_kwarg: self.unit_id}
+        try:
+            try:
+                result = await asyncio.wait_for(
+                    self._client.write_registers(
+                        address=address, values=words, **kwargs
+                    ),
+                    timeout=self._timeout,
+                )
+            finally:
+                await self._pace()
+            return not result.isError()
+        except (ConnectionException, ModbusIOException, asyncio.TimeoutError):
+            if not self._is_shutting_down:
+                _LOGGER.debug(
+                    "Anker Modbus connection error writing INT32 at %d", address
+                )
+            return False
+        except Exception as err:
+            if not self._is_shutting_down:
+                _LOGGER.exception(
+                    "Anker Modbus exception writing INT32 at %d: %s",
+                    address,
+                    err,
+                )
+            return False

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -341,17 +341,30 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
 
     @property
     def needs_software_max_charge(self) -> bool:
-        """True when max_charge_power is a read-only device cap rather than a
-        writable register, so a software ceiling entity governs it (e.g. Zendure
-        chargeMaxLimit, Anker 10036)."""
-        return not any(d["key"] == "max_charge_power" for d in self.number_definitions)
+        """True when max_charge_power has no writable register and no sensor.
+
+        Zendure exposes chargeMaxLimit only as telemetry, so a software ceiling
+        number entity governs it. Anker exposes 10036 as a read-only sensor —
+        PD follows the device value directly, with no soft-max entity.
+        """
+        if any(d["key"] == "max_charge_power" for d in self.number_definitions):
+            return False
+        if any(d["key"] == "max_charge_power" for d in self.sensor_definitions):
+            return False
+        return True
 
     @property
     def needs_software_max_discharge(self) -> bool:
-        """True when max_discharge_power is a read-only device cap rather than a
-        writable register (e.g. Anker 10038). Zendure exposes inverse_max_power
-        as a writable number instead, so it reports False."""
-        return not any(d["key"] == "max_discharge_power" for d in self.number_definitions)
+        """True when max_discharge_power has no writable register and no sensor.
+
+        Anker exposes 10038 as a read-only sensor (no soft-max entity). Zendure
+        exposes inverse_max_power as a writable number, so it reports False.
+        """
+        if any(d["key"] == "max_discharge_power" for d in self.number_definitions):
+            return False
+        if any(d["key"] == "max_discharge_power" for d in self.sensor_definitions):
+            return False
+        return True
 
     @property
     def is_available(self) -> bool:
@@ -810,9 +823,9 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             self.min_soc = int(self.data["min_soc"])
         if "max_charge_power" in self.data:
             device_cap = int(self.data["max_charge_power"])
-            # When max_charge_power is a read-only device cap (Zendure/Anker), honour
-            # the user's software ceiling on top of it; otherwise the polled register
-            # value is itself the user setting.
+            # When max_charge_power is a soft-capped telemetry value (Zendure),
+            # honour the user's software ceiling on top of it; otherwise the
+            # polled register/sensor value is itself the effective limit.
             self.max_charge_power = (
                 min(device_cap, self.user_max_charge_power)
                 if self.needs_software_max_charge else device_cap

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -348,7 +348,8 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         Anker exposes 10038 as a read-only sensor (no soft-max entity). Zendure
         exposes inverse_max_power as a writable number, so it reports False.
         """
-        if any(d["key"] == "max_discharge_power" for d in self.number_definitions):
+        writable_keys = {d["key"] for d in self.number_definitions}
+        if {"max_discharge_power", "inverse_max_power"} & writable_keys:
             return False
         if any(d["key"] == "max_discharge_power" for d in self.sensor_definitions):
             return False
@@ -438,7 +439,10 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 # Skip if the user explicitly disabled RS485 via the switch.
                 # Already inside self.lock, so call the driver directly (the
                 # set_rs485_control wrapper would re-acquire the lock and deadlock).
-                if not self.rs485_user_disabled:
+                if (
+                    self.capabilities.has_rs485_control
+                    and not self.rs485_user_disabled
+                ):
                     if await self.driver.set_rs485_control(True):
                         _LOGGER.info("[%s] RS485 control mode re-enabled after reconnection", self.name)
                     else:

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -23,6 +23,7 @@ from ..const import (
 from ..drivers.esphome import EsphomeEntityDriver
 from ..drivers.marstek import MarstekModbusDriver
 from ..drivers.zendure import ZendureLocalDriver, ZENDURE_MODEL_2400AC_PRO
+from ..drivers.anker import AnkerModbusDriver
 from ..drivers.base import SetpointResult
 from .alarm_notifier import AlarmNotifier
 
@@ -114,7 +115,7 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         self.serial_port = serial_port
         self.consumption_sensor = consumption_sensor
         self.brand = brand
-        if self.brand == "zendure":
+        if self.brand in ("zendure", "anker"):
             full_charge_voltage_taper_enabled = False
             active_balance_mode_enabled = False
 
@@ -246,6 +247,14 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             self.driver = EsphomeEntityDriver(
                 hass,
                 esphome_device_id or self.host,
+                max_charge_power_w=self.max_charge_power,
+                max_discharge_power_w=self.max_discharge_power,
+            )
+        elif self.brand == "anker":
+            self.driver = AnkerModbusDriver(
+                self.host,
+                self.port,
+                self.slave_id,
                 max_charge_power_w=self.max_charge_power,
                 max_discharge_power_w=self.max_discharge_power,
             )

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -158,9 +158,11 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         self.commanded_charge_power = 0
         self.commanded_discharge_power = 0
         # Software charge-power ceiling for drivers whose reported max_charge_power
-        # is a read-only device cap (Zendure chargeMaxLimit). Caps PD allocation
-        # below the device limit; default = device max (no extra cap). Persisted.
+        # is a read-only device cap (Zendure chargeMaxLimit / Anker 10036). Caps PD
+        # allocation below the device limit; default = device max (no extra cap).
+        # Persisted. Same idea for discharge on Anker (10038).
         self.user_max_charge_power = max_charge_power
+        self.user_max_discharge_power = max_discharge_power
         self.allow_charge = allow_charge
         self.allow_discharge = allow_discharge
         self.active_balance_mode_enabled = active_balance_mode_enabled
@@ -341,8 +343,15 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
     def needs_software_max_charge(self) -> bool:
         """True when max_charge_power is a read-only device cap rather than a
         writable register, so a software ceiling entity governs it (e.g. Zendure
-        chargeMaxLimit)."""
+        chargeMaxLimit, Anker 10036)."""
         return not any(d["key"] == "max_charge_power" for d in self.number_definitions)
+
+    @property
+    def needs_software_max_discharge(self) -> bool:
+        """True when max_discharge_power is a read-only device cap rather than a
+        writable register (e.g. Anker 10038). Zendure exposes inverse_max_power
+        as a writable number instead, so it reports False."""
+        return not any(d["key"] == "max_discharge_power" for d in self.number_definitions)
 
     @property
     def is_available(self) -> bool:
@@ -372,8 +381,16 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         return {
             "identifiers": {(DOMAIN, f"{self.device_key}")},
             "name": self.name,
-            "manufacturer": "Zendure" if self.brand == "zendure" else "Marstek",
-            "model": self.driver.model_label or ("Zendure" if self.brand == "zendure" else "Venus"),
+            "manufacturer": (
+                "Zendure" if self.brand == "zendure"
+                else "Anker" if self.brand == "anker"
+                else "Marstek"
+            ),
+            "model": self.driver.model_label or (
+                "Zendure" if self.brand == "zendure"
+                else "Solarbank Max AC" if self.brand == "anker"
+                else "Venus"
+            ),
         }
 
     async def connect(self) -> bool:
@@ -793,15 +810,19 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             self.min_soc = int(self.data["min_soc"])
         if "max_charge_power" in self.data:
             device_cap = int(self.data["max_charge_power"])
-            # When max_charge_power is a read-only device cap (Zendure), honour the
-            # user's software ceiling on top of it; otherwise the polled register
+            # When max_charge_power is a read-only device cap (Zendure/Anker), honour
+            # the user's software ceiling on top of it; otherwise the polled register
             # value is itself the user setting.
             self.max_charge_power = (
                 min(device_cap, self.user_max_charge_power)
                 if self.needs_software_max_charge else device_cap
             )
         if "max_discharge_power" in self.data:
-            self.max_discharge_power = int(self.data["max_discharge_power"])
+            device_cap = int(self.data["max_discharge_power"])
+            self.max_discharge_power = (
+                min(device_cap, self.user_max_discharge_power)
+                if self.needs_software_max_discharge else device_cap
+            )
 
         if updated_data:
             _LOGGER.debug(

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -619,7 +619,7 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             fetch_keys = []
             for key in group.keys:
                 sensor = self._def_by_key.get(key, {})
-                entity_type = self._get_entity_type(sensor)
+                entity_type = self._get_entity_type(sensor, fallback_key=key)
                 registry_entry = None
                 for unique_id in (
                     f"{self.device_key}_{key}",   # current format (post-migration)
@@ -840,9 +840,17 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
 
         return self.data
 
-    def _get_entity_type(self, sensor_definition: dict) -> str:
-        """Determine entity type based on sensor definition."""
-        key = sensor_definition["key"]
+    def _get_entity_type(self, sensor_definition: dict, fallback_key: str | None = None) -> str:
+        """Determine entity type based on sensor definition.
+
+        Telemetry-only keys (present in driver field/read groups but not in any
+        entity definition list — e.g. Anker max_charge/discharge power caps used
+        for soft-max clamping) resolve via ``fallback_key`` and default to
+        ``sensor`` so the poll loop does not KeyError on an empty stub dict.
+        """
+        key = sensor_definition.get("key", fallback_key)
+        if not key:
+            return "sensor"
 
         # Check which definition list this sensor belongs to by key
         if key in [s["key"] for s in self.sensor_definitions]:
@@ -856,7 +864,7 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         elif key in [s["key"] for s in self.binary_sensor_definitions]:
             return "binary_sensor"
         else:
-            # Default to sensor if not found
+            # Default to sensor if not found (telemetry-only / soft-max keys)
             return "sensor"
 
     async def write_control(self, key: str, value: int, do_refresh: bool = True):

--- a/custom_components/omnibattery/number.py
+++ b/custom_components/omnibattery/number.py
@@ -70,10 +70,12 @@ async def async_setup_entry(
             entities.append(MarstekManualSetPowerNumber(coordinator, "charge"))
             entities.append(MarstekManualSetPowerNumber(coordinator, "discharge"))
 
-        # Drivers whose max_charge_power is a read-only device cap (Zendure) get
-        # a software charge-power ceiling instead of the writable register entity.
+        # Drivers whose max_charge_power is a read-only device cap (Zendure/Anker)
+        # get a software charge-power ceiling instead of the writable register entity.
         if coordinator.needs_software_max_charge:
             entities.append(MarstekSoftMaxChargeNumber(coordinator))
+        if coordinator.needs_software_max_discharge:
+            entities.append(MarstekSoftMaxDischargeNumber(coordinator))
 
     # Add config numbers (system-level, PD parameters). Conditional entities are
     # gated on their feature key being present (enabled OR disabled) — the panel
@@ -689,7 +691,7 @@ class MarstekManualSetPowerNumber(CoordinatorEntity, NumberEntity):
 
 class MarstekSoftMaxChargeNumber(CoordinatorEntity, NumberEntity):
     """Software charge-power ceiling for drivers whose reported max_charge_power
-    is a read-only device cap (Zendure chargeMaxLimit).
+    is a read-only device cap (Zendure chargeMaxLimit / Anker 10036).
 
     Stores a user limit on the coordinator; the poll loop applies
     min(device_cap, user limit) to coordinator.max_charge_power, which the PD
@@ -729,6 +731,52 @@ class MarstekSoftMaxChargeNumber(CoordinatorEntity, NumberEntity):
             min(int(device_cap), new_value) if device_cap is not None else new_value
         )
         _LOGGER.info("%s: user_max_charge_power → %dW", self.coordinator.name, new_value)
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        """Return device information."""
+        return self.coordinator.battery_device_info
+
+
+class MarstekSoftMaxDischargeNumber(CoordinatorEntity, NumberEntity):
+    """Software discharge-power ceiling for drivers whose reported max_discharge_power
+    is a read-only device cap (Anker 10038).
+
+    Mirrors :class:`MarstekSoftMaxChargeNumber` for the discharge direction.
+    """
+
+    def __init__(self, coordinator: MarstekVenusDataUpdateCoordinator) -> None:
+        """Initialize the soft max-discharge entity."""
+        super().__init__(coordinator)
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "max_discharge_power"
+        self._attr_unique_id = f"{coordinator.device_key}_max_discharge_power"
+        self.entity_id = english_entity_id("number", coordinator.name, "max_discharge_power")
+        self._attr_icon = "mdi:battery-arrow-down-outline"
+        self._attr_native_unit_of_measurement = "W"
+        self._attr_native_min_value = 0
+        self._attr_native_max_value = coordinator.capabilities.max_discharge_power_w
+        self._attr_native_step = 10
+        self._attr_should_poll = False
+
+    @property
+    def native_value(self) -> float:
+        """Return the user-set discharge ceiling."""
+        return float(self.coordinator.user_max_discharge_power)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Store the ceiling, persist it, and apply it against the device cap now."""
+        new_value = int(value)
+        self.coordinator.user_max_discharge_power = new_value
+        self.coordinator.persist_battery_config("user_max_discharge_power", new_value)
+        device_cap = None
+        if self.coordinator.data is not None:
+            device_cap = self.coordinator.data.get("max_discharge_power")
+        self.coordinator.max_discharge_power = (
+            min(int(device_cap), new_value) if device_cap is not None else new_value
+        )
+        _LOGGER.info("%s: user_max_discharge_power → %dW", self.coordinator.name, new_value)
         self.async_write_ha_state()
 
     @property

--- a/custom_components/omnibattery/number.py
+++ b/custom_components/omnibattery/number.py
@@ -70,8 +70,9 @@ async def async_setup_entry(
             entities.append(MarstekManualSetPowerNumber(coordinator, "charge"))
             entities.append(MarstekManualSetPowerNumber(coordinator, "discharge"))
 
-        # Drivers whose max_charge_power is a read-only device cap (Zendure/Anker)
-        # get a software charge-power ceiling instead of the writable register entity.
+        # Drivers whose max_charge_power is telemetry-only with no sensor entity
+        # (Zendure chargeMaxLimit) get a software charge-power ceiling. Anker
+        # exposes 10036/10038 as sensors instead — no soft-max numbers.
         if coordinator.needs_software_max_charge:
             entities.append(MarstekSoftMaxChargeNumber(coordinator))
         if coordinator.needs_software_max_discharge:
@@ -690,8 +691,8 @@ class MarstekManualSetPowerNumber(CoordinatorEntity, NumberEntity):
 
 
 class MarstekSoftMaxChargeNumber(CoordinatorEntity, NumberEntity):
-    """Software charge-power ceiling for drivers whose reported max_charge_power
-    is a read-only device cap (Zendure chargeMaxLimit / Anker 10036).
+    """Software charge-power ceiling for drivers whose max_charge_power is
+    telemetry-only with no sensor entity (Zendure chargeMaxLimit).
 
     Stores a user limit on the coordinator; the poll loop applies
     min(device_cap, user limit) to coordinator.max_charge_power, which the PD
@@ -740,10 +741,9 @@ class MarstekSoftMaxChargeNumber(CoordinatorEntity, NumberEntity):
 
 
 class MarstekSoftMaxDischargeNumber(CoordinatorEntity, NumberEntity):
-    """Software discharge-power ceiling for drivers whose reported max_discharge_power
-    is a read-only device cap (Anker 10038).
-
-    Mirrors :class:`MarstekSoftMaxChargeNumber` for the discharge direction.
+    """Software discharge-power ceiling when max_discharge_power has no register
+    or sensor entity. Anker exposes 10038 as a sensor (no soft-max); this
+    remains for drivers that need a software discharge ceiling.
     """
 
     def __init__(self, coordinator: MarstekVenusDataUpdateCoordinator) -> None:

--- a/custom_components/omnibattery/sensor.py
+++ b/custom_components/omnibattery/sensor.py
@@ -289,7 +289,15 @@ class MarstekVenusSensor(CoordinatorEntity, SensorEntity):
         
         # Map numeric values to state names if available
         if "states" in self.definition:
-            return self.definition["states"].get(value, value)
+            states = self.definition["states"]
+            if value in states:
+                return states[value]
+            # Coordinators may store ints as floats after scale/round; try int key.
+            try:
+                ivalue = int(value)
+            except (TypeError, ValueError):
+                return value
+            return states.get(ivalue, value)
         
         # For bit-described values, show which bits are active
         if "bit_descriptions" in self.definition:

--- a/custom_components/omnibattery/sensors/balance_sensors.py
+++ b/custom_components/omnibattery/sensors/balance_sensors.py
@@ -20,7 +20,11 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up balance sensor entities — one group of 5 per battery."""
+    """Set up balance sensor entities — one group of 5 per battery.
+
+    Skipped for brands without per-cell voltage telemetry (e.g. Anker): the
+    five diagnostic "Balans" sensors need max/min cell voltage to be meaningful.
+    """
     monitor: BalanceMonitor | None = hass.data[DOMAIN][entry.entry_id].get("balance_monitor")
     if monitor is None:
         return
@@ -29,6 +33,10 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
 
     for coordinator in coordinators:
+        sensor_keys = {d["key"] for d in coordinator.sensor_definitions}
+        if "max_cell_voltage" not in sensor_keys or "min_cell_voltage" not in sensor_keys:
+            continue
+
         host = coordinator.device_key
         init = monitor.get_initial_state(host)
 
@@ -45,7 +53,8 @@ async def async_setup_entry(
 
         entities.extend([delta, status, trend, last_read, avg4w])
 
-    async_add_entities(entities)
+    if entities:
+        async_add_entities(entities)
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -37,7 +37,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -74,6 +74,22 @@
           "name": "Descriptive name to identify this battery",
           "host": "IP address of the Zendure device on your local network",
           "port": "HTTP port (default 80)"
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       },
       "battery_connection_esphome": {
@@ -477,6 +493,22 @@
           "port": "HTTP port (default 80)"
         }
       },
+      "reconfigure_battery_anker": {
+        "title": "Reconfigure battery {battery_num} — Connection (Anker)",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "New IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
+        }
+      },
       "reconfigure_battery_esphome": {
         "title": "Reconfigure battery {battery_num} — Connection (LilyGo/ESPHome)",
         "description": "Update the ESPHome device for Marstek battery {battery_num}. All other settings are preserved.",
@@ -570,7 +602,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -972,6 +1004,22 @@
           "hourly_balance_max_offset_w": "Maximum power offset the controller can apply. The slider ceiling is the combined discharge power of all configured batteries.",
           "hourly_balance_deadband_wh": "Tolerance band around the target. No correction is applied when the net balance is within ±N kWh of the target. 0 = exact correction.",
           "hourly_balance_hysteresis_w": "Minimum change in offset required before a new correction is applied. Prevents micro-adjustments every cycle. 0 = apply every cycle. Default: 15 W."
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -1280,6 +1280,12 @@
       "battery_power": {
         "name": "Battery Power"
       },
+      "max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
       "internal_temperature": {
         "name": "Internal Temperature"
       },

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -1301,6 +1301,12 @@
       "inverter_state": {
         "name": "Inverter State"
       },
+      "battery_status": {
+        "name": "Battery Status"
+      },
+      "operating_mode": {
+        "name": "Operating Mode"
+      },
       "battery_voltage": {
         "name": "Battery Voltage"
       },

--- a/custom_components/omnibattery/switch.py
+++ b/custom_components/omnibattery/switch.py
@@ -64,7 +64,9 @@ async def async_setup_entry(
         if controller:
             entities.append(BatteryAllowChargeSwitch(hass, entry, controller, coordinator))
             entities.append(BatteryAllowDischargeSwitch(hass, entry, controller, coordinator))
-            if coordinator.brand != "zendure":
+            # Marstek-only cell maintenance: voltage taper + active balance need
+            # per-cell voltages Anker/Zendure do not expose the same way.
+            if coordinator.brand not in ("zendure", "anker"):
                 entities.append(BatteryFullChargeVoltageTaperSwitch(hass, entry, controller, coordinator))
                 entities.append(BatteryActiveBalanceModeSwitch(hass, entry, controller, coordinator))
 

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -37,7 +37,7 @@
           "brand": "Marca de la bateria"
         },
         "data_description": {
-          "brand": "Selecciona el fabricant de la bateria. Marstek Venus utilitza Modbus TCP. Zendure SolarFlow utilitza HTTP local (requereix HEMS activat a l'app Zendure)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -485,6 +485,22 @@
           "port": "Port HTTP (per defecte 80)"
         }
       },
+      "reconfigure_battery_anker": {
+        "title": "Reconfigure battery {battery_num} — Connection (Anker)",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "New IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
+        }
+      },
       "reconfigure_battery_esphome": {
         "title": "Reconfigura la bateria {battery_num} — Connexió (LilyGo/ESPHome)",
         "description": "Actualitza el dispositiu ESPHome de la bateria Marstek {battery_num}. La resta d'ajustos es conserven.",
@@ -502,6 +518,22 @@
         "description": "S'ha trobat una còpia de seguretat de {count} configuració(ns) anterior(s) (connexió, opcions i ajust). Vols restaurar-la per recuperar-ho tot sense tornar a configurar? Les teves entitats i historial es reconnectaran automàticament.",
         "data": {
           "restore": "Restaura la configuració anterior"
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },
@@ -579,7 +611,7 @@
           "brand": "Marca de la bateria"
         },
         "data_description": {
-          "brand": "Selecciona el fabricant de la bateria. Marstek Venus utilitza Modbus TCP. Zendure SolarFlow utilitza HTTP local (requereix HEMS activat a l'app Zendure)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -989,6 +1021,22 @@
           "hourly_balance_max_offset_w": "Desplaçament de potència màxim que el controlador pot aplicar. El slider està limitat a la potència combinada de les bateries.",
           "hourly_balance_deadband_wh": "Tolerància al voltant de l'objectiu. No s'aplica correcció si el balanç net està dins de ±N kWh de l'objectiu. 0 = correcció exacta.",
           "hourly_balance_hysteresis_w": "Canvi mínim en el desplaçament necessari per aplicar una nova correcció. Evita micro-ajustos cada cicle. 0 = aplicar sempre. Per defecte: 15 W."
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -1319,6 +1319,12 @@
       "inverter_state": {
         "name": "Estat de l'Inversor"
       },
+      "battery_status": {
+        "name": "Estat de la Bateria"
+      },
+      "operating_mode": {
+        "name": "Mode de Funcionament"
+      },
       "battery_voltage": {
         "name": "Tensió de la Bateria"
       },

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -1298,6 +1298,12 @@
       "battery_power": {
         "name": "Potència de la Bateria"
       },
+      "max_charge_power": {
+        "name": "Màx. potència de càrrega"
+      },
+      "max_discharge_power": {
+        "name": "Màx. potència de descàrrega"
+      },
       "internal_temperature": {
         "name": "Temperatura Interna"
       },

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -37,7 +37,7 @@
           "brand": "Batteriemarke"
         },
         "data_description": {
-          "brand": "Wählen Sie den Hersteller der Batterie. Marstek Venus verwendet Modbus TCP. Zendure SolarFlow verwendet lokales HTTP (erfordert HEMS in der Zendure-App aktiviert)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -485,6 +485,22 @@
           "port": "HTTP-Port (Standard 80)"
         }
       },
+      "reconfigure_battery_anker": {
+        "title": "Reconfigure battery {battery_num} — Connection (Anker)",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "New IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
+        }
+      },
       "reconfigure_battery_esphome": {
         "title": "Batterie {battery_num} neu konfigurieren — Verbindung (LilyGo/ESPHome)",
         "description": "Aktualisiere das ESPHome-Gerät der Marstek-Batterie {battery_num}. Alle anderen Einstellungen bleiben erhalten.",
@@ -502,6 +518,22 @@
         "description": "Eine gespeicherte Sicherung von {count} vorherigen Konfiguration(en) (Verbindung, Optionen und Abstimmung) wurde gefunden. Wiederherstellen, um alles ohne erneute Einrichtung zurückzubekommen? Deine Entitäten und der Verlauf werden automatisch wieder verbunden.",
         "data": {
           "restore": "Vorherige Konfiguration wiederherstellen"
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },
@@ -579,7 +611,7 @@
           "brand": "Batteriemarke"
         },
         "data_description": {
-          "brand": "Wählen Sie den Hersteller der Batterie. Marstek Venus verwendet Modbus TCP. Zendure SolarFlow verwendet lokales HTTP (erfordert HEMS in der Zendure-App aktiviert)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -989,6 +1021,22 @@
           "hourly_balance_max_offset_w": "Maximaler Leistungsversatz des Reglers. Der Schieberegler ist auf die kombinierte Entladeleistung aller Batterien begrenzt.",
           "hourly_balance_deadband_wh": "Toleranzband um den Zielwert. Keine Korrektur, wenn die Nettobilanz innerhalb von ±N kWh liegt. 0 = exakte Korrektur.",
           "hourly_balance_hysteresis_w": "Minimale Änderung des Versatzes, bevor eine neue Korrektur angewendet wird. Verhindert Mikro-Anpassungen jeden Zyklus. 0 = immer anwenden. Standard: 15 W."
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -1298,6 +1298,12 @@
       "battery_power": {
         "name": "Batterieleistung"
       },
+      "max_charge_power": {
+        "name": "Max. Ladeleistung"
+      },
+      "max_discharge_power": {
+        "name": "Max. Entladeleistung"
+      },
       "internal_temperature": {
         "name": "Innentemperatur"
       },

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -1319,6 +1319,12 @@
       "inverter_state": {
         "name": "Wechselrichterstatus"
       },
+      "battery_status": {
+        "name": "Batteriestatus"
+      },
+      "operating_mode": {
+        "name": "Betriebsmodus"
+      },
       "battery_voltage": {
         "name": "Batteriespannung"
       },

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -1286,6 +1286,12 @@
       "battery_power": {
         "name": "Battery Power"
       },
+      "max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
       "internal_temperature": {
         "name": "Internal Temperature"
       },

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -1307,6 +1307,12 @@
       "inverter_state": {
         "name": "Inverter State"
       },
+      "battery_status": {
+        "name": "Battery Status"
+      },
+      "operating_mode": {
+        "name": "Operating Mode"
+      },
       "battery_voltage": {
         "name": "Battery Voltage"
       },

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -37,7 +37,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -479,6 +479,22 @@
           "port": "HTTP port (default 80)"
         }
       },
+      "reconfigure_battery_anker": {
+        "title": "Reconfigure battery {battery_num} — Connection (Anker)",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "New IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
+        }
+      },
       "reconfigure_battery_esphome": {
         "title": "Reconfigure battery {battery_num} — Connection (LilyGo/ESPHome)",
         "description": "Update the ESPHome device for Marstek battery {battery_num}. All other settings are preserved.",
@@ -496,6 +512,22 @@
         "description": "Found a saved backup of {count} previous configuration(s) (connection, options and tuning). Restore it to recover everything without setting it up again? Your entities and history reconnect automatically.",
         "data": {
           "restore": "Restore previous configuration"
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },
@@ -573,7 +605,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -977,6 +1009,22 @@
           "hourly_balance_max_offset_w": "Maximum power offset the controller can apply. The slider ceiling is the combined discharge power of all configured batteries.",
           "hourly_balance_deadband_wh": "Tolerance band around the target. No correction is applied when the net balance is within ±N kWh of the target. 0 = exact correction.",
           "hourly_balance_hysteresis_w": "Minimum change in offset required before a new correction is applied. Prevents micro-adjustments every cycle. 0 = apply every cycle. Default: 15 W."
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -1298,6 +1298,12 @@
       "battery_power": {
         "name": "Potencia de la Batería"
       },
+      "max_charge_power": {
+        "name": "Máx. potencia de carga"
+      },
+      "max_discharge_power": {
+        "name": "Máx. potencia de descarga"
+      },
       "internal_temperature": {
         "name": "Temperatura Interna"
       },

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -1319,6 +1319,12 @@
       "inverter_state": {
         "name": "Estado del Inversor"
       },
+      "battery_status": {
+        "name": "Estado de la Batería"
+      },
+      "operating_mode": {
+        "name": "Modo de Operación"
+      },
       "battery_voltage": {
         "name": "Tensión de la Batería"
       },

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -37,7 +37,7 @@
           "brand": "Marca de la batería"
         },
         "data_description": {
-          "brand": "Selecciona el fabricante de la batería. Marstek Venus usa Modbus TCP. Zendure SolarFlow usa HTTP local (requiere HEMS activado en la app Zendure)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -485,6 +485,22 @@
           "port": "Puerto HTTP (por defecto 80)"
         }
       },
+      "reconfigure_battery_anker": {
+        "title": "Reconfigure battery {battery_num} — Connection (Anker)",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "New IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
+        }
+      },
       "reconfigure_battery_esphome": {
         "title": "Reconfigurar batería {battery_num} — Conexión (LilyGo/ESPHome)",
         "description": "Actualiza el dispositivo ESPHome de la batería Marstek {battery_num}. El resto de ajustes se conservan.",
@@ -502,6 +518,22 @@
         "description": "Se encontró una copia de seguridad de {count} configuración(es) anterior(es) (conexión, opciones y ajuste). ¿Restaurarla para recuperar todo sin configurarlo de nuevo? Tus entidades e histórico se reconectarán automáticamente.",
         "data": {
           "restore": "Restaurar la configuración anterior"
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },
@@ -579,7 +611,7 @@
           "brand": "Marca de la batería"
         },
         "data_description": {
-          "brand": "Selecciona el fabricante de la batería. Marstek Venus usa Modbus TCP. Zendure SolarFlow usa HTTP local (requiere HEMS activado en la app Zendure)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -989,6 +1021,22 @@
           "hourly_balance_max_offset_w": "Desplazamiento de potencia máximo que el controlador puede aplicar. El slider está limitado a la potencia combinada de las baterías.",
           "hourly_balance_deadband_wh": "Tolerancia alrededor del objetivo. No se aplica corrección si el balance neto está dentro de ±N kWh del objetivo. 0 = corrección exacta.",
           "hourly_balance_hysteresis_w": "Cambio mínimo en el desplazamiento necesario para aplicar una nueva corrección. Evita micro-ajustes cada ciclo. 0 = aplicar siempre. Por defecto: 15 W."
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -1319,6 +1319,12 @@
       "inverter_state": {
         "name": "État de l'Onduleur"
       },
+      "battery_status": {
+        "name": "État de la Batterie"
+      },
+      "operating_mode": {
+        "name": "Mode de Fonctionnement"
+      },
       "battery_voltage": {
         "name": "Tension Batterie"
       },

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -1298,6 +1298,12 @@
       "battery_power": {
         "name": "Puissance Batterie"
       },
+      "max_charge_power": {
+        "name": "Puissance max. charge"
+      },
+      "max_discharge_power": {
+        "name": "Puissance max. décharge"
+      },
       "internal_temperature": {
         "name": "Température Interne"
       },

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -37,7 +37,7 @@
           "brand": "Marque de la batterie"
         },
         "data_description": {
-          "brand": "Sélectionnez le fabricant de la batterie. Marstek Venus utilise Modbus TCP. Zendure SolarFlow utilise HTTP local (nécessite HEMS activé dans l'application Zendure)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -485,6 +485,22 @@
           "port": "Port HTTP (par défaut 80)"
         }
       },
+      "reconfigure_battery_anker": {
+        "title": "Reconfigure battery {battery_num} — Connection (Anker)",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "New IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
+        }
+      },
       "reconfigure_battery_esphome": {
         "title": "Reconfigurer la batterie {battery_num} — Connexion (LilyGo/ESPHome)",
         "description": "Mettez à jour l'appareil ESPHome de la batterie Marstek {battery_num}. Tous les autres réglages sont conservés.",
@@ -502,6 +518,22 @@
         "description": "Une sauvegarde de {count} configuration(s) précédente(s) (connexion, options et réglages) a été trouvée. La restaurer pour tout récupérer sans reconfigurer ? Vos entités et votre historique se reconnecteront automatiquement.",
         "data": {
           "restore": "Restaurer la configuration précédente"
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },
@@ -579,7 +611,7 @@
           "brand": "Marque de la batterie"
         },
         "data_description": {
-          "brand": "Sélectionnez le fabricant de la batterie. Marstek Venus utilise Modbus TCP. Zendure SolarFlow utilise HTTP local (nécessite HEMS activé dans l'application Zendure)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -989,6 +1021,22 @@
           "hourly_balance_max_offset_w": "Décalage de puissance maximal du contrôleur. Le curseur est limité à la puissance de décharge combinée des batteries.",
           "hourly_balance_deadband_wh": "Bande de tolérance autour de l objectif. Aucune correction si le bilan net est dans ±N kWh de l objectif. 0 = correction exacte.",
           "hourly_balance_hysteresis_w": "Variation minimale du décalage nécessaire pour appliquer une nouvelle correction. Évite les micro-ajustements à chaque cycle. 0 = appliquer toujours. Par défaut : 15 W."
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -1319,6 +1319,12 @@
       "inverter_state": {
         "name": "Omvormerstatus"
       },
+      "battery_status": {
+        "name": "Batterijstatus"
+      },
+      "operating_mode": {
+        "name": "Bedrijfsmodus"
+      },
       "battery_voltage": {
         "name": "Batterijspanning"
       },

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -37,7 +37,7 @@
           "brand": "Batterijmerk"
         },
         "data_description": {
-          "brand": "Selecteer de fabrikant van de batterij. Marstek Venus gebruikt Modbus TCP. Zendure SolarFlow gebruikt lokaal HTTP (vereist HEMS ingeschakeld in de Zendure-app)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -485,6 +485,22 @@
           "port": "HTTP-poort (standaard 80)"
         }
       },
+      "reconfigure_battery_anker": {
+        "title": "Reconfigure battery {battery_num} — Connection (Anker)",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "New IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
+        }
+      },
       "reconfigure_battery_esphome": {
         "title": "Batterij {battery_num} opnieuw configureren — Verbinding (LilyGo/ESPHome)",
         "description": "Werk het ESPHome-apparaat van Marstek-batterij {battery_num} bij. Alle andere instellingen blijven behouden.",
@@ -502,6 +518,22 @@
         "description": "Er is een back-up van {count} vorige configuratie(s) (verbinding, opties en afstemming) gevonden. Herstellen om alles terug te krijgen zonder opnieuw in te stellen? Je entiteiten en geschiedenis worden automatisch opnieuw verbonden.",
         "data": {
           "restore": "Vorige configuratie herstellen"
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },
@@ -579,7 +611,7 @@
           "brand": "Batterijmerk"
         },
         "data_description": {
-          "brand": "Selecteer de fabrikant van de batterij. Marstek Venus gebruikt Modbus TCP. Zendure SolarFlow gebruikt lokaal HTTP (vereist HEMS ingeschakeld in de Zendure-app)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -989,6 +1021,22 @@
           "hourly_balance_max_offset_w": "Maximale vermogensverschuiving van de regelaar. Het schuifregelaarmaximum is de gecombineerde ontlaadvermogens van alle batterijen.",
           "hourly_balance_deadband_wh": "Tolerantieband rondom het doel. Geen correctie als het nettosaldo binnen ±N kWh van het doel valt. 0 = exacte correctie.",
           "hourly_balance_hysteresis_w": "Minimale verandering in de verschuiving vereist voordat een nieuwe correctie wordt toegepast. Voorkomt micro-aanpassingen elke cyclus. 0 = altijd toepassen. Standaard: 15 W."
+        }
+      },
+      "battery_connection_anker": {
+        "title": "Configure battery {battery_num} — Connection (Anker)",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Modbus Port",
+          "slave_id": "Modbus Slave ID"
+        },
+        "data_description": {
+          "name": "Descriptive name to identify this battery",
+          "host": "IP address shown in the Anker app under Third-Party Control",
+          "port": "Modbus TCP port (default 502)",
+          "slave_id": "Modbus slave/unit id (default 1)"
         }
       }
     },

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -1298,6 +1298,12 @@
       "battery_power": {
         "name": "Batterijvermogen"
       },
+      "max_charge_power": {
+        "name": "Max. Laadvermogen"
+      },
+      "max_discharge_power": {
+        "name": "Max. Ontlaadvermogen"
+      },
       "internal_temperature": {
         "name": "Interne Temperatuur"
       },

--- a/site-docs/index.es.md
+++ b/site-docs/index.es.md
@@ -1,6 +1,6 @@
 ![Omnibattery](assets/logo-github.png){ width="420" }
 
-**Omnibattery** es una integración personalizada para Home Assistant que monitoriza y controla baterías solares enchufables — Marstek Venus (series E v2/v3, Venus A y Venus D) y Zendure SolarFlow (2400 AC+ / AC Pro) — mediante Modbus TCP o HTTP local.
+**Omnibattery** es una integración personalizada para Home Assistant que monitoriza y controla baterías solares enchufables — Marstek Venus (series E v2/v3, Venus A y Venus D), Zendure SolarFlow (2400 AC+ / AC Pro) y Anker SOLIX Solarbank Max AC — mediante Modbus TCP o HTTP local.
 
 <div class="grid cards" markdown>
 

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,6 +1,6 @@
 ![Omnibattery](assets/logo-github.png){ width="420" }
 
-**Omnibattery** is a custom Home Assistant integration to monitor and control pluggable solar batteries — Marstek Venus (E v2/v3, Venus A and Venus D series) and Zendure SolarFlow (2400 AC+ / AC Pro) — via Modbus TCP or local HTTP.
+**Omnibattery** is a custom Home Assistant integration to monitor and control pluggable solar batteries — Marstek Venus (E v2/v3, Venus A and Venus D series), Zendure SolarFlow (2400 AC+ / AC Pro), and Anker SOLIX Solarbank Max AC — via Modbus TCP or local HTTP.
 
 <div class="grid cards" markdown>
 

--- a/site-docs/installation.es.md
+++ b/site-docs/installation.es.md
@@ -6,8 +6,8 @@
 
 | Componente | Descripción |
 |---|---|
-| Batería | Marstek Venus E v2/v3, Venus A, Venus D **o** Zendure SolarFlow 2400 AC+ / AC Pro |
-| Conversor Modbus | Dispositivo RS485 → Modbus TCP (p. ej. Elfin-EW11) — **solo necesario para Marstek Venus E v2**. Las Venus E v3, Venus A y Venus D se conectan por Ethernet y soportan Modbus TCP de forma nativa. No necesario para Zendure (HTTP local). |
+| Batería | Marstek Venus E v2/v3, Venus A, Venus D **o** Zendure SolarFlow 2400 AC+ / AC Pro **o** Anker SOLIX Solarbank Max AC |
+| Conversor Modbus | Dispositivo RS485 → Modbus TCP (p. ej. Elfin-EW11) — **solo necesario para Marstek Venus E v2**. Las Venus E v3, Venus A y Venus D se conectan por Ethernet y soportan Modbus TCP de forma nativa. Anker Solarbank Max AC usa Modbus TCP nativo (activar en la app Anker bajo Third-Party Control; solo un cliente Modbus a la vez). No necesario para Zendure (HTTP local). |
 | Adaptador serie *(opcional)* | Adaptador USB–RS485 para conexión serie directa (Modbus RTU) a baterías Marstek. |
 | Sensor de red | Sensor HA que mide el consumo total de la red (p. ej. Shelly EM3, Neurio, contador inteligente) |
 

--- a/site-docs/installation.md
+++ b/site-docs/installation.md
@@ -6,8 +6,8 @@
 
 | Component | Description |
 |---|---|
-| Battery | Marstek Venus E v2/v3, Venus A, Venus D **or** Zendure SolarFlow 2400 AC+ / AC Pro |
-| Modbus converter | RS485 → Modbus TCP device (e.g. Elfin-EW11) — **Marstek Venus E v2 only**. Venus E v3, Venus A and Venus D connect via Ethernet and support Modbus TCP natively. Not required for Zendure (local HTTP). |
+| Battery | Marstek Venus E v2/v3, Venus A, Venus D **or** Zendure SolarFlow 2400 AC+ / AC Pro **or** Anker SOLIX Solarbank Max AC |
+| Modbus converter | RS485 → Modbus TCP device (e.g. Elfin-EW11) — **Marstek Venus E v2 only**. Venus E v3, Venus A and Venus D connect via Ethernet and support Modbus TCP natively. Anker Solarbank Max AC uses native Modbus TCP (enable under Third-Party Control in the Anker app; only one Modbus client at a time). Not required for Zendure (local HTTP). |
 | Serial adapter *(optional)* | USB–RS485 adapter for direct serial (Modbus RTU) connection to Marstek batteries. |
 | Grid sensor | HA sensor measuring total grid consumption (e.g. Shelly EM3, Neurio, smart meter integration) |
 

--- a/site-docs/reference/architecture.es.md
+++ b/site-docs/reference/architecture.es.md
@@ -14,10 +14,13 @@ flowchart TD
 
     DRV --> M[MarstekModbusDriver\nModbus TCP/RTU]
     DRV --> Z[ZendureLocalDriver\nHTTP local]
+    DRV --> A[AnkerModbusDriver\nModbus TCP]
     DRV2 --> M
     DRV2 --> Z
+    DRV2 --> A
     M --> BAT1[Batería Marstek]
     Z --> BAT2[Batería Zendure]
+    A --> BAT3[Anker Solarbank]
 ```
 
 El bucle de control y el coordinador nunca hablan con el hardware directamente:
@@ -40,8 +43,10 @@ subpaquetes por responsabilidad.
 | `drivers/base.py` | `BatteryDriver`, `DriverCapabilities` | El contrato del driver y el dataclass de rasgos estáticos |
 | `drivers/marstek.py` | `MarstekModbusDriver` | Marstek Venus (v2/v3/vA/vD) por Modbus TCP / RTU |
 | `drivers/zendure.py` | `ZendureLocalDriver` | Zendure SolarFlow por HTTP local |
+| `drivers/anker.py` | `AnkerModbusDriver` | Anker SOLIX Solarbank Max AC por Modbus TCP (lecturas FC03/FC04) |
 | `infra/coordinator.py` | `MarstekVenusDataUpdateCoordinator` | Polling periódico de telemetría (vía el driver), actualización de entidades |
 | `infra/modbus_client.py` | `MarstekModbusClient` | Transporte Modbus TCP/RTU asíncrono con pymodbus, reintentos con backoff |
+| `infra/anker_modbus_client.py` | `AnkerModbusClient` | Modbus TCP asíncrono para Anker (lecturas FC03/FC04, escrituras FC06/FC16) |
 | `infra/external_loads.py` | — | Ajuste por dispositivos excluidos y reparto del excedente solar |
 | `infra/alarm_notifier.py` | `AlarmNotifier` | Detección de cambios de bits de alarma/fallo y formateo de notificaciones persistentes de HA |
 | `infra/entity_naming.py` | — | IDs de entidad basados en translation-key y migraciones del registro |
@@ -109,7 +114,7 @@ control y entidades lo leen desde `coordinator.capabilities`:
 
 El coordinador selecciona el driver según la marca configurada
 ([`infra/coordinator.py`](https://github.com/ffunes/omnibattery/blob/main/custom_components/omnibattery/infra/coordinator.py)):
-`zendure` → `ZendureLocalDriver`, en otro caso `MarstekModbusDriver`. El driver
+`zendure` → `ZendureLocalDriver`, `anker` → `AnkerModbusDriver`, `esphome` → `EsphomeEntityDriver`, en otro caso `MarstekModbusDriver`. El driver
 también posee las listas de definiciones de registro/entidad de su versión, que
 las plataformas leen en lugar de ramificar por la cadena de versión.
 

--- a/site-docs/reference/architecture.md
+++ b/site-docs/reference/architecture.md
@@ -14,10 +14,13 @@ flowchart TD
 
     DRV --> M[MarstekModbusDriver\nModbus TCP/RTU]
     DRV --> Z[ZendureLocalDriver\nlocal HTTP]
+    DRV --> A[AnkerModbusDriver\nModbus TCP]
     DRV2 --> M
     DRV2 --> Z
+    DRV2 --> A
     M --> BAT1[Marstek battery]
     Z --> BAT2[Zendure battery]
+    A --> BAT3[Anker Solarbank]
 ```
 
 The control loop and the coordinator never talk to the hardware directly: every
@@ -40,8 +43,10 @@ subpackages by responsibility.
 | `drivers/base.py` | `BatteryDriver`, `DriverCapabilities` | The driver contract and the static-traits dataclass |
 | `drivers/marstek.py` | `MarstekModbusDriver` | Marstek Venus (v2/v3/vA/vD) over Modbus TCP / RTU |
 | `drivers/zendure.py` | `ZendureLocalDriver` | Zendure SolarFlow over local HTTP |
+| `drivers/anker.py` | `AnkerModbusDriver` | Anker SOLIX Solarbank Max AC over Modbus TCP (FC03/FC04 reads) |
 | `infra/coordinator.py` | `MarstekVenusDataUpdateCoordinator` | Periodic telemetry polling (via the driver), entity updates |
 | `infra/modbus_client.py` | `MarstekModbusClient` | Async Modbus TCP/RTU transport via pymodbus, retries with backoff |
+| `infra/anker_modbus_client.py` | `AnkerModbusClient` | Async Modbus TCP for Anker (FC03/FC04 reads, FC06/FC16 writes) |
 | `infra/external_loads.py` | — | Excluded-device load adjustment and solar-surplus crediting |
 | `infra/alarm_notifier.py` | `AlarmNotifier` | Alarm/fault bit-delta detection and HA persistent notification formatting |
 | `infra/entity_naming.py` | — | Translation-key based entity IDs and registry migrations |
@@ -108,7 +113,7 @@ these from `coordinator.capabilities`:
 
 The coordinator selects the driver from the configured brand
 ([`infra/coordinator.py`](https://github.com/ffunes/omnibattery/blob/main/custom_components/omnibattery/infra/coordinator.py)):
-`zendure` → `ZendureLocalDriver`, otherwise `MarstekModbusDriver`. The driver
+`zendure` → `ZendureLocalDriver`, `anker` → `AnkerModbusDriver`, `esphome` → `EsphomeEntityDriver`, otherwise `MarstekModbusDriver`. The driver
 also owns its version's register/entity definition lists, which the platform
 setups read back instead of branching on the version string.
 

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -58,6 +58,34 @@ def test_model_label():
     assert _driver().model_label == "Solarbank Max AC"
 
 
+def test_power_caps_are_telemetry_not_sensors():
+    """Hardware max charge/discharge (10036/10038) must stay off SENSOR_DEFINITIONS
+    so the soft-max number entities can own the user-facing Max. Laadvermogen /
+    Max. Ontlaadvermogen unique_ids."""
+    from custom_components.omnibattery.drivers import anker as anker_mod
+
+    sensor_keys = {d["key"] for d in anker_mod.SENSOR_DEFINITIONS}
+    number_keys = {d["key"] for d in anker_mod.NUMBER_DEFINITIONS}
+    field_keys = {f["key"] for f in anker_mod._FIELD_SPECS}
+    assert "max_charge_power" not in sensor_keys
+    assert "max_discharge_power" not in sensor_keys
+    assert "max_charge_power" not in number_keys
+    assert "max_discharge_power" not in number_keys
+    assert "max_charge_power" in field_keys
+    assert "max_discharge_power" in field_keys
+    assert "max_charge_power" in _driver().control_dependency_keys
+    assert "max_discharge_power" in _driver().control_dependency_keys
+
+
+def test_status_and_mode_sensors_have_state_maps():
+    from custom_components.omnibattery.drivers import anker as anker_mod
+
+    by_key = {d["key"]: d for d in anker_mod.SENSOR_DEFINITIONS}
+    assert by_key["battery_status"]["states"][1] == "Charging"
+    assert by_key["battery_status"]["states"][2] == "Discharging"
+    assert by_key["operating_mode"]["states"][3] == "Third-Party Control"
+
+
 def test_encode_int32_roundtrip():
     for value in (0, 500, -800, 3500, -3500):
         words = encode_int32(value)

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -253,6 +253,25 @@ async def test_net_power_from_data_uses_applied_echo():
     assert drv.net_power_from_data(result.applied) == -400
 
 
+@pytest.mark.asyncio
+async def test_net_power_from_data_rejects_stale_echo_after_reconnect():
+    client = _fake_client()
+    drv = _driver(client=client)
+    result = await drv.apply_setpoint(-400)
+
+    assert await drv.connect() is True
+    assert drv.net_power_from_data(result.applied) is None
+
+
+@pytest.mark.asyncio
+async def test_net_power_from_data_rejects_echo_outside_third_party_mode():
+    drv = _driver()
+    result = await drv.apply_setpoint(400)
+    result.applied["operating_mode"] = 0
+
+    assert drv.net_power_from_data(result.applied) is None
+
+
 # ----------------------------------------------------------------------
 # SOC limits
 # ----------------------------------------------------------------------

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -292,20 +292,30 @@ async def test_standby_writes_zero_setpoint():
 
 
 @pytest.mark.asyncio
-async def test_probe_reads_soc_over_fc04(monkeypatch):
+async def test_probe_reads_soc_and_power_caps(monkeypatch):
     created = {}
 
     class FakeClient:
         def __init__(self, host, port, slave_id=1, timeout=5.0):
             created["args"] = (host, port, slave_id)
             self.unit_id = slave_id
+            self.connected = True
             self.async_connect = AsyncMock(return_value=True)
             self.async_close = AsyncMock()
-            self.async_read_input_register = AsyncMock(return_value=42)
+            # Range 10000–10050: SOC at 10014, max charge 10036, max discharge 10038
+            buf = [0] * 51
+            buf[14] = 55
+            buf[36], buf[37] = encode_int32(3000)
+            buf[38], buf[39] = encode_int32(2800)
+            self.async_read_input_block = AsyncMock(return_value=buf)
+            self.async_read_holding_block = AsyncMock(return_value=None)
 
     monkeypatch.setattr(
         "custom_components.omnibattery.drivers.anker.AnkerModbusClient",
         FakeClient,
     )
-    assert await AnkerModbusDriver.probe("10.0.0.5", 502, 1) is True
+    ok, caps = await AnkerModbusDriver.probe("10.0.0.5", 502, 1)
+    assert ok is True
     assert created["args"] == ("10.0.0.5", 502, 1)
+    assert caps["max_charge_power"] == 3000
+    assert caps["max_discharge_power"] == 2800

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -1,0 +1,281 @@
+"""Unit tests for the Anker Solarbank Max AC Modbus driver."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, call
+
+import pytest
+
+from custom_components.omnibattery.drivers import AnkerModbusDriver, DriverCapabilities
+from custom_components.omnibattery.infra.anker_modbus_client import encode_int32
+from custom_components.omnibattery.infra.modbus_client import decode_registers
+
+
+def _fake_client():
+    client = AsyncMock()
+    client.connected = True
+    client.unit_id = 1
+    client.async_connect = AsyncMock(return_value=True)
+    client.async_close = AsyncMock()
+    client.set_shutting_down = AsyncMock()
+    client.async_write_register = AsyncMock(return_value=True)
+    client.async_write_registers_int32 = AsyncMock(return_value=True)
+    client.async_read_holding_register = AsyncMock(return_value=3)
+    client.async_read_input_register = AsyncMock(return_value=55)
+    client.async_read_input_block = AsyncMock(return_value=None)
+    client.async_read_holding_block = AsyncMock(return_value=None)
+    return client
+
+
+def _driver(client=None, **kw):
+    return AnkerModbusDriver(
+        "1.2.3.4",
+        502,
+        1,
+        client=client or _fake_client(),
+        **kw,
+    )
+
+
+# ----------------------------------------------------------------------
+# capabilities / identity
+# ----------------------------------------------------------------------
+def test_capabilities():
+    caps = _driver().capabilities
+    assert isinstance(caps, DriverCapabilities)
+    assert caps.hardware_soc_cutoff is True
+    assert caps.has_force_mode is False
+    assert caps.has_rs485_control is False
+    assert caps.has_mppt_pv is False
+    assert caps.has_energy_counters is True
+    assert caps.max_charge_power_w == 3500
+    assert caps.max_discharge_power_w == 3500
+    assert caps.min_charge_power_w == 100
+    assert caps.min_discharge_power_w == 100
+    assert caps.setpoint_confirm_reliable is False
+
+
+def test_model_label():
+    assert _driver().model_label == "Solarbank Max AC"
+
+
+def test_encode_int32_roundtrip():
+    for value in (0, 500, -800, 3500, -3500):
+        words = encode_int32(value)
+        assert decode_registers(words, "int32") == value
+
+
+# ----------------------------------------------------------------------
+# connect / mode
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_connect_sets_third_party_mode_when_needed():
+    client = _fake_client()
+    client.async_read_holding_register = AsyncMock(return_value=0)
+    drv = _driver(client=client)
+    assert await drv.connect() is True
+    client.async_write_register.assert_awaited_with(10064, 3)
+
+
+@pytest.mark.asyncio
+async def test_connect_skips_mode_write_when_already_third_party():
+    client = _fake_client()
+    client.async_read_holding_register = AsyncMock(return_value=3)
+    drv = _driver(client=client)
+    assert await drv.connect() is True
+    client.async_write_register.assert_not_awaited()
+
+
+# ----------------------------------------------------------------------
+# telemetry — FC03/FC04
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_read_telemetry_uses_fc04_for_input_and_inverts_battery_power():
+    client = _fake_client()
+
+    # Range 10000–10050: SOC at 10014, battery power at 10008 (+discharge on wire)
+    # Build a buffer of zeros then poke the fields.
+    buf = [0] * 51
+    # int32 +612 discharge at 10008 → offsets 8,9
+    buf[8], buf[9] = encode_int32(612)
+    buf[14] = 47  # SOC
+    client.async_read_input_block = AsyncMock(return_value=buf)
+    client.async_read_holding_block = AsyncMock(return_value=None)
+
+    drv = _driver(client=client)
+    snap = await drv.read_telemetry(["battery_soc", "battery_power"])
+
+    # Must use input (FC04), not holding
+    client.async_read_input_block.assert_awaited()
+    for c in client.async_read_input_block.await_args_list:
+        assert c.args[0] == 10000
+    client.async_read_holding_block.assert_not_awaited()
+
+    assert snap["battery_soc"] == 47
+    assert snap["battery_power"] == -612  # inverted to Omnibattery convention
+
+
+@pytest.mark.asyncio
+async def test_read_telemetry_uses_fc03_for_operating_mode_and_soc_limits():
+    client = _fake_client()
+    client.async_read_input_block = AsyncMock(return_value=None)
+
+    holding_mode = [0] * 13  # 10060–10072
+    holding_mode[4] = 3  # 10064
+    holding_soc = [95, 12, 0, 0]  # 60000–60003; ignore 60002/60003
+
+    async def _holding(start, count):
+        if start == 10060:
+            return holding_mode
+        if start == 60000:
+            return holding_soc
+        return None
+
+    client.async_read_holding_block = AsyncMock(side_effect=_holding)
+    drv = _driver(client=client)
+    snap = await drv.read_telemetry(
+        ["operating_mode", "charging_cutoff_capacity", "discharging_cutoff_capacity"]
+    )
+
+    assert snap["operating_mode"] == 3
+    assert snap["charging_cutoff_capacity"] == 95
+    assert snap["discharging_cutoff_capacity"] == 12
+    starts = [c.args[0] for c in client.async_read_holding_block.await_args_list]
+    assert 10060 in starts
+    assert 60000 in starts
+    client.async_read_input_block.assert_not_awaited()
+
+
+# ----------------------------------------------------------------------
+# apply_setpoint
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_apply_setpoint_charge_writes_negative_wire_value():
+    client = _fake_client()
+    drv = _driver(client=client)
+    result = await drv.apply_setpoint(500)
+    assert result.ok is True
+    assert result.net_power_w == 500
+    assert result.confirmed is False
+    client.async_write_registers_int32.assert_awaited_with(10071, -500)
+
+
+@pytest.mark.asyncio
+async def test_apply_setpoint_discharge_writes_positive_wire_value():
+    client = _fake_client()
+    drv = _driver(client=client)
+    result = await drv.apply_setpoint(-800)
+    assert result.ok is True
+    assert result.net_power_w == -800
+    client.async_write_registers_int32.assert_awaited_with(10071, 800)
+
+
+@pytest.mark.asyncio
+async def test_apply_setpoint_idle_writes_zero():
+    client = _fake_client()
+    drv = _driver(client=client)
+    result = await drv.apply_setpoint(0)
+    assert result.ok is True
+    assert result.net_power_w == 0
+    client.async_write_registers_int32.assert_awaited_with(10071, 0)
+
+
+@pytest.mark.asyncio
+async def test_apply_setpoint_snaps_forbidden_band_to_idle():
+    client = _fake_client()
+    drv = _driver(client=client)
+    result = await drv.apply_setpoint(50)
+    assert result.ok is True
+    assert result.net_power_w == 0
+    client.async_write_registers_int32.assert_awaited_with(10071, 0)
+
+
+@pytest.mark.asyncio
+async def test_apply_setpoint_clamps_to_3500():
+    client = _fake_client()
+    drv = _driver(client=client)
+    result = await drv.apply_setpoint(5000)
+    assert result.net_power_w == 3500
+    client.async_write_registers_int32.assert_awaited_with(10071, -3500)
+
+
+@pytest.mark.asyncio
+async def test_net_power_from_data_uses_applied_echo():
+    client = _fake_client()
+    drv = _driver(client=client)
+    result = await drv.apply_setpoint(-400)
+    assert drv.net_power_from_data(result.applied) == -400
+
+
+# ----------------------------------------------------------------------
+# SOC limits
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_apply_config_writes_60000_and_60001_only():
+    client = _fake_client()
+    drv = _driver(client=client)
+    ok = await drv.apply_config(
+        max_soc_pct=95,
+        min_soc_pct=10,
+        max_charge_power_w=3500,
+        max_discharge_power_w=3500,
+    )
+    assert ok is True
+    assert client.async_write_register.await_args_list == [
+        call(60000, 95),
+        call(60001, 10),
+    ]
+    written_addrs = [c.args[0] for c in client.async_write_register.await_args_list]
+    assert 60002 not in written_addrs
+    assert 60003 not in written_addrs
+
+
+@pytest.mark.asyncio
+async def test_apply_config_clamps_to_device_ranges():
+    client = _fake_client()
+    drv = _driver(client=client)
+    await drv.apply_config(
+        max_soc_pct=70,  # below 80
+        min_soc_pct=40,  # above 20
+        max_charge_power_w=3500,
+        max_discharge_power_w=3500,
+    )
+    assert client.async_write_register.await_args_list == [
+        call(60000, 80),
+        call(60001, 20),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_set_charge_cutoff_writes_60000_only():
+    client = _fake_client()
+    drv = _driver(client=client)
+    assert await drv.set_charge_cutoff(100) is True
+    client.async_write_register.assert_awaited_once_with(60000, 100)
+
+
+@pytest.mark.asyncio
+async def test_standby_writes_zero_setpoint():
+    client = _fake_client()
+    drv = _driver(client=client)
+    assert await drv.standby() is True
+    client.async_write_registers_int32.assert_awaited_with(10071, 0)
+
+
+@pytest.mark.asyncio
+async def test_probe_reads_soc_over_fc04(monkeypatch):
+    created = {}
+
+    class FakeClient:
+        def __init__(self, host, port, slave_id=1, timeout=5.0):
+            created["args"] = (host, port, slave_id)
+            self.unit_id = slave_id
+            self.async_connect = AsyncMock(return_value=True)
+            self.async_close = AsyncMock()
+            self.async_read_input_register = AsyncMock(return_value=42)
+
+    monkeypatch.setattr(
+        "custom_components.omnibattery.drivers.anker.AnkerModbusClient",
+        FakeClient,
+    )
+    assert await AnkerModbusDriver.probe("10.0.0.5", 502, 1) is True
+    assert created["args"] == ("10.0.0.5", 502, 1)

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -84,6 +84,8 @@ def test_status_and_mode_sensors_have_state_maps():
     assert by_key["battery_status"]["states"][1] == "Charging"
     assert by_key["battery_status"]["states"][2] == "Discharging"
     assert by_key["operating_mode"]["states"][3] == "Third-Party Control"
+    # Register 10156 reports tenths of a degree (340 → 34.0 °C).
+    assert by_key["temperature"]["scale"] == 0.1
 
 
 def test_encode_int32_roundtrip():

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -155,7 +155,7 @@ async def test_apply_setpoint_charge_writes_negative_wire_value():
     result = await drv.apply_setpoint(500)
     assert result.ok is True
     assert result.net_power_w == 500
-    assert result.confirmed is False
+    assert result.confirmed is True
     client.async_write_registers_int32.assert_awaited_with(10071, -500)
 
 

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -145,6 +145,23 @@ async def test_read_telemetry_uses_fc04_for_input_and_inverts_battery_power():
 
 
 @pytest.mark.asyncio
+async def test_read_telemetry_caps_peak_charge_power_at_hw_max():
+    """Register 10036 can report peak/aggregate values (e.g. 7000 W); clamp to 3500."""
+    client = _fake_client()
+    buf = [0] * 51
+    buf[36], buf[37] = encode_int32(7000)
+    buf[38], buf[39] = encode_int32(3000)
+    client.async_read_input_block = AsyncMock(return_value=buf)
+    client.async_read_holding_block = AsyncMock(return_value=None)
+
+    drv = _driver(client=client)
+    snap = await drv.read_telemetry(["max_charge_power", "max_discharge_power"])
+
+    assert snap["max_charge_power"] == 3500
+    assert snap["max_discharge_power"] == 3000
+
+
+@pytest.mark.asyncio
 async def test_read_telemetry_uses_fc03_for_operating_mode_and_soc_limits():
     client = _fake_client()
     client.async_read_input_block = AsyncMock(return_value=None)

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -58,17 +58,17 @@ def test_model_label():
     assert _driver().model_label == "Solarbank Max AC"
 
 
-def test_power_caps_are_telemetry_not_sensors():
-    """Hardware max charge/discharge (10036/10038) must stay off SENSOR_DEFINITIONS
-    so the soft-max number entities can own the user-facing Max. Laadvermogen /
-    Max. Ontlaadvermogen unique_ids."""
+def test_power_caps_are_read_only_sensors():
+    """Hardware max charge/discharge (10036/10038) are sensors only — not
+    writable numbers and not setup sliders. Soft-max entities must not claim
+    the same unique_ids."""
     from custom_components.omnibattery.drivers import anker as anker_mod
 
     sensor_keys = {d["key"] for d in anker_mod.SENSOR_DEFINITIONS}
     number_keys = {d["key"] for d in anker_mod.NUMBER_DEFINITIONS}
     field_keys = {f["key"] for f in anker_mod._FIELD_SPECS}
-    assert "max_charge_power" not in sensor_keys
-    assert "max_discharge_power" not in sensor_keys
+    assert "max_charge_power" in sensor_keys
+    assert "max_discharge_power" in sensor_keys
     assert "max_charge_power" not in number_keys
     assert "max_discharge_power" not in number_keys
     assert "max_charge_power" in field_keys

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -302,13 +302,17 @@ async def test_probe_reads_soc_and_power_caps(monkeypatch):
             self.connected = True
             self.async_connect = AsyncMock(return_value=True)
             self.async_close = AsyncMock()
-            # Range 10000–10050: SOC at 10014, max charge 10036, max discharge 10038
-            buf = [0] * 51
-            buf[14] = 55
-            buf[36], buf[37] = encode_int32(3000)
-            buf[38], buf[39] = encode_int32(2800)
-            self.async_read_input_block = AsyncMock(return_value=buf)
-            self.async_read_holding_block = AsyncMock(return_value=None)
+
+            async def _read_input(address, data_type="uint16", count=None):
+                if address == 10014:
+                    return 55
+                if address == 10036:
+                    return 3000
+                if address == 10038:
+                    return 2800
+                return None
+
+            self.async_read_input_register = AsyncMock(side_effect=_read_input)
 
     monkeypatch.setattr(
         "custom_components.omnibattery.drivers.anker.AnkerModbusClient",
@@ -317,5 +321,5 @@ async def test_probe_reads_soc_and_power_caps(monkeypatch):
     ok, caps = await AnkerModbusDriver.probe("10.0.0.5", 502, 1)
     assert ok is True
     assert created["args"] == ("10.0.0.5", 502, 1)
-    assert caps["max_charge_power"] == 3000
-    assert caps["max_discharge_power"] == 2800
+    assert caps["device_max_charge_power"] == 3000
+    assert caps["device_max_discharge_power"] == 2800

--- a/tests/test_coordinator_driver_capabilities.py
+++ b/tests/test_coordinator_driver_capabilities.py
@@ -1,0 +1,54 @@
+"""Regression tests for driver-specific coordinator capability handling."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from custom_components.omnibattery import _device_owns_initial_config
+from custom_components.omnibattery.infra.coordinator import (
+    MarstekVenusDataUpdateCoordinator,
+)
+
+
+def test_only_zendure_owns_initial_config():
+    assert _device_owns_initial_config("zendure") is True
+    assert _device_owns_initial_config("anker") is False
+    assert _device_owns_initial_config("marstek") is False
+
+
+def test_inverse_max_power_is_a_hardware_discharge_limit():
+    coordinator = SimpleNamespace(
+        number_definitions=[{"key": "inverse_max_power"}],
+        sensor_definitions=[],
+    )
+
+    assert (
+        MarstekVenusDataUpdateCoordinator.needs_software_max_discharge.fget(
+            coordinator
+        )
+        is False
+    )
+
+
+async def test_reconnect_skips_rs485_for_driver_without_capability():
+    driver = SimpleNamespace(connect=AsyncMock(return_value=True))
+    coordinator = SimpleNamespace(
+        name="Anker",
+        host="192.0.2.1",
+        port=502,
+        _consecutive_failures=1,
+        _is_connected=False,
+        _suspension_reset_time=object(),
+        lock=asyncio.Lock(),
+        driver=driver,
+        capabilities=SimpleNamespace(has_rs485_control=False),
+        rs485_user_disabled=False,
+    )
+
+    result = await MarstekVenusDataUpdateCoordinator.async_reconnect_fresh(
+        coordinator
+    )
+
+    assert result is True
+    driver.connect.assert_awaited_once()


### PR DESCRIPTION
Supersedes #121 while preserving @wouterbouvy's original commit history and authorship. This repository-owned branch avoids writing to the contributor's fork.

Integration fixes added during maintainer review:
- apply persisted SOC limits during Anker setup;
- skip RS485 recovery calls for drivers without that capability;
- invalidate the write-only Anker setpoint echo after reconnects or mode changes;
- recognize Zendure inverse_max_power as its writable discharge limit;
- add regression coverage for these driver-specific paths.

Validation:
- focused Anker/coordinator tests: 26 passed;
- complete suite: 757 passed, 10 skipped.