### PR TITLE
feat(charge-delay): hold cushion-only shortfall for the cheapest hour

### DIFF
--- a/.github/ISSUE_TEMPLATE/battery_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/battery_support_request.yml
@@ -1,0 +1,158 @@
+name: "🔋 New battery support"
+description: "Request support for a new battery brand or model"
+title: "[BATTERY SUPPORT] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## New battery support request
+
+        Thank you for helping us assess a new battery integration. You do not need technical knowledge: fill in what you know and select **I don't know** where appropriate.
+
+        The most important information is the manufacturer's **developer documentation**: a local API, Modbus/RS485 protocol, MQTT topics, HTTP API, or another interface that allows the battery to be monitored and controlled. A user manual or commercial product page usually does not contain this information.
+
+        > Do not publish passwords, tokens, API keys, complete serial numbers, or personal information.
+
+  - type: textarea
+    id: device
+    attributes:
+      label: Requested battery
+      description: Copy the name shown on the label, packaging, or manufacturer app. Complete everything you know.
+      placeholder: |
+        Manufacturer: Marstek, Zendure, EcoFlow...
+        Exact model:
+        Firmware version:
+        Official product page: https://...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: requested_support
+    attributes:
+      label: What kind of support are you requesting?
+      options:
+        - "Full control: charging, discharging, and monitoring"
+        - "Monitoring only"
+        - "One specific feature"
+        - "I don't know"
+    validations:
+      required: true
+
+  - type: textarea
+    id: development_documentation
+    attributes:
+      label: Developer documentation
+      description: |
+        Provide links to official technical documentation: an API, Modbus register map, RS485 protocol, MQTT topics, HTTP endpoints, SDK, or developer portal.
+        If only a PDF is available, you can drag it into this field. If you cannot find any developer documentation, write **I could not find it** and, if possible, explain where you looked.
+      placeholder: |
+        Official documentation: https://...
+        Document name and version: ...
+        Or: I could not find it; I checked...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: documentation_access
+    attributes:
+      label: Documentation access
+      options:
+        - "Publicly available without an account"
+        - "Requires a free account"
+        - "Requires manufacturer approval or an NDA"
+        - "I only have a PDF or local copy"
+        - "I could not find developer documentation"
+        - "I don't know"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: connection_methods
+    attributes:
+      label: Known connection methods
+      description: Select everything mentioned on the device, in the app, or in the documentation.
+      options:
+        - label: "Local network over Ethernet or Wi-Fi"
+        - label: "Modbus TCP"
+        - label: "RS485 / Modbus RTU"
+        - label: "MQTT"
+        - label: "Local HTTP API"
+        - label: "Cloud / Internet API"
+        - label: "Bluetooth, USB, or serial port"
+        - label: "I don't know"
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Blocking requirements checklist
+
+        Select only the capabilities you can clearly find in the documentation. **You do not need to understand the names in parentheses**; they are the internal keys Omnibattery needs. Leave anything you are unsure about unchecked.
+
+  - type: checkboxes
+    id: blocking_capabilities
+    attributes:
+      label: Capabilities found in the documentation
+      description: These are the minimum controls and measurements required to operate the battery safely.
+      options:
+        - label: "Read the real battery percentage — SOC (`battery_soc`)"
+        - label: "Read actual charging and discharging power in W (`battery_power`)"
+        - label: "Command a specific charging power (`apply_setpoint +W`)"
+        - label: "Command a specific discharging power (`apply_setpoint -W`)"
+        - label: "Stop charging and discharging and remain idle at 0 W (`standby`)"
+        - label: "Determine the safe maximum charging and discharging power"
+        - label: "Detect when the connection or telemetry is no longer updating"
+        - label: "Enable external control, if the device requires it"
+        - label: "Determine whether commands are temporary or stored in device memory"
+        - label: "I cannot identify these capabilities"
+
+  - type: textarea
+    id: technical_clues
+    attributes:
+      label: Technical references and useful clues
+      description: Optional. Include page numbers, field names, or links to projects that already communicate with this battery. You may also attach screenshots with sensitive information removed.
+      placeholder: |
+        SOC: page 12, register 1234
+        Power: batteryPower field
+        Control: /device/control endpoint
+        Existing project: https://github.com/...
+
+  - type: dropdown
+    id: hardware_access
+    attributes:
+      label: Do you have access to the battery for testing?
+      description: A driver must be tested on real hardware to validate signs, limits, and commands.
+      options:
+        - "Yes, I can test versions and share results"
+        - "Yes, with step-by-step instructions"
+        - "I may be able to contact someone who owns one"
+        - "No"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: What would you like to achieve?
+      description: Explain it in your own words. For example, charge from surplus solar, track household consumption, or use several batteries together.
+      placeholder: "I would like Omnibattery to..."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Confirmations
+      options:
+        - label: "I have searched for existing requests for this brand and model."
+          required: true
+        - label: "I have removed passwords, tokens, API keys, complete serial numbers, and other sensitive information."
+          required: true
+        - label: "I understand that available documentation does not guarantee integration or a development date."
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        The maintainer will use this information to complete the [driver requirements assessment](https://github.com/ffunes/Omnibattery/blob/main/site-docs/reference/driver-requirements-template.md) and determine whether the model is suitable, suitable with limitations, or not suitable.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,7 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💡 Feature Request / Idea
-    url: https://github.com/ffunes/Marstek-Venus-Energy-Manager/discussions/categories/feature-ideas
+  - name: 💡 General Feature Request / Idea
+    url: https://github.com/ffunes/Omnibattery/discussions/categories/feature-ideas
     about: >
-      Feature requests go through community voting. Post your idea in Discussions
-      so others can vote on it. Ideas with enough support get prioritized for
-      development.
+      General ideas go through community voting in Discussions. To request support
+      for a new battery model, use the Battery Support form above instead.

--- a/custom_components/omnibattery/control/charge_delay.py
+++ b/custom_components/omnibattery/control/charge_delay.py
@@ -294,7 +294,8 @@ class ChargeDelayManager:
         3. No T_start detected and past fallback hour → unlock
         4. Past T_end with no active production → unlock
         5. Batteries already at target → unlock
-        6. Insufficient remaining solar energy → unlock
+        6. Insufficient remaining solar energy → unlock, unless only the safety
+           cushion is missing and a cheaper feasible hour lies ahead → hold
         7. Insufficient time before T_end → unlock
         8. Otherwise → keep delay active
         """
@@ -529,6 +530,38 @@ class ChargeDelayManager:
             )
 
         if energy_insufficient:
+            # Inside the safety cushion (energy_needed <= net_solar < needed × factor)
+            # the forecast still covers the target on its own; only the 30% margin is
+            # missing. Unlocking instantly there is the expensive branch: it dumps the
+            # whole self-charge into the morning export peak while the midday trough,
+            # when the same kWh would cost a fraction of the forgone teruglever
+            # revenue, is still ahead. Hold for the cheapest feasible hour instead,
+            # bounded by the moment the BARE balance (no safety factor) is projected
+            # to break, so the SOC target stays reachable and the cushion is the only
+            # thing spent. Genuine deficits (net < needed) still unlock immediately.
+            if net_solar_for_battery >= energy_needed_kwh:
+                cushion_edge_h = self._estimate_energy_balance_unlock_h(
+                    forecast_today,
+                    energy_needed_kwh,
+                    ctrl._solar_t_start,
+                    t_end,
+                    now_h,
+                    safety_factor=1.0,
+                )
+                edge_h = (
+                    time_backup_unlock_h
+                    if cushion_edge_h is None
+                    else min(time_backup_unlock_h, cushion_edge_h)
+                )
+                release_h = self._price_hold_release_h(now_h, edge_h, charge_time_h)
+                if release_h is not None and now_h + 1e-6 < release_h:
+                    _LOGGER.info(
+                        "Charge Delay: Cushion-only shortfall (net=%.1f >= needed=%.1f, "
+                        "factored=%.1f) - holding for cheaper hour %.2fh (edge %.2fh)",
+                        net_solar_for_battery, energy_needed_kwh,
+                        energy_needed_kwh * DELAY_SAFETY_FACTOR, release_h, edge_h,
+                    )
+                    return True
             _LOGGER.info(
                 "Charge Delay: Insufficient solar (net=%.1f < needed=%.1f) - unlocking (reason: energy_balance)",
                 net_solar_for_battery, energy_needed_kwh * DELAY_SAFETY_FACTOR
@@ -555,12 +588,10 @@ class ChargeDelayManager:
         # charge_time_h is passed so the scorer weights the WHOLE charge window, not
         # just the starting slot (a cheap start followed by pricey hours can cost
         # more export than a slightly dearer start sitting in a sustained trough).
-        release_h = self._price_optimal_release_h(now_h, est_unlock_h, charge_time_h)
+        release_h = self._price_hold_release_h(now_h, est_unlock_h, charge_time_h)
         if release_h is not None:
             if now_h + 1e-6 < release_h:
                 # A cheaper feasible hour lies ahead, keep holding for it.
-                status["estimated_unlock_time"] = _h_to_hhmm(release_h)
-                status["state"] = f"Delayed (price, {_h_to_hhmm(release_h)} est.)"
                 return True
             # Current hour is the cheapest feasible export hour, release now.
             _LOGGER.info(
@@ -573,6 +604,33 @@ class ChargeDelayManager:
         # All checks passed - keep delay active
         status["state"] = f"Delayed ({status['estimated_unlock_time']} est.)"
         return True
+
+    def _price_hold_release_h(
+        self, now_h: float, edge_h: float, charge_h: float | None = None
+    ) -> float | None:
+        """Pick the cheapest start in ``[now_h, edge_h]`` and mark the hold.
+
+        Thin wrapper around :meth:`_price_optimal_release_h` shared by the two
+        callers that can hold the delay for a cheaper hour (the cushion-only
+        shortfall and the feasible-window release), so the held status is written
+        in exactly one place.
+
+        Returns the chosen start hour: a value greater than ``now_h`` means the
+        delay is being held (the status dict has been updated to say so),
+        ``now_h`` means the current hour is already the cheapest, and ``None``
+        means there is no price-based decision to make (no usable price data, or
+        no room left before the edge).
+        """
+        if edge_h <= now_h:
+            return None
+        release_h = self._price_optimal_release_h(now_h, edge_h, charge_h)
+        if release_h is None or now_h + 1e-6 >= release_h:
+            return release_h
+        ctrl = self._controller
+        hhmm = ctrl._consumption_tracker.h_to_hhmm(release_h)
+        ctrl._charge_delay_status["estimated_unlock_time"] = hhmm
+        ctrl._charge_delay_status["state"] = f"Delayed (price, {hhmm} est.)"
+        return release_h
 
     def _price_optimal_release_h(
         self, now_h: float, edge_h: float, charge_h: float | None = None
@@ -712,11 +770,17 @@ class ChargeDelayManager:
         t_start: float,
         t_end: float,
         now_h: float,
+        safety_factor: float = DELAY_SAFETY_FACTOR,
     ) -> float | None:
         """Estimate when the energy balance condition will trigger the delay unlock.
 
         Binary-searches for the earliest time t >= now_h where:
-          remaining_solar(t) - remaining_consumption(t) < energy_needed × DELAY_SAFETY_FACTOR
+          remaining_solar(t) - remaining_consumption(t) < energy_needed × safety_factor
+
+        ``safety_factor`` defaults to :data:`DELAY_SAFETY_FACTOR` (the real unlock
+        edge). Callers pass ``1.0`` to project the BARE balance edge instead: the
+        last moment the forecast still covers the target with no cushion left,
+        which bounds how long the cushion-only price hold may wait.
 
         Returns the estimated hour as float, or None if it cannot be estimated.
         """
@@ -729,7 +793,7 @@ class ChargeDelayManager:
         # measured over the configured consumption window, not daylight hours.
         avg_consumption = ctrl._consumption_tracker.get_avg_daily_consumption()
         window_hours_per_day = ctrl._consumption_tracker.get_consumption_window_hours_per_day()
-        threshold = energy_needed_kwh * DELAY_SAFETY_FACTOR
+        threshold = energy_needed_kwh * safety_factor
 
         def net_solar_at(t: float) -> float:
             """Net solar available for battery at time t."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ plugins:
             Hourly net balance: Balance neto horario
             Technical reference: Referencia técnica
             Architecture: Arquitectura
+            Battery driver requirements: Requisitos para drivers de batería
             Modbus registers: Registros Modbus
             HA entities: Entidades HA
             Troubleshooting: Solución de problemas
@@ -146,6 +147,7 @@ nav:
       - Hourly net balance: features/hourly-net-balance.md
   - Technical reference:
       - Architecture: reference/architecture.md
+      - Battery driver requirements: reference/driver-requirements-template.md
       - Modbus registers: reference/modbus-registers.md
       - HA entities: reference/entities.md
   - Troubleshooting: troubleshooting.md

--- a/site-docs/features/solar-charge-delay.md
+++ b/site-docs/features/solar-charge-delay.md
@@ -32,6 +32,9 @@ Every time the sensor value changes by more than 0.05 kWh, the integration re-ev
 
 Once the delay is unlocked it stays unlocked for the rest of the day.
 
+!!! note "Cushion-only shortfall waits for the cheapest hour"
+    The energy-balance unlock fires at `net_solar < energy_needed × 1.3`, where the 30 % is a safety cushion rather than the target itself. When only that cushion is missing (`net_solar` is still at or above the bare `energy_needed`) and predictive charging runs in a price-driven mode, the delay does not release on the spot: it holds for the cheapest remaining hour, bounded by the moment the unfactored balance is projected to break. Self-charging then lands in the midday price trough instead of the morning export peak, and the SOC target stays reachable. A genuine deficit (`net_solar < energy_needed`) still unlocks immediately, as does any day without usable price data.
+
 !!! note "Transient forecast gaps and manual re-evaluation"
     A configured forecast sensor that reads `unavailable`/`unknown` for a moment — while it refreshes, or during the window after a Home Assistant restart before all sensors have loaded — no longer disables the delay for the whole day. The delay is held through a short grace window (sensor state `Waiting for forecast`) and only unlocks if the sensor stays unavailable past it. If the delay did already unlock and you want it back the same day, **toggle the Solar Charge Delay switch off and then on**: that re-evaluates the delay from scratch instead of waiting for the midnight reset.
 

--- a/site-docs/reference/driver-requirements-template.es.md
+++ b/site-docs/reference/driver-requirements-template.es.md
@@ -1,0 +1,423 @@
+# Plantilla de requisitos para integrar un driver de batería
+
+Esta plantilla sirve para auditar la documentación oficial de una batería antes
+de desarrollar su driver para Omnibattery. La referencia funcional es **Marstek
+Venus E v3**, pero no se exige que otra marca copie sus registros ni sus modos.
+Lo que debe conservarse es el contrato semántico de Omnibattery: leer el estado
+real de la batería y ordenar una potencia neta segura.
+
+La plantilla debe completarse por combinación de **marca, modelo y familia de
+firmware**. Una API documentada para un modelo no se debe dar por válida para
+toda la gama.
+
+## Resultado de la evaluación
+
+Usa estas clasificaciones:
+
+| Código | Significado |
+|---|---|
+| **B** | Bloqueante. Sin esta capacidad no debe habilitarse el control automático. |
+| **R** | Requerida para una integración robusta. Puede admitirse provisionalmente si el riesgo está documentado y mitigado. |
+| **O** | Opcional. Su ausencia elimina entidades o funcionalidades concretas, pero no el control básico. |
+
+Para el origen de cada dato o control:
+
+| Código | Origen |
+|---|---|
+| **N** | Nativo: la batería lo expone directamente. |
+| **D** | Derivado: el driver lo calcula a partir de datos nativos. |
+| **C** | Configurado: lo aporta el usuario o una constante validada por modelo. |
+| **X** | No soportado: la entidad o funcionalidad queda fuera. |
+
+Dictamen final:
+
+- **APTO**: están cubiertos todos los requisitos B y R.
+- **APTO CON LIMITACIONES**: están cubiertos todos los B, pero falta algún R u
+  O. Deben enumerarse las funciones desactivadas y los riesgos residuales.
+- **NO APTO**: falta al menos un B, la documentación no permite confirmar la
+  semántica de los comandos o el control depende de una interfaz inestable/no
+  autorizada.
+
+## 1. Identificación y evidencia documental
+
+| Campo | Valor a completar |
+|---|---|
+| Fabricante | `...` |
+| Modelo comercial | `...` |
+| Identificador devuelto por el equipo | `...` |
+| Firmware mínimo/máximo verificado | `...` |
+| Región o variante de hardware | `...` |
+| Capacidad y potencia nominales | `...` |
+| Tipo de acoplamiento | `AC / DC / híbrido` |
+| Documento oficial, versión y fecha | `...` |
+| URL o fichero archivado | `...` |
+| Contacto/canal de soporte del fabricante | `...` |
+| Equipo real usado para validar | `...` |
+| Fecha de la prueba | `...` |
+
+Documentar también:
+
+- [ ] La interfaz está publicada o autorizada por el fabricante.
+- [ ] Se conocen los modelos y firmwares a los que aplica.
+- [ ] Se han guardado ejemplos reales de petición y respuesta, sin secretos.
+- [ ] Cada campo tiene tipo, unidad, escala, signo, rango y valor centinela.
+- [ ] Cada escritura tiene rango, granularidad, persistencia y respuesta de error.
+- [ ] Se conocen límites de frecuencia, concurrencia y tamaño de petición.
+- [ ] Se conoce qué ocurre al reiniciar, perder la conexión o cerrar Omnibattery.
+
+### Matriz de compatibilidad de firmware
+
+| Modelo | Firmware | Transporte | Lectura | Escritura | Diferencias conocidas | Estado |
+|---|---|---|---|---|---|---|
+| `...` | `...` | `...` | `sí/no` | `sí/no` | `...` | `probado/no probado` |
+
+### Ficha de transporte y acceso
+
+| Aspecto | Valor a completar |
+|---|---|
+| Alcance | `local / cloud / ambos` |
+| Protocolo y versión | `...` |
+| Dirección, puerto, endpoint o topic | `...` |
+| Descubrimiento | `manual / mDNS / broadcast / cloud / ...` |
+| Autenticación y renovación | `...` |
+| Cifrado/TLS y validación de certificado | `...` |
+| Identificador de unidad/dispositivo | `...` |
+| Timeout y reintentos recomendados | `...` |
+| Máximo de conexiones simultáneas | `...` |
+| Límite de lecturas/escrituras | `...` |
+| Orden o atomicidad de escrituras múltiples | `...` |
+| Timestamp, secuencia o TTL de telemetría | `...` |
+| Comandos volátiles frente a persistentes | `...` |
+| Comportamiento sin red/cloud | `...` |
+
+Una API exclusivamente cloud no es un rechazo automático, pero su latencia,
+caducidad de token, cuotas y comportamiento durante una caída deben permitir un
+reposo seguro y una cadencia de control estable. Estas condiciones forman parte
+del dictamen, no son meros detalles de implementación.
+
+## 2. Puerta de entrada: mínimos para control automático
+
+Todos los puntos siguientes son bloqueantes:
+
+- [ ] Existe un transporte programático con conexión, reconexión y cierre
+  controlables (`Modbus TCP/RTU`, HTTP local, MQTT, API equivalente).
+- [ ] Puede leerse un **SOC real** y actualizado en porcentaje.
+- [ ] Puede obtenerse la **potencia real de batería**, directa o derivada de
+  medidas simultáneas, con la convención de signo de Omnibattery.
+- [ ] Puede ordenarse una **carga** a potencia limitada.
+- [ ] Puede ordenarse una **descarga** a potencia limitada.
+- [ ] Puede ordenarse y mantener un estado de **reposo** (`0 W`) seguro.
+- [ ] Se conocen los límites máximos seguros de carga y descarga por unidad.
+- [ ] La protección BMS independiente del fabricante continúa activa bajo
+  control externo. Omnibattery no sustituye protecciones eléctricas del BMS.
+- [ ] La cadencia de escritura necesaria no desgasta memoria flash ni incumple
+  límites de la API. Si hay comandos volátiles y persistentes, están distinguidos.
+- [ ] Se puede detectar una comunicación obsoleta o perdida sin reutilizar datos
+  antiguos indefinidamente.
+
+Si falta SOC, potencia medida, una de las dos direcciones o un reposo fiable, el
+driver es **NO APTO** para el bucle automático bidireccional. Se puede estudiar
+un modo de solo monitorización, pero no debe presentarse como soporte completo.
+
+## 3. Contrato canónico de Omnibattery
+
+El driver traduce el protocolo de la marca al contrato de
+`drivers/base.py::BatteryDriver`. La capa de control nunca debe conocer
+direcciones de registro, endpoints, topics ni nombres propietarios.
+
+### Convenciones obligatorias
+
+- Potencia neta: `+W` significa **carga**, `-W` significa **descarga** y `0 W`
+  significa reposo.
+- `battery_power` usa la misma convención y representa potencia **medida**, no
+  solamente el último setpoint solicitado.
+- Potencia en `W`, energía/capacidad en `kWh`, SOC en `%`, tensión en `V` y
+  temperatura en `°C` después de aplicar escala.
+- Un valor fallido se omite o se entrega como desconocido; nunca se inventa `0`
+  si cero es una medida válida.
+- `apply_setpoint()` limita el valor al sobre de potencia del equipo y devuelve
+  un `SetpointResult` coherente aunque el protocolo no tenga readback inmediato.
+
+### Superficie mínima del driver
+
+| Superficie | Requisito | Nivel |
+|---|---|---|
+| Identidad/capacidades | `capabilities`, `model_label` y, si existe, `serial` estable | R |
+| Ciclo de vida | `connected`, `connect()`, `close()`, `set_shutting_down()` | B |
+| Lectura | `read_groups` y `read_telemetry(keys)` con caché si la fuente es push | B |
+| Control neto | `apply_setpoint(+W/-W/0)` | B |
+| Controles de entidad | `write_control(key, value)`; devuelve `False` para claves no soportadas | R |
+| Eco de orden | `net_power_from_data(data)`; puede devolver `None` si no hay eco | R |
+| Dependencias | `control_dependency_keys` para datos que deben leerse aunque su entidad esté deshabilitada | R |
+| Configuración | `apply_config(...)`, omitiendo de forma explícita los ajustes no aplicables | R |
+| Parada | `standby()` que deje el equipo en un estado seguro antes de cerrar | B |
+| Corte de carga | `set_charge_cutoff()` o retorno controlado `False` cuando se aplique por software | O/condicional |
+| Puerta externa | `set_rs485_control()`/`get_rs485_control()` o equivalente si el equipo la necesita | B/condicional |
+
+Aunque algunos métodos semánticos todavía no estén declarados abstractos en la
+clase base, el coordinador los usa y el nuevo driver debe implementarlos.
+
+### Capacidades a declarar
+
+| `DriverCapabilities` | Valor | Evidencia/justificación |
+|---|---:|---|
+| `hardware_soc_cutoff` | `...` | `...` |
+| `has_force_mode` | `...` | `...` |
+| `push_telemetry` | `...` | `...` |
+| `max_charge_power_w` | `...` | `...` |
+| `max_discharge_power_w` | `...` | `...` |
+| `min_charge_power_w` | `...` | `...` |
+| `min_discharge_power_w` | `...` | `...` |
+| `has_mppt_pv` | `...` | `...` |
+| `has_alarm_registers` | `...` | `...` |
+| `has_rs485_control` | `...` | `...` |
+| `has_energy_counters` | `...` | `...` |
+| `setpoint_confirm_reliable` | `...` | `...` |
+| `actuator_latency_s` | `...` | Medida de peor caso, no promedio |
+
+## 4. Mapa mínimo de palancas y telemetría
+
+### Núcleo obligatorio
+
+| Clave/operación Omnibattery | Nivel | Qué debe aportar la marca | Sustitución admitida |
+|---|---|---|---|
+| `battery_soc` | B | SOC real 0–100 %, con cadencia y antigüedad conocidas | No se acepta una estimación simple por tensión como soporte completo |
+| `battery_power` | B | Potencia instantánea real en ambos sentidos | Fórmula D a partir de flujos simultáneos y validados |
+| `apply_setpoint(+W)` | B | Orden de carga con límite de potencia | Combinación de modo + límite o propiedad única |
+| `apply_setpoint(-W)` | B | Orden de descarga con límite de potencia | Combinación de modo + límite o propiedad única |
+| `apply_setpoint(0)` / `standby()` | B | Reposo mantenido, sin quedar en un modo autónomo que exporte | Secuencia documentada de modo y límites a cero |
+| Límites máx. de potencia | B | Valores por modelo o lectura del equipo | Configuración C limitada por máximos oficiales |
+| Estado de conexión/frescura | B | Error, timestamp, disponibilidad o mecanismo equivalente | Temporizador de caducidad en el driver |
+| Eco del setpoint | R | Modo/límite aplicado o aceptado | Caché de orden solo para optimizar; no sustituye potencia medida |
+| Latencia de actuador | R | Tiempo escritura → aplicación → reflejo en telemetría | Medición sobre equipo real y margen conservador |
+| Potencia mínima fiable | R | Mínimo no nulo sostenible y pasos aceptados | Constante C por modelo, validada físicamente |
+
+### Telemetría y controles que amplían funciones
+
+| Clave canónica | Nivel | Función que habilita | Si falta |
+|---|---|---|---|
+| `battery_total_energy` | R | Energía almacenada, reparto y carga predictiva | Capacidad C introducida por el usuario |
+| `total_charging_energy` / `total_discharging_energy` | O | Energía y eficiencia acumuladas | Integración D de `battery_power`, con persistencia |
+| `max_cell_voltage` | O | Taper y pausa segura al 100 %, recalibración y balance | Desactivar las funciones dependientes de tensión de celda |
+| `min_cell_voltage` | O | Delta de celdas y monitor de balance | No publicar delta/balance |
+| `internal_temperature` | O | Derating térmico de carga/descarga | No habilitar el límite térmico |
+| `inverter_state` | O | Confirmación adicional de standby/corte BMS | Usar solo potencia medida; omitir detecciones que exijan estado |
+| `ac_offgrid_power` | O | Detectar carga de backup y excluir la batería del PD | Desactivar exclusión automática por backup |
+| `backup_function` o equivalente | O | Saber/controlar el modo backup | Omitir la entidad y su lógica específica |
+| `mppt1_power`…`mppt4_power` | O | Producción DC y eficiencia por plano | `has_mppt_pv=False`; no crear esas entidades |
+| `alarm_status` / `fault_status` | O | Alarmas de sistema | No crear el sensor/notificador dependiente |
+| `battery_voltage` | O | Diagnóstico | Omitir la entidad |
+| Identidad, firmware, RSSI | O | Diagnóstico y soporte | Omitir entidades; preferir `serial` estable si existe |
+| Corte SOC hardware | O | Persistencia autónoma de límites SOC | `hardware_soc_cutoff=False` y corte por software |
+| Límite potencia escribible | O | Ajuste persistente en el equipo | Límite C en software, sin fingir una entidad hardware |
+| Puerta de control externo | Condicional | Activar/devolver el control al firmware | Solo obligatoria si los setpoints no funcionan sin ella |
+
+## 5. Referencia: Marstek Venus E v3
+
+La v3 define el comportamiento de referencia, no la forma obligatoria del
+protocolo:
+
+| Semántica | Implementación v3 de referencia |
+|---|---|
+| SOC | `battery_soc`, registro `37005`, `uint16`, `%` |
+| Potencia medida | `battery_power`, registro `30001`, `int16`; positiva al cargar y negativa al descargar |
+| Orden de carga | `set_discharge_power=0`, `set_charge_power=W`, `force_mode=charge` |
+| Orden de descarga | `set_discharge_power=W`, `set_charge_power=0`, `force_mode=discharge` |
+| Reposo | Ambos setpoints a `0` y `force_mode=stop` |
+| Sobre de potencia | Setpoints `0–2500 W`, paso documentado `50 W`; límites de instalación en `max_charge_power`/`max_discharge_power` |
+| Potencia mínima declarada | `800 W` para los límites v3; se refleja en las capacidades del driver |
+| Control externo | `rs485_control_mode`, comandos específicos `0x55AA`/`0x55BB` |
+| Corte SOC | No hay registros de corte en v3; Omnibattery aplica min/max SOC por software |
+| Confirmación | Readback de modo, setpoints y potencia; tolerancia durante la rampa |
+| Transporte | Modbus, polling, un único slot TCP y pacing específico |
+
+La consecuencia importante es que **`force_mode` no es obligatorio**. Otra
+batería puede cumplir exactamente el mismo contrato mediante un único límite
+con signo, dos límites, un enum distinto o una API HTTP.
+
+## 6. Sustituciones válidas: patrón Zendure
+
+Zendure demuestra qué ausencias se pueden resolver dentro de Omnibattery:
+
+| Ausencia/diferencia de la marca | Adaptación válida del driver |
+|---|---|
+| No existe `battery_power` directo | Se deriva como `outputPackPower - packInputPower`, tras validar signo y simultaneidad |
+| No hay contadores kWh | Omnibattery integra `battery_power` y persiste los totales sintéticos |
+| No se informa capacidad nominal | El usuario configura `battery_total_energy` en kWh |
+| No existe `force_mode` Marstek | `acMode` + `inputLimit`/`outputLimit` implementan el setpoint neto |
+| El límite de carga es de solo lectura | Se combina el máximo real del equipo con un techo de software del usuario |
+| Las celdas llegan como una lista de packs | El driver calcula extremos globales y publica también claves por pack |
+| El readback tarda varios segundos | Se declara `setpoint_confirm_reliable=False` y una `actuator_latency_s` conservadora |
+| La escritura frecuente podría tocar flash | Los setpoints usan modo volátil; la configuración persistente usa escritura explícita a flash |
+
+Reglas para aceptar una sustitución:
+
+- [ ] La fórmula y la convención de signo están probadas con carga, descarga y reposo.
+- [ ] Las entradas de una fórmula corresponden al mismo instante o su desfase es acotado.
+- [ ] El dato derivado conserva unidad, rango y precisión suficientes.
+- [ ] Los acumuladores se restauran tras reinicio y toleran huecos de telemetría.
+- [ ] Un valor C queda identificado como configuración, no como lectura del equipo.
+- [ ] La UI no crea una entidad hardware que en realidad no existe.
+
+No deben sintetizarse sin una fuente física fiable: SOC real, alarmas, temperatura,
+tensiones de celda ni confirmación de potencia entregada. Una caché del último
+comando representa **intención**, no estado real.
+
+## 7. Matriz de degradación funcional
+
+Completarla antes de aprobar el desarrollo:
+
+| Funcionalidad | Dependencias mínimas | Alternativa | Estado para este modelo |
+|---|---|---|---|
+| Control PD carga/descarga | SOC, potencia medida, setpoint ±W/0, límites | Ninguna para soporte completo | `...` |
+| Gestión multi-batería | Lo anterior por unidad; capacidad mejora el reparto energético | Capacidad C | `...` |
+| Límites min/max SOC | SOC + mando de reposo | Hardware o software | `...` |
+| Carga predictiva/precios | SOC + capacidad kWh + control de carga | Capacidad C | `...` |
+| Energía/ciclos/eficiencia | Contadores o potencia con tiempo fiable | Integración D | `...` |
+| Taper/protección al 100 % | `max_cell_voltage`, SOC y potencia | Sin alternativa equivalente | `...` |
+| Monitor/diagnóstico de balance | `max_cell_voltage` + `min_cell_voltage` | Extremos D desde celdas/packs | `...` |
+| Carga semanal completa | SOC, potencia y control; corte hardware si existe | Corte software | `...` |
+| Límite térmico | Temperatura interna | Ninguna | `...` |
+| Exclusión por backup | Potencia off-grid y estado/modo backup | Ninguna fiable | `...` |
+| Producción MPPT/DC | Potencia por MPPT o total DC | Suma D de canales | `...` |
+| Alarmas | Bits/códigos de fallo con tabla oficial | Ninguna | `...` |
+| Persistencia de energía sintética | Potencia + identificador estable | Clave de dispositivo menos estable | `...` |
+
+Una función marcada como no soportada debe quedar fuera mediante capacidades,
+definiciones de entidades o configuración. No debe recibir ceros ficticios.
+
+## 8. Ficha de mapeo de telemetría
+
+Añadir una fila por cada clave. En “evidencia” indicar página/sección del manual
+y adjuntar una muestra real anonimizada.
+
+| Clave Omnibattery | B/R/O | Campo/registro/topic fabricante | R/W | Tipo/endian | Escala y unidad final | Rango/centinelas | Cadencia/TTL | N/D/C/X | Evidencia | Validado |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `battery_soc` | B | `...` | R | `...` | `... → %` | `...` | `...` | `...` | `...` | [ ] |
+| `battery_power` | B | `...` | R | `...` | `... → W; +carga/-descarga` | `...` | `...` | `...` | `...` | [ ] |
+| Estado/eco de setpoint | R | `...` | R | `...` | `...` | `...` | `...` | `...` | `...` | [ ] |
+| `battery_total_energy` | R | `...` | R/C | `...` | `... → kWh` | `...` | `...` | `...` | `...` | [ ] |
+| `total_charging_energy` | O | `...` | R | `...` | `... → kWh` | `...` | `...` | `...` | `...` | [ ] |
+| `total_discharging_energy` | O | `...` | R | `...` | `... → kWh` | `...` | `...` | `...` | `...` | [ ] |
+| `max_cell_voltage` | O | `...` | R | `...` | `... → V` | `...` | `...` | `...` | `...` | [ ] |
+| `min_cell_voltage` | O | `...` | R | `...` | `... → V` | `...` | `...` | `...` | `...` | [ ] |
+| `internal_temperature` | O | `...` | R | `...` | `... → °C` | `...` | `...` | `...` | `...` | [ ] |
+| `inverter_state` | O | `...` | R | enum | `mapa: ...` | `...` | `...` | `...` | `...` | [ ] |
+| `ac_offgrid_power` | O | `...` | R | `...` | `... → W` | `...` | `...` | `...` | `...` | [ ] |
+| Alarmas/fallos | O | `...` | R | bitmap/enum | `mapa: ...` | `...` | `...` | `...` | `...` | [ ] |
+| MPPT/PV | O | `...` | R | `...` | `... → W` | `...` | `...` | `...` | `...` | [ ] |
+| Identidad/firmware | O | `...` | R | string | `...` | `...` | `...` | `...` | `...` | [ ] |
+
+## 9. Ficha de mapeo de controles
+
+| Operación semántica | B/R/O | Campo(s)/comando(s) fabricante | Secuencia | Rango/paso | Volátil/persistente | ACK/readback | Timeout/latencia | Estado seguro al fallar | Evidencia | Validado |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Conectar/autenticar | B | `...` | `...` | — | — | `...` | `...` | sin control | `...` | [ ] |
+| Cargar a `W` | B | `...` | `...` | `...` | `...` | `...` | `...` | `...` | `...` | [ ] |
+| Descargar a `W` | B | `...` | `...` | `...` | `...` | `...` | `...` | `...` | `...` | [ ] |
+| Reposo `0 W` | B | `...` | `...` | `...` | `...` | `...` | `...` | `...` | `...` | [ ] |
+| Límite máximo carga | R | `...` | `...` | `...` | `...` | `...` | `...` | límite C | `...` | [ ] |
+| Límite máximo descarga | R | `...` | `...` | `...` | `...` | `...` | `...` | límite C | `...` | [ ] |
+| Corte SOC máximo | O | `...` | `...` | `...` | `...` | `...` | `...` | software | `...` | [ ] |
+| Corte SOC mínimo | O | `...` | `...` | `...` | `...` | `...` | `...` | software | `...` | [ ] |
+| Activar control externo | Cond. | `...` | `...` | `...` | `...` | `...` | `...` | devolver control | `...` | [ ] |
+| Restablecer control del fabricante | Cond. | `...` | `...` | — | `...` | `...` | `...` | `...` | `...` | [ ] |
+| Otros controles UI | O | `...` | `...` | `...` | `...` | `...` | `...` | omitir entidad | `...` | [ ] |
+
+## 10. Pruebas mínimas de aceptación
+
+No basta con que el documento mencione una clave; debe verificarse sobre equipo
+real o simulador oficial representativo.
+
+### Transporte y datos
+
+- [ ] Conecta, lee identidad/SOC y cierra sin dejar recursos o sesiones abiertos.
+- [ ] Reconecta después de timeout, reinicio del equipo y cambio temporal de red.
+- [ ] Rechaza respuestas parciales, valores centinela y datos fuera de rango.
+- [ ] Caduca la caché push o los últimos datos cuando deja de recibir mensajes.
+- [ ] Mantiene las unidades y el signo en carga, descarga y reposo.
+- [ ] Respeta exclusión mutua si el dispositivo solo admite una conexión.
+
+### Control
+
+- [ ] `+W`: carga, queda limitada al máximo y la potencia medida cambia de signo correcto.
+- [ ] `-W`: descarga, queda limitada al máximo y la potencia medida cambia de signo correcto.
+- [ ] `0 W`: detiene ambos sentidos y no vuelve solo a exportar/importar.
+- [ ] Transiciones carga → descarga, descarga → carga y movimiento → reposo.
+- [ ] Comandos repetidos son idempotentes y no desgastan flash.
+- [ ] Si una orden usa varias escrituras, un fallo parcial converge a reposo o a
+  otro estado definido; se ha verificado el orden obligatorio.
+- [ ] El readback distingue orden aceptada de potencia realmente entregada.
+- [ ] Se mide latencia en caso normal y peor caso; se configura el valor conservador.
+- [ ] Una escritura fallida devuelve razón y no actualiza la caché como confirmada.
+- [ ] Al descargar con SOC mínimo y cargar con SOC máximo, el sistema queda seguro.
+- [ ] Al cerrar Omnibattery se aplica `standby()` y, si procede, se devuelve el control al firmware.
+
+### Sustituciones y degradación
+
+- [ ] Cada fórmula D tiene pruebas unitarias con valores límite y signos.
+- [ ] Energía sintética sobrevive a reinicios y no integra durante huecos de datos.
+- [ ] La capacidad C se valida contra rangos razonables y aparece como configurada.
+- [ ] Las funciones X no crean entidades, avisos ni decisiones con valores ficticios.
+- [ ] El driver convive con otra marca en un pool multi-batería.
+
+### Cobertura de código esperada
+
+- [ ] Contrato del driver: conexión, grupos de lectura, escalado y claves ausentes.
+- [ ] `apply_setpoint`: carga, descarga, cero, clamp, fallo, ACK tardío y sin readback.
+- [ ] `net_power_from_data` y `control_dependency_keys`.
+- [ ] Configuración/cortes/standby y puerta de control condicional.
+- [ ] Detección de modelo y validación del flujo de configuración.
+- [ ] Matriz de firmware/modelo soportado y no soportado.
+
+## 11. Informe de decisión para copiar y completar
+
+```text
+Marca/modelo:
+Firmware probado:
+Documentación oficial (versión/fecha/enlace):
+
+Dictamen: APTO / APTO CON LIMITACIONES / NO APTO
+
+Bloqueantes B:
+- SOC real: N/D/C/X — evidencia:
+- Potencia real: N/D/C/X — evidencia/fórmula:
+- Carga regulable: sí/no — rango/paso:
+- Descarga regulable: sí/no — rango/paso:
+- Reposo seguro: sí/no — secuencia:
+- Límites seguros: origen/valores:
+- Frescura y pérdida de conexión: mecanismo:
+
+Adaptaciones en Omnibattery:
+- Datos derivados:
+- Datos configurados por usuario:
+- Límites aplicados por software:
+
+Funcionalidades excluidas:
+-
+
+Riesgos abiertos:
+-
+
+Pruebas en hardware pendientes:
+-
+
+Responsable de aprobación y fecha:
+```
+
+## 12. Checklist de implementación después de aprobar
+
+- [ ] Crear el driver sin filtrar detalles propietarios fuera de `drivers/`.
+- [ ] Añadir selección/detección de marca y modelo en el flujo de configuración.
+- [ ] Instanciar el driver en el coordinador y declarar correctamente capacidades.
+- [ ] Definir solo las entidades realmente soportadas y sus traducciones.
+- [ ] Añadir campos de configuración para valores C, como capacidad nominal.
+- [ ] Desactivar por capacidad las funciones que dependan de claves X.
+- [ ] Añadir pruebas unitarias del driver y pruebas de integración multi-marca.
+- [ ] Documentar prerrequisitos del equipo, firmwares y limitaciones conocidas.
+- [ ] Actualizar diagnósticos ocultando credenciales, tokens y números de serie sensibles.
+
+La aprobación documental autoriza iniciar el driver, pero no sustituye la prueba
+en hardware. Una clave que aparece en el manual puede tener signo invertido,
+escala distinta, latencia, clamp interno o comportamiento diferente según
+firmware; todo ello debe quedar validado antes de declarar soporte estable.

--- a/site-docs/reference/driver-requirements-template.md
+++ b/site-docs/reference/driver-requirements-template.md
@@ -1,0 +1,378 @@
+# Battery driver requirements template
+
+Use this template to audit a battery manufacturer's official development
+documentation before implementing an Omnibattery driver. **Marstek Venus E v3**
+is the functional reference, but another brand does not need the same registers
+or modes. It must satisfy the same semantic contract: report the battery's real
+state and accept a safe signed net-power command.
+
+Complete one assessment per manufacturer, model and firmware family.
+
+## Assessment outcome
+
+Requirement levels:
+
+| Code | Meaning |
+|---|---|
+| **B** | Blocking. Automatic control must not be enabled without it. |
+| **R** | Required for a robust production integration. A provisional exception needs a documented mitigation. |
+| **O** | Optional. Its absence removes specific entities or features, not core control. |
+
+Source classifications:
+
+| Code | Source |
+|---|---|
+| **N** | Native device value or control. |
+| **D** | Derived by the driver from native data. |
+| **C** | User-configured or validated model constant. |
+| **X** | Unsupported; the dependent entity or feature is omitted. |
+
+Final verdict:
+
+- **SUITABLE**: every B and R requirement is covered.
+- **SUITABLE WITH LIMITATIONS**: every B requirement is covered, but an R or O
+  item is missing. Disabled features and residual risks are listed.
+- **NOT SUITABLE**: a B item is missing, command semantics cannot be confirmed,
+  or control depends on an unstable or unauthorised interface.
+
+## 1. Device and documentation evidence
+
+| Field | Value |
+|---|---|
+| Manufacturer | `...` |
+| Commercial model | `...` |
+| Device-reported model | `...` |
+| Verified firmware range | `...` |
+| Region/hardware variant | `...` |
+| Rated capacity and power | `...` |
+| Coupling type | `AC / DC / hybrid` |
+| Official document, revision and date | `...` |
+| URL or archived file | `...` |
+| Manufacturer support channel | `...` |
+| Hardware used for validation | `...` |
+| Test date | `...` |
+
+- [ ] The interface is published or authorised by the manufacturer.
+- [ ] Applicable models and firmware versions are explicitly known.
+- [ ] Real request/response examples have been retained without secrets.
+- [ ] Every field documents type, unit, scale, sign, range and sentinels.
+- [ ] Every write documents range, step, persistence and error response.
+- [ ] Rate, concurrency and request-size limits are known.
+- [ ] Restart, disconnect and Omnibattery shutdown behaviour is known.
+
+### Firmware compatibility matrix
+
+| Model | Firmware | Transport | Read | Write | Known differences | Status |
+|---|---|---|---|---|---|---|
+| `...` | `...` | `...` | `yes/no` | `yes/no` | `...` | `tested/untested` |
+
+### Transport and access worksheet
+
+| Aspect | Value |
+|---|---|
+| Scope | `local / cloud / both` |
+| Protocol and version | `...` |
+| Address, port, endpoint or topic | `...` |
+| Discovery | `manual / mDNS / broadcast / cloud / ...` |
+| Authentication and renewal | `...` |
+| Encryption/TLS and certificate validation | `...` |
+| Unit/device identifier | `...` |
+| Recommended timeout and retry policy | `...` |
+| Maximum simultaneous connections | `...` |
+| Read/write rate limit | `...` |
+| Ordering/atomicity of multi-write commands | `...` |
+| Telemetry timestamp, sequence or TTL | `...` |
+| Volatile versus persistent commands | `...` |
+| Behaviour without network/cloud | `...` |
+
+A cloud-only API is not automatically rejected, but its latency, token expiry,
+quotas and outage behaviour must allow safe idle and stable control cadence.
+These constraints are part of the verdict, not merely implementation detail.
+
+## 2. Admission gate for automatic control
+
+Every item below is blocking:
+
+- [ ] A programmable transport supports controlled connect, reconnect and close.
+- [ ] Real, fresh battery SOC can be read as a percentage.
+- [ ] Real battery power is available directly or can be derived from simultaneous measurements.
+- [ ] The device accepts power-limited charging commands.
+- [ ] The device accepts power-limited discharging commands.
+- [ ] The device accepts and holds a safe idle command (`0 W`).
+- [ ] Safe per-unit charge and discharge maxima are known.
+- [ ] The manufacturer's independent BMS protections remain active under external control.
+- [ ] The required write cadence neither wears flash nor violates API limits.
+- [ ] Stale or lost communications can be detected without reusing old data forever.
+
+Without SOC, measured power, either direction, or reliable idle, the driver is
+**NOT SUITABLE** for bidirectional automatic control. A monitoring-only mode may
+still be considered but is not full support.
+
+## 3. Omnibattery canonical contract
+
+The driver translates vendor protocol details into
+`drivers/base.py::BatteryDriver`; registers, endpoints, topics and proprietary
+names must not leak into the control layer.
+
+Mandatory conventions:
+
+- Signed net power: `+W` charges, `-W` discharges, `0 W` idles.
+- `battery_power` follows the same convention and is a measurement, not merely
+  the last requested setpoint.
+- Final units are W, kWh, %, V and °C.
+- Failed values are omitted or unknown; never invent zero when zero is valid.
+- `apply_setpoint()` clamps to the device envelope and always returns a coherent
+  `SetpointResult`, even without immediate readback.
+
+### Minimum driver surface
+
+| Surface | Requirement | Level |
+|---|---|---|
+| Identity/capabilities | `capabilities`, `model_label`, and stable `serial` when available | R |
+| Lifecycle | `connected`, `connect()`, `close()`, `set_shutting_down()` | B |
+| Read | `read_groups`, `read_telemetry(keys)`; cache push data | B |
+| Net control | `apply_setpoint(+W/-W/0)` | B |
+| Entity controls | `write_control(key, value)`; return `False` for unsupported keys | R |
+| Command echo | `net_power_from_data(data)`; `None` is allowed when no echo exists | R |
+| Dependencies | `control_dependency_keys` for data polled even if its entity is disabled | R |
+| Configuration | `apply_config(...)`, explicitly skipping inapplicable settings | R |
+| Shutdown | `standby()` leaves the device safe before close | B |
+| Charge cutoff | `set_charge_cutoff()` or controlled `False` for software enforcement | O/conditional |
+| External-control gate | `set_rs485_control()`/`get_rs485_control()` or equivalent when required | B/conditional |
+
+The coordinator currently calls some semantic methods that are not yet abstract
+on the base class; a new driver must still implement them.
+
+### Declared capabilities
+
+| `DriverCapabilities` | Value | Evidence/rationale |
+|---|---:|---|
+| `hardware_soc_cutoff` | `...` | `...` |
+| `has_force_mode` | `...` | `...` |
+| `push_telemetry` | `...` | `...` |
+| `max_charge_power_w` | `...` | `...` |
+| `max_discharge_power_w` | `...` | `...` |
+| `min_charge_power_w` | `...` | `...` |
+| `min_discharge_power_w` | `...` | `...` |
+| `has_mppt_pv` | `...` | `...` |
+| `has_alarm_registers` | `...` | `...` |
+| `has_rs485_control` | `...` | `...` |
+| `has_energy_counters` | `...` | `...` |
+| `setpoint_confirm_reliable` | `...` | `...` |
+| `actuator_latency_s` | `...` | Worst case, not average |
+
+## 4. Minimum telemetry and control levers
+
+### Blocking core
+
+| Omnibattery key/operation | Level | Vendor requirement | Accepted substitute |
+|---|---|---|---|
+| `battery_soc` | B | Fresh real SOC, 0–100% | A simple voltage estimate is not full support |
+| `battery_power` | B | Instantaneous power in both directions | D formula from simultaneous validated flows |
+| `apply_setpoint(+W)` | B | Power-limited charge | Mode + limit or one signed property |
+| `apply_setpoint(-W)` | B | Power-limited discharge | Mode + limit or one signed property |
+| `apply_setpoint(0)` / `standby()` | B | Held idle without autonomous import/export | Documented zero-limit/mode sequence |
+| Maximum power | B | Per-model values or device readings | C values bounded by official maxima |
+| Availability/freshness | B | Error, timestamp or equivalent | Driver cache expiry timer |
+| Setpoint echo | R | Applied/accepted mode and limit | Intent cache only optimises; it is not measured power |
+| Actuator latency | R | Write-to-application-to-telemetry delay | Hardware measurement with conservative margin |
+| Reliable minimum power | R | Sustainable non-zero minimum and command step | Validated per-model C constant |
+
+### Optional feature inputs
+
+| Canonical key | Level | Enables | If absent |
+|---|---|---|---|
+| `battery_total_energy` | R | Stored energy, allocation and predictive charging | User-configured C capacity |
+| Charge/discharge energy totals | O | Energy and cumulative efficiency | Integrate `battery_power` with persistence |
+| `max_cell_voltage` | O | 100% taper/pause, recalibration and balance | Disable voltage-dependent features |
+| `min_cell_voltage` | O | Cell delta and balance monitor | Do not expose delta/balance |
+| `internal_temperature` | O | Thermal derating | Do not enable temperature limiting |
+| `inverter_state` | O | Extra standby/BMS-cut confirmation | Use measured power only; omit dependent detections |
+| `ac_offgrid_power` | O | Backup-load exclusion from PD | Disable automatic backup exclusion |
+| Backup mode/control | O | Observe/control backup behaviour | Omit entity and specific logic |
+| MPPT/PV power | O | DC production and plane efficiency | `has_mppt_pv=False` |
+| Alarm/fault state | O | System alarm notifications | Omit dependent sensor/notifier |
+| Battery voltage | O | Diagnostics | Omit entity |
+| Identity, firmware, RSSI | O | Diagnostics/support | Omit entities; prefer stable serial when available |
+| Hardware SOC cutoff | O | Autonomous persistent SOC limits | Software enforcement |
+| Writable power cap | O | Persistent device configuration | Software cap without a fake hardware entity |
+| External-control gate | Conditional | Enables/restores external control | Required only when setpoints depend on it |
+
+## 5. Reference behaviour: Marstek Venus E v3
+
+The v3 is a behavioural reference, not a required protocol shape:
+
+| Semantics | v3 reference implementation |
+|---|---|
+| SOC | `battery_soc`, register `37005`, `uint16`, `%` |
+| Measured power | `battery_power`, register `30001`, `int16`; positive charge, negative discharge |
+| Charge | Discharge setpoint 0, charge setpoint W, force mode charge |
+| Discharge | Discharge setpoint W, charge setpoint 0, force mode discharge |
+| Idle | Both setpoints 0 and force mode stop |
+| Power envelope | Setpoints 0–2500 W, documented 50 W step; installation caps are separate |
+| Declared minimum | 800 W in v3 power-limit definitions |
+| External control | RS485 control gate with device-specific commands |
+| SOC cutoff | No v3 cutoff registers; Omnibattery enforces min/max SOC in software |
+| Confirmation | Mode, setpoint and measured-power readback with ramp tolerance |
+| Transport | Polled Modbus with a single TCP slot and model-specific pacing |
+
+`force_mode` is therefore not mandatory. A signed limit, two directional limits
+or different vendor enum may implement the same contract.
+
+## 6. Accepted substitutions: the Zendure pattern
+
+| Vendor difference | Valid driver adaptation |
+|---|---|
+| No direct `battery_power` | Derive `outputPackPower - packInputPower` after validating sign and simultaneity |
+| No kWh counters | Integrate `battery_power` and persist synthetic totals |
+| No nominal capacity | Let the user configure `battery_total_energy` |
+| No Marstek force mode | Map net power to `acMode` plus input/output limits |
+| Read-only charge cap | Combine the device cap with a user software ceiling |
+| Cells reported per pack | Derive global extremes and optionally expose per-pack keys |
+| Multi-second readback lag | Set unreliable confirmation and conservative actuator latency capabilities |
+| Frequent writes may touch flash | Use volatile setpoints and explicit persistent configuration writes |
+
+Accept a substitute only when its sign, timing, range and persistence have been
+tested. Configured values must be labelled as configuration, not device
+telemetry. Do not fabricate SOC, alarms, temperature, cell voltages or delivered
+power without a reliable physical source; a command cache records intent only.
+
+## 7. Feature degradation matrix
+
+| Feature | Minimum dependencies | Alternative | Model status |
+|---|---|---|---|
+| PD charge/discharge | SOC, measured power, ±W/0 control, limits | None for full support | `...` |
+| Multi-battery | Core per unit; capacity improves energy allocation | C capacity | `...` |
+| Min/max SOC | SOC + idle command | Hardware or software | `...` |
+| Predictive/pricing charge | SOC + kWh capacity + charge control | C capacity | `...` |
+| Energy/cycles/efficiency | Counters or timestamped power | D integration | `...` |
+| 100% taper/protection | Max cell voltage, SOC and power | No equivalent | `...` |
+| Balance monitoring | Max + min cell voltage | D extremes from cells/packs | `...` |
+| Weekly full charge | SOC, power and control; cutoff if available | Software cutoff | `...` |
+| Thermal limit | Internal temperature | None | `...` |
+| Backup exclusion | Off-grid power and backup state/mode | None reliable | `...` |
+| MPPT/DC production | Per-channel or total DC power | D sum | `...` |
+| Alarms | Official fault bits/codes | None | `...` |
+| Synthetic-energy identity | Power + stable device ID | Less-stable device key | `...` |
+
+Unsupported features must be gated by capabilities, entity definitions or
+configuration. They must not receive fabricated zero values.
+
+## 8. Telemetry mapping worksheet
+
+| Omnibattery key | B/R/O | Vendor field/register/topic | R/W | Type/endian | Scale/final unit | Range/sentinels | Cadence/TTL | N/D/C/X | Evidence | Tested |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `battery_soc` | B | `...` | R | `...` | `... → %` | `...` | `...` | `...` | `...` | [ ] |
+| `battery_power` | B | `...` | R | `...` | `... → W; +charge/-discharge` | `...` | `...` | `...` | `...` | [ ] |
+| Setpoint state/echo | R | `...` | R | `...` | `...` | `...` | `...` | `...` | `...` | [ ] |
+| `battery_total_energy` | R | `...` | R/C | `...` | `... → kWh` | `...` | `...` | `...` | `...` | [ ] |
+| Charge/discharge totals | O | `...` | R | `...` | `... → kWh` | `...` | `...` | `...` | `...` | [ ] |
+| Max/min cell voltage | O | `...` | R | `...` | `... → V` | `...` | `...` | `...` | `...` | [ ] |
+| `internal_temperature` | O | `...` | R | `...` | `... → °C` | `...` | `...` | `...` | `...` | [ ] |
+| `inverter_state` | O | `...` | R | enum | `map: ...` | `...` | `...` | `...` | `...` | [ ] |
+| `ac_offgrid_power` | O | `...` | R | `...` | `... → W` | `...` | `...` | `...` | `...` | [ ] |
+| Alarms/faults | O | `...` | R | bitmap/enum | `map: ...` | `...` | `...` | `...` | `...` | [ ] |
+| MPPT/PV | O | `...` | R | `...` | `... → W` | `...` | `...` | `...` | `...` | [ ] |
+| Identity/firmware | O | `...` | R | string | `...` | `...` | `...` | `...` | `...` | [ ] |
+
+## 9. Control mapping worksheet
+
+| Semantic operation | B/R/O | Vendor fields/commands | Sequence | Range/step | Volatile/persistent | ACK/readback | Timeout/latency | Safe failure state | Evidence | Tested |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Connect/authenticate | B | `...` | `...` | — | — | `...` | `...` | no control | `...` | [ ] |
+| Charge at W | B | `...` | `...` | `...` | `...` | `...` | `...` | `...` | `...` | [ ] |
+| Discharge at W | B | `...` | `...` | `...` | `...` | `...` | `...` | `...` | `...` | [ ] |
+| Idle at 0 W | B | `...` | `...` | `...` | `...` | `...` | `...` | `...` | `...` | [ ] |
+| Max charge/discharge | R | `...` | `...` | `...` | `...` | `...` | `...` | C limit | `...` | [ ] |
+| Max/min SOC cutoff | O | `...` | `...` | `...` | `...` | `...` | `...` | software | `...` | [ ] |
+| Enable external control | Cond. | `...` | `...` | `...` | `...` | `...` | `...` | restore control | `...` | [ ] |
+| Restore vendor control | Cond. | `...` | `...` | — | `...` | `...` | `...` | `...` | `...` | [ ] |
+| Other UI controls | O | `...` | `...` | `...` | `...` | `...` | `...` | omit entity | `...` | [ ] |
+
+## 10. Minimum acceptance tests
+
+Transport and data:
+
+- [ ] Connect, read identity/SOC and close without leaking resources.
+- [ ] Reconnect after timeout, device restart and temporary network loss.
+- [ ] Reject partial replies, sentinels and out-of-range values.
+- [ ] Expire push caches or last-known data when updates stop.
+- [ ] Preserve units and sign in charge, discharge and idle.
+- [ ] Respect mutual exclusion when the device allows one connection only.
+
+Control:
+
+- [ ] Positive, negative and zero setpoints work and clamp safely.
+- [ ] Charge↔discharge and movement→idle transitions work.
+- [ ] Repeated commands are idempotent and do not wear flash.
+- [ ] A partially failed multi-write command converges to idle or another defined
+  safe state, and required write ordering has been verified.
+- [ ] Readback distinguishes accepted intent from delivered power.
+- [ ] Normal and worst-case latency are measured; the conservative value is declared.
+- [ ] Failed writes return a reason and do not update cache as confirmed.
+- [ ] Max/min SOC cases remain safe.
+- [ ] Shutdown calls `standby()` and restores vendor control when applicable.
+
+Substitution and degradation:
+
+- [ ] Every D formula has boundary and sign unit tests.
+- [ ] Synthetic energy survives restart and skips telemetry gaps.
+- [ ] C capacity is range-validated and labelled as configured.
+- [ ] X features create no entities or decisions with fake values.
+- [ ] The driver works in a mixed-brand battery pool.
+
+Expected code coverage includes lifecycle, read groups, scaling, missing keys,
+all setpoint paths, clamping, failures, delayed/no readback,
+`net_power_from_data`, dependency keys, configuration, standby, model detection,
+and the supported firmware matrix.
+
+## 11. Copyable decision report
+
+```text
+Manufacturer/model:
+Firmware tested:
+Official documentation (revision/date/link):
+
+Verdict: SUITABLE / SUITABLE WITH LIMITATIONS / NOT SUITABLE
+
+Blocking items:
+- Real SOC: N/D/C/X — evidence:
+- Real power: N/D/C/X — evidence/formula:
+- Adjustable charge: yes/no — range/step:
+- Adjustable discharge: yes/no — range/step:
+- Safe idle: yes/no — sequence:
+- Safe limits: source/values:
+- Freshness and connection loss: mechanism:
+
+Omnibattery adaptations:
+- Derived data:
+- User-configured data:
+- Software-enforced limits:
+
+Disabled features:
+-
+
+Open risks:
+-
+
+Pending hardware tests:
+-
+
+Approval owner and date:
+```
+
+## 12. Post-approval implementation checklist
+
+- [ ] Create the driver without leaking vendor details outside `drivers/`.
+- [ ] Add brand/model selection and detection to the config flow.
+- [ ] Instantiate the driver in the coordinator and declare capabilities.
+- [ ] Define only supported entities and translations.
+- [ ] Add configuration fields for C values such as nominal capacity.
+- [ ] Capability-gate every feature that depends on an X key.
+- [ ] Add driver unit tests and mixed-brand integration tests.
+- [ ] Document device prerequisites, firmware and limitations.
+- [ ] Redact credentials, tokens and sensitive serials from diagnostics.
+
+Document approval allows implementation to start; it does not replace hardware
+validation. Sign, scale, latency, internal clamps and firmware-specific behaviour
+must all be verified before declaring stable support.

--- a/tests/test_charge_delay.py
+++ b/tests/test_charge_delay.py
@@ -644,3 +644,106 @@ def test_window_release_now_when_current_window_cheapest():
     slots = [_slot(11, 0.10), _slot(12, 0.10), _slot(13, 0.30), _slot(14, 0.30)]
     mgr = _make_mgr(_price_ctrl(slots))
     assert mgr._price_optimal_release_h(11.0, 16.0, 2.0) == 11.0
+
+
+# ----------------------------------------------------------------------
+# energy_balance cushion: price-aware hold instead of an instant unlock
+# ----------------------------------------------------------------------
+
+def _at_hour(monkeypatch, hour):
+    """Freeze charge_delay's wall clock at ``hour`` (whole hours only)."""
+    import custom_components.omnibattery.control.charge_delay as cd
+
+    monkeypatch.setattr(
+        cd, "datetime", SimpleNamespace(now=lambda: SimpleNamespace(hour=hour, minute=0))
+    )
+
+
+def _cushion_mgr(forecast):
+    """Gate sitting in the cushion band at 09:00.
+
+    needed = (80-50)% x 10 kWh = 3.0 kWh, factored (x1.3) = 3.9 kWh.
+    remaining_consumption = 5.0 x 7/24 = 1.46 kWh.
+    """
+    ctrl = _controller(
+        coordinators=[_coord(soc=50, total_energy=10.0, min_soc=20)],
+        _consumption_tracker=_tracker(get_avg_daily_consumption=lambda: 5.0),
+        _solar_t_start=8.0,
+    )
+    return _make_mgr(ctrl, states={"sensor.forecast": _state(forecast)})
+
+
+def test_cushion_shortfall_holds_for_cheaper_hour(monkeypatch):
+    # net = 3.39: below the factored 3.9 edge but still above the bare 3.0 need
+    # -> hold for the cheaper hour instead of unlocking into the morning peak.
+    _at_hour(monkeypatch, 9)
+    mgr = _cushion_mgr(5.7)
+    mgr._price_optimal_release_h = lambda now_h, edge_h, charge_h=None: 12.0
+    assert mgr._should_delay_charge(80) is True
+    assert mgr._controller._charge_delay_status["estimated_unlock_time"] == "12:00"
+    assert "price" in mgr._controller._charge_delay_status["state"]
+
+
+def test_cushion_shortfall_unlocks_when_now_is_cheapest(monkeypatch):
+    _at_hour(monkeypatch, 9)
+    mgr = _cushion_mgr(5.7)
+    mgr._price_optimal_release_h = lambda now_h, edge_h, charge_h=None: now_h
+    assert mgr._should_delay_charge(80) is False
+    assert mgr._controller._charge_delay_status["unlock_reason"] == "energy_balance"
+
+
+def test_cushion_shortfall_unlocks_without_price_data(monkeypatch):
+    # No price data -> legacy instant unlock preserved.
+    _at_hour(monkeypatch, 9)
+    mgr = _cushion_mgr(5.7)
+    mgr._price_optimal_release_h = lambda now_h, edge_h, charge_h=None: None
+    assert mgr._should_delay_charge(80) is False
+    assert mgr._controller._charge_delay_status["unlock_reason"] == "energy_balance"
+
+
+def test_genuine_deficit_unlocks_without_consulting_prices(monkeypatch):
+    # net = 1.09 < needed 3.0: a real deficit, grid charging may be
+    # required -> unlock immediately, prices must not be able to hold it.
+    _at_hour(monkeypatch, 9)
+    mgr = _cushion_mgr(3.0)
+    called = []
+    mgr._price_optimal_release_h = lambda *a, **kw: called.append(1) or 12.0
+    assert mgr._should_delay_charge(80) is False
+    assert mgr._controller._charge_delay_status["unlock_reason"] == "energy_balance"
+    assert called == []
+
+
+def test_cushion_hold_window_never_passes_bare_balance_edge(monkeypatch):
+    # The edge handed to the price scorer is the BARE (x1.0) balance crossing,
+    # never the factored one, so the hold cannot eat into the target itself.
+    _at_hour(monkeypatch, 9)
+    mgr = _cushion_mgr(5.7)
+    edges = []
+    mgr._price_optimal_release_h = lambda now_h, edge_h, charge_h=None: edges.append(edge_h) or now_h
+    # Record what the gate actually asked the projection for, so the expected edge
+    # is built from the same inputs the code used (not a re-derived guess).
+    projections = []
+    real_estimate = mgr._estimate_energy_balance_unlock_h
+    def _spy(*args, **kwargs):
+        result = real_estimate(*args, **kwargs)
+        projections.append((args, kwargs, result))
+        return result
+    mgr._estimate_energy_balance_unlock_h = _spy
+    mgr._should_delay_charge(80)
+
+    bare = [p for p in projections if p[1].get("safety_factor") == 1.0]
+    assert len(bare) == 1, "the bare-balance projection must be requested exactly once"
+    bare_edge = bare[0][2]
+    time_backup_h = 16.0 - mgr._controller._charge_delay_status["charge_time_h"] - 0.5
+    assert edges == [pytest.approx(min(bare_edge, time_backup_h))]
+    assert edges[0] > 9.0  # there was room to wait at all
+
+
+def test_estimate_bare_edge_is_later_than_factored_edge():
+    ctrl = _controller(
+        _consumption_tracker=_tracker(consumption_window_hours_in_range=lambda a, b: 0.0),
+    )
+    mgr = _make_mgr(ctrl)
+    factored = mgr._estimate_energy_balance_unlock_h(10.0, 1.0, 8.0, 16.0, 8.0)
+    bare = mgr._estimate_energy_balance_unlock_h(10.0, 1.0, 8.0, 16.0, 8.0, safety_factor=1.0)
+    assert bare > factored


### PR DESCRIPTION
The energy-balance unlock fires at `net_solar < energy_needed × 1.3`. That 30% is a cushion, not the target, but the branch unlocks on the spot and never looks at prices, unlike the feasible-window path right below it. On a marginal-looking summer morning the whole PV self-charge then lands in the export peak while the midday trough is still ahead.

2026-07-22 here, 10 kWh forecast, released 07:00 with `unlock_reason: energy_balance`: needed 3.12 kWh, net_solar 3.42, factored edge 4.06. The forecast covered the target on its own, only the cushion was short. Battery filled 34% to 95% between 07:06 and 11:58 while export was worth €0.20/kWh; the 12:00-14:00 slots sat at €0.025-0.04. After 12:00 it was full, so the rest of the day exported at the bottom. About €0.35, no grid import involved (0.07 kWh all day).

**Change:** when `net_solar` is still at or above the bare `energy_needed`, hold for the cheapest feasible hour instead of unlocking. The window ends at the projected bare-balance crossing (new `safety_factor` arg on `_estimate_energy_balance_unlock_h`, default unchanged), capped by the time-backup edge, so the SOC target stays reachable. Both hold sites now write their status through one `_price_hold_release_h` helper. Real deficits (`net_solar < energy_needed`), days without usable price data, and non-price-driven predictive modes unlock immediately as before.

The projection is the cosine model, so it can disagree with measured production. Each cycle re-checks the measured net, so a bad projection unlocks itself.

6 cases added in `tests/test_charge_delay.py`; suite 711 passed, 10 skipped.
