### PR TITLE
Fix Anker false non_delivery from post-write power sampling

### DIFF
--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -246,7 +246,11 @@ class AnkerModbusDriver(BatteryDriver):
             has_energy_counters=True,
             has_daily_energy_counters=False,
             setpoint_confirm_reliable=False,
-            actuator_latency_s=1.0,
+            # Above FAST_ACTUATOR_MAX_LATENCY_S (1.5): skip immediate post-write
+            # power sampling. Anker ramps over a few seconds; treating it as fast
+            # produced false non_delivery (ACK ok, actual=0W) and 5-minute pool
+            # exclusions. Poll-time judgment uses DISCHARGE_ENGAGE_GRACE_S instead.
+            actuator_latency_s=2.5,
         )
 
     def _build_read_groups(self) -> list[ReadGroup]:
@@ -476,23 +480,17 @@ class AnkerModbusDriver(BatteryDriver):
         self._last_net_power_w = net
         applied = {"commanded_net_power": net, "operating_mode": _OPERATING_MODE_THIRD_PARTY}
         # Register 10071 is never_read_device — Modbus write success is the ACK.
-        # Returning confirmed=False made the control loop treat every readback
-        # cycle as ack_mismatch (Anker is a "fast" actuator so read_back is
-        # periodically True). When read_back is requested, also sample delivered
-        # power from input 10008 for non-delivery detection.
-        battery_power_w: Optional[int] = None
-        if read_back:
-            snap = await self.read_telemetry(["battery_power"])
-            raw = snap.get("battery_power")
-            if raw is not None:
-                battery_power_w = int(raw)
-                applied["battery_power"] = battery_power_w
+        # Do not sample battery_power here for delivery evidence: Anker often still
+        # reports 0 W in the first second after a write, which the control loop
+        # treated as non_delivery. Delivered power is judged on the next poll
+        # (slow-actuator path + engage grace).
+        _ = read_back
         return SetpointResult(
             ok=True,
             net_power_w=net,
             confirmed=True,
             exact=True,
-            battery_power_w=battery_power_w,
+            battery_power_w=None,
             applied=applied,
         )
 

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -53,6 +53,9 @@ def test_capabilities():
     assert caps.min_charge_power_w == 100
     assert caps.min_discharge_power_w == 100
     assert caps.setpoint_confirm_reliable is False
+    # Must exceed FAST_ACTUATOR_MAX_LATENCY_S (1.5) so post-write power
+    # sampling is not used for non_delivery judgments.
+    assert caps.actuator_latency_s > 1.5
 
 
 def test_model_label():
@@ -259,7 +262,11 @@ async def test_apply_setpoint_charge_writes_negative_wire_value():
     assert result.ok is True
     assert result.net_power_w == 500
     assert result.confirmed is True
+    assert result.battery_power_w is None
     client.async_write_registers_int32.assert_awaited_with(10071, -500)
+    # Immediate telemetry sample must not run — 0 W right after write
+    # falsely tripped non_delivery in the control loop.
+    client.async_read_input_block.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Anker Solarbank Max AC was treated as a fast Modbus actuator (`actuator_latency_s=1.0`), so the control loop sampled `battery_power` immediately after a successful write.
- That sample is often still **0 W** while Anker ramps, which produced false `non_delivery` exclusions (`ACK ok but not delivering power … Excluding from pool for 5 minutes`).
- Raise latency to **2.5 s** (above `FAST_ACTUATOR_MAX_LATENCY_S`) so delivery is judged on the poll path with engage grace, and stop using an immediate `battery_power` sample as delivery evidence in `apply_setpoint` (write success remains the ACK).

## Test plan
- [ ] On an Anker Solarbank Max AC in third-party control, command a discharge (~1–2 kW)
- [ ] Confirm the battery is not excluded for `non_delivery` within the first few control cycles after a setpoint change
- [ ] Confirm power eventually shows on the battery power sensor and PD continues allocating
- [ ] `pytest tests/test_anker_driver.py` passes