### PR TITLE
Fix Anker false non_delivery pool exclusions

### DIFF
--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -3543,10 +3543,23 @@ class ChargeDischargeController:
         silently stalled registerless battery in a pool is excluded, not
         re-commanded forever.
         """
+        if not coordinator.capabilities.detect_power_non_delivery:
+            # Drivers like Anker: write ACK is authoritative; battery_power is not
+            # a trustworthy delivery signal under third-party control.
+            return
         actual_abs = abs(actual_power)
         if actual_abs >= 0.10 * discharge_power:
             self._non_responsive.clear(coordinator)
             return
+        # Status-based delivery: shared inverter_state Discharge (3) means the
+        # unit is engaged even if the power register still reads near zero.
+        inv_state = coordinator.data.get("inverter_state") if coordinator.data else None
+        try:
+            if inv_state is not None and int(inv_state) == 3:
+                self._non_responsive.clear(coordinator)
+                return
+        except (TypeError, ValueError):
+            pass
         engage_started = self._discharge_engage_started.get(coordinator)
         within_engage_grace = (
             engage_started is not None

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -246,7 +246,11 @@ class AnkerModbusDriver(BatteryDriver):
             has_energy_counters=True,
             has_daily_energy_counters=False,
             setpoint_confirm_reliable=False,
-            actuator_latency_s=1.0,
+            # Above FAST_ACTUATOR_MAX_LATENCY_S (1.5): skip immediate post-write
+            # power sampling. Anker ramps over a few seconds; treating it as fast
+            # produced false non_delivery (ACK ok, actual=0W) and 5-minute pool
+            # exclusions. Poll-time judgment uses DISCHARGE_ENGAGE_GRACE_S instead.
+            actuator_latency_s=2.5,
         )
 
     def _build_read_groups(self) -> list[ReadGroup]:
@@ -476,23 +480,17 @@ class AnkerModbusDriver(BatteryDriver):
         self._last_net_power_w = net
         applied = {"commanded_net_power": net, "operating_mode": _OPERATING_MODE_THIRD_PARTY}
         # Register 10071 is never_read_device — Modbus write success is the ACK.
-        # Returning confirmed=False made the control loop treat every readback
-        # cycle as ack_mismatch (Anker is a "fast" actuator so read_back is
-        # periodically True). When read_back is requested, also sample delivered
-        # power from input 10008 for non-delivery detection.
-        battery_power_w: Optional[int] = None
-        if read_back:
-            snap = await self.read_telemetry(["battery_power"])
-            raw = snap.get("battery_power")
-            if raw is not None:
-                battery_power_w = int(raw)
-                applied["battery_power"] = battery_power_w
+        # Do not sample battery_power here for delivery evidence: Anker often still
+        # reports 0 W in the first second after a write, which the control loop
+        # treated as non_delivery. Delivered power is judged on the next poll
+        # (slow-actuator path + engage grace).
+        _ = read_back
         return SetpointResult(
             ok=True,
             net_power_w=net,
             confirmed=True,
             exact=True,
-            battery_power_w=battery_power_w,
+            battery_power_w=None,
             applied=applied,
         )
 

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -251,6 +251,9 @@ class AnkerModbusDriver(BatteryDriver):
             # produced false non_delivery (ACK ok, actual=0W) and 5-minute pool
             # exclusions. Poll-time judgment uses DISCHARGE_ENGAGE_GRACE_S instead.
             actuator_latency_s=2.5,
+            # Input 10008 is not a reliable delivery oracle under third-party
+            # control — do not exclude the battery from the PD pool on ~0 W.
+            detect_power_non_delivery=False,
         )
 
     def _build_read_groups(self) -> list[ReadGroup]:

--- a/custom_components/omnibattery/drivers/base.py
+++ b/custom_components/omnibattery/drivers/base.py
@@ -104,6 +104,13 @@ class DriverCapabilities:
     # actuator can take seconds. Defaults to the fast (register) case.
     actuator_latency_s: float = 0.5
 
+    # True when battery_power telemetry is reliable enough to exclude a unit from
+    # the pool for ACK-ok / ~0 W non-delivery. Anker's third-party setpoint path
+    # often leaves input 10008 at 0 W even while the unit is following the command,
+    # so exclusion based on that sample is a false positive (no RS485 wake either).
+    # Defaults True so Marstek/Zendure keep pool protection.
+    detect_power_non_delivery: bool = True
+
     # Minimum reliable operating power (watts, per unit) below which the hardware
     # will not sustain a non-zero charge/discharge. Marstek v2/v3 report 800 W (the
     # max_charge/discharge_power register floor); vA/vD/Zendure have no such floor

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -56,6 +56,7 @@ def test_capabilities():
     # Must exceed FAST_ACTUATOR_MAX_LATENCY_S (1.5) so post-write power
     # sampling is not used for non_delivery judgments.
     assert caps.actuator_latency_s > 1.5
+    assert caps.detect_power_non_delivery is False
 
 
 def test_model_label():

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -53,6 +53,9 @@ def test_capabilities():
     assert caps.min_charge_power_w == 100
     assert caps.min_discharge_power_w == 100
     assert caps.setpoint_confirm_reliable is False
+    # Must exceed FAST_ACTUATOR_MAX_LATENCY_S (1.5) so post-write power
+    # sampling is not used for non_delivery judgments.
+    assert caps.actuator_latency_s > 1.5
 
 
 def test_model_label():
@@ -259,7 +262,11 @@ async def test_apply_setpoint_charge_writes_negative_wire_value():
     assert result.ok is True
     assert result.net_power_w == 500
     assert result.confirmed is True
+    assert result.battery_power_w is None
     client.async_write_registers_int32.assert_awaited_with(10071, -500)
+    # Immediate telemetry sample must not run — 0 W right after write
+    # falsely tripped non_delivery in the control loop.
+    client.async_read_input_block.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Anker was treated as a fast actuator and/or judged on `battery_power` (register 10008), which often stays at **0 W** under third-party control even when the setpoint write succeeded.
- That produced false `non_delivery` exclusions (`ACK ok but not delivering power … Excluding from pool for 5 minutes`).
- Raise `actuator_latency_s` to **2.5 s**, stop sampling power in `apply_setpoint`, and set `detect_power_non_delivery=False` for Anker so the unit stays in the PD pool while setpoints continue to be written.

## Test plan
- [ ] Deploy this branch on an Anker Solarbank Max AC
- [ ] Command discharge (~1 kW) for several minutes
- [ ] Confirm no `Non-responsive … non_delivery` exclusion appears
- [ ] Confirm operating mode stays third-party and setpoints keep being written
- [ ] `pytest tests/test_anker_driver.py tests/test_set_battery_power_skip.py` passes