### PR TITLE
fix-issue-26-non-responsive

### DIFF
--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform, CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.event import async_track_time_interval, async_track_time_change, async_track_state_change_event, async_call_later
 from homeassistant.util import dt as dt_util
@@ -105,6 +106,9 @@ from .const import (
     CONF_PRICE_INTEGRATION_TYPE,
     CONF_MAX_PRICE_THRESHOLD,
     CONF_DISCHARGE_PRICE_THRESHOLD,
+    CONF_MIN_ARBITRAGE_MARGIN,
+    CONF_ROUND_TRIP_EFFICIENCY,
+    DEFAULT_ROUND_TRIP_EFFICIENCY,
     CONF_AVERAGE_PRICE_SENSOR,
     CONF_DP_PRICE_DISCHARGE_CONTROL,
     CONF_RT_PRICE_DISCHARGE_CONTROL,
@@ -140,6 +144,8 @@ from .const import (
     FEEDFORWARD_COOLDOWN_S,
     FEEDFORWARD_PULSE_GUARD_S,
     PD_ZERO_CROSS_MIN_HOLD_S,
+    MAX_SUPPORTED_SENSOR_INTERVAL_S,
+    SLOW_SENSOR_WARN_INTERVALS,
     FAST_ACTUATOR_MAX_LATENCY_S,
     DISCHARGE_ENGAGE_GRACE_S,
     IDLE_RUNAWAY_POWER_W,
@@ -456,6 +462,9 @@ class ChargeDischargeController:
         self._max_stale_cycles = 15             # safety valve: ~30s before forcing recalculation
         self._control_lock = asyncio.Lock()     # serialize control cycle across timer + sensor-event triggers
         self._grid_at_min_soc_last_ts = None     # last accumulation timestamp for grid-at-min-soc kWh integration
+        self._slow_sensor_warned = False        # one-shot warning/repair for unsupported sensor cadence
+        self._slow_sensor_intervals = 0         # consecutive unsupported sensor intervals
+        self._fast_sensor_intervals = 0         # consecutive supported intervals used to clear the repair
 
         # Normal high-SOC charge protection. These must exist before the first
         # capacity calculation because _battery_power_limit() reads them.
@@ -589,8 +598,13 @@ class ChargeDischargeController:
         self.price_integration_type = config_entry.data.get(CONF_PRICE_INTEGRATION_TYPE, PRICE_INTEGRATION_NORDPOOL)
         self.max_price_threshold = config_entry.data.get(CONF_MAX_PRICE_THRESHOLD, None)
         self.discharge_price_threshold = config_entry.data.get(CONF_DISCHARGE_PRICE_THRESHOLD, None)
+        self.min_arbitrage_margin = config_entry.data.get(CONF_MIN_ARBITRAGE_MARGIN, None)
+        self.round_trip_efficiency = config_entry.data.get(
+            CONF_ROUND_TRIP_EFFICIENCY, DEFAULT_ROUND_TRIP_EFFICIENCY
+        )
         self.dp_price_discharge_control: bool = config_entry.data.get(CONF_DP_PRICE_DISCHARGE_CONTROL, False)
         self._dp_daily_avg_price: Optional[float] = None  # Computed from price slots in _evaluate_dynamic_pricing
+        self._dp_arbitrage_ceiling: Optional[float] = None  # Set per evaluation when the margin gate is on
         # Tibber is service-based (no price sensor): the engine polls tibber.get_prices
         # and caches the parsed slots here.
         self._tibber_price_slots: list = []
@@ -1138,6 +1152,10 @@ class ChargeDischargeController:
         self.price_integration_type = self.config_entry.data.get(CONF_PRICE_INTEGRATION_TYPE, PRICE_INTEGRATION_NORDPOOL)
         self.max_price_threshold = self.config_entry.data.get(CONF_MAX_PRICE_THRESHOLD, None)
         self.discharge_price_threshold = self.config_entry.data.get(CONF_DISCHARGE_PRICE_THRESHOLD, None)
+        self.min_arbitrage_margin = self.config_entry.data.get(CONF_MIN_ARBITRAGE_MARGIN, None)
+        self.round_trip_efficiency = self.config_entry.data.get(
+            CONF_ROUND_TRIP_EFFICIENCY, DEFAULT_ROUND_TRIP_EFFICIENCY
+        )
         self.capacity_protection_enabled = self.config_entry.data.get(CONF_CAPACITY_PROTECTION_ENABLED, False)
         self.capacity_protection_soc_threshold = self.config_entry.data.get(CONF_CAPACITY_PROTECTION_SOC_THRESHOLD, DEFAULT_CAPACITY_PROTECTION_SOC)
         self.capacity_protection_limit = self.config_entry.data.get(CONF_CAPACITY_PROTECTION_LIMIT, DEFAULT_CAPACITY_PROTECTION_LIMIT)
@@ -3110,12 +3128,18 @@ class ChargeDischargeController:
         ignore_discharge_blockers: set[str] | None = None,
         bypass_blockers: bool = False,
         force_write: bool = False,
+        preserve_non_responsive_episode: bool = False,
     ) -> bool:
         """Set charge/discharge power for a single battery with ACK verification.
 
         ``force_write`` bypasses the bus-load skip-write so the command is always
         written, even when the battery's set-points already match — used by the
         non-responsive recovery to re-pin a battery that has slipped its control.
+
+        ``preserve_non_responsive_episode`` is used only for the recovery path's
+        internal standby write. That write is not a real direction decision and
+        must not make the following discharge command clear the active failure
+        episode and its already-consumed wake attempt.
 
         Returns True if command was acknowledged, False otherwise.
         """
@@ -3224,7 +3248,11 @@ class ChargeDischargeController:
         # so the flip is seen even on a cycle that skips the write, and the tracker
         # is reset on the flip so a stale count from a prior session can't carry over.
         net_sign = 1 if net_power > 0 else -1 if net_power < 0 else 0
-        if net_sign == -1 and self._last_commanded_net_sign.get(coordinator) != -1:
+        if (
+            not preserve_non_responsive_episode
+            and net_sign == -1
+            and self._last_commanded_net_sign.get(coordinator) != -1
+        ):
             self._discharge_engage_started[coordinator] = dt_util.utcnow()
             self._non_responsive.clear(coordinator)
         # Mirror stamp for the opposite transition: a flip from a move into idle
@@ -3232,9 +3260,14 @@ class ChargeDischargeController:
         # battery idle from the start (no prior commanded move) gets no grace —
         # there is no ramp-down to wait out, and a genuine runaway found at
         # startup (the original #434 case) should trip immediately.
-        if net_sign == 0 and self._last_commanded_net_sign.get(coordinator, 0) != 0:
+        if (
+            not preserve_non_responsive_episode
+            and net_sign == 0
+            and self._last_commanded_net_sign.get(coordinator, 0) != 0
+        ):
             self._idle_commanded_started[coordinator] = dt_util.utcnow()
-        self._last_commanded_net_sign[coordinator] = net_sign
+        if not preserve_non_responsive_episode:
+            self._last_commanded_net_sign[coordinator] = net_sign
         if net_sign != 0:
             # Commanding a move ends any idle-runaway episode.
             self._idle_runaway_handled.pop(coordinator, None)
@@ -3261,15 +3294,7 @@ class ChargeDischargeController:
         # drops and we fall through to a real write so the tracker keeps seeing it.
         data = coordinator.data or {}
         current_net = coordinator.driver.net_power_from_data(data)
-        # Queued-gateway mode re-asserts the setpoint every cycle (skip disabled)
-        # so a dropped write on a lossy queueing gateway self-heals next cycle the
-        # way the legacy MVEM path did; skip-if-unchanged would starve it (#77).
-        if (
-            not force_write
-            and not coordinator.queued_gateway_compatibility
-            and current_net is not None
-            and current_net == net_power
-        ):
+        if not force_write and current_net is not None and current_net == net_power:
             skip_write = True
             if net_power == 0:
                 # Commanded idle but the battery is actually discharging means it
@@ -3331,7 +3356,7 @@ class ChargeDischargeController:
                 batt_power = data.get("battery_power")
                 skip_write = (
                     batt_power is not None
-                    and abs(float(batt_power)) >= 0.10 * abs(net_power)
+                    and float(batt_power) <= -0.10 * abs(net_power)
                 )
                 # Slow actuators (Zendure HTTP) never read back per-write, so the
                 # ACK-path non-delivery detection further down never runs for them.
@@ -3387,21 +3412,16 @@ class ChargeDischargeController:
         # Attempt the setpoint + verify, with one retry on failure.
         # last_fail_reason carries the most specific failure category seen across
         # both attempts so the non-responsive tracker can surface *why*.
-        # Queued-gateway mode uses a single attempt: an immediate resend re-issues
-        # the write under fresh transaction IDs and re-creates the orphan late-reply
-        # mismatch the transport layer avoids (#77). Recovery is left to the next
-        # control cycle, which re-asserts because skip-if-unchanged is disabled here.
         last_fail_reason: str | None = None
-        max_attempts = 1 if coordinator.queued_gateway_compatibility else 2
-        for attempt in range(max_attempts):
+        for attempt in range(2):
             result = await coordinator.apply_power(net_power, read_back=read_back)
 
             if not result.ok:
                 last_fail_reason = result.failure_reason or "comm_failure"
                 if not coordinator._is_shutting_down:
                     _LOGGER.warning(
-                        "[%s] Power write/feedback failed (attempt %d/%d, reason=%s)",
-                        coordinator.name, attempt + 1, max_attempts, last_fail_reason
+                        "[%s] Power write/feedback failed (attempt %d/2, reason=%s)",
+                        coordinator.name, attempt + 1, last_fail_reason
                     )
                 continue
 
@@ -3438,21 +3458,21 @@ class ChargeDischargeController:
                         )
                 actual_power = result.battery_power_w
                 _LOGGER.debug(
-                    "[%s] Power ACK: force=%d charge=%dW discharge=%dW battery=%dW",
+                    "[%s] Power ACK: force=%d charge=%dW discharge=%dW battery=%sW",
                     coordinator.name,
                     expected_force_mode,
                     int(charge_power),
                     int(discharge_power),
                     actual_power,
                 )
-                if charge_power > 0:
+                if charge_power > 0 and actual_power is not None:
                     self._log_low_power_delivery(
                         coordinator,
                         command="charge",
                         commanded_power=charge_power,
                         actual_power=actual_power,
                     )
-                elif discharge_power > 0:
+                elif discharge_power > 0 and actual_power is not None:
                     self._log_low_power_delivery(
                         coordinator,
                         command="discharge",
@@ -3462,7 +3482,13 @@ class ChargeDischargeController:
                 # Detect non-responsive battery: ACK ok but not delivering discharge
                 # power. Register drivers reach this only on a readback cycle; slow
                 # actuators run the same judgment at poll time (see skip-write block).
-                if discharge_power >= 100 and charge_power == 0:
+                # Skip when delivered power is unknown (e.g. Anker write ACK without
+                # a successful battery_power sample).
+                if (
+                    discharge_power >= 100
+                    and charge_power == 0
+                    and actual_power is not None
+                ):
                     await self._check_non_delivery(
                         coordinator, discharge_power, actual_power, attempt=attempt,
                     )
@@ -3471,7 +3497,7 @@ class ChargeDischargeController:
             # Readback happened but the set-points did not match (mismatch), or the
             # confirmation read never followed (feedback_timeout). Both retryable.
             last_fail_reason = result.failure_reason or "ack_mismatch"
-            if attempt + 1 < max_attempts:
+            if attempt == 0:
                 # On a driver whose readback lags the write (Zendure HTTP echoes the
                 # previous limit for ~2 s), a first-attempt mismatch is expected
                 # echo/engage latency that the retry resolves — log it at debug, not
@@ -3511,9 +3537,9 @@ class ChargeDischargeController:
                 coordinator, last_fail_reason or "comm_failure"
             )
             _LOGGER.error(
-                "[%s] Power command failed after %d attempt(s) (reason=%s). "
+                "[%s] Power command failed after 2 attempts (reason=%s). "
                 "Battery may not have received command.",
-                coordinator.name, max_attempts, last_fail_reason or "comm_failure"
+                coordinator.name, last_fail_reason or "comm_failure"
             )
         return False
 
@@ -3532,8 +3558,8 @@ class ChargeDischargeController:
         silently stalled registerless battery in a pool is excluded, not
         re-commanded forever.
         """
-        actual_abs = abs(actual_power)
-        if actual_abs >= 0.10 * discharge_power:
+        delivered_discharge = max(0.0, -float(actual_power))
+        if delivered_discharge >= 0.10 * discharge_power:
             self._non_responsive.clear(coordinator)
             return
         engage_started = self._discharge_engage_started.get(coordinator)
@@ -3590,7 +3616,7 @@ class ChargeDischargeController:
         # and must reach the wake/reconnect recovery path (issue #26).
         reason = "standby_no_delivery" if is_standby else "non_delivery"
         outcome = self._non_responsive.record_non_delivery(
-            coordinator, discharge_power, actual_abs,
+            coordinator, discharge_power, delivered_discharge,
             reason=reason, retry_attempted=attempt > 0,
         )
         # First threshold-cross: a one-shot wake nudge (reconnect/re-assert), but
@@ -3637,8 +3663,11 @@ class ChargeDischargeController:
             ok = await coordinator.async_reconnect_fresh()
             await self._set_battery_power(
                 coordinator, 0, 0, bypass_blockers=True, force_write=True,
+                preserve_non_responsive_episode=True,
             )
-            return ok
+            return ok and getattr(
+                coordinator, "_last_rs485_reenable_success", True
+            ) is not False
         _LOGGER.info(
             "[%s] Non-delivery — re-asserting RS485 control + forcing standby",
             coordinator.name,
@@ -3658,8 +3687,11 @@ class ChargeDischargeController:
             ok = await coordinator.async_reconnect_fresh()
         await self._set_battery_power(
             coordinator, 0, 0, bypass_blockers=True, force_write=True,
+            preserve_non_responsive_episode=True,
         )
-        return ok
+        return ok and getattr(
+            coordinator, "_last_rs485_reenable_success", True
+        ) is not False
 
     # =========================================================================
     # DYNAMIC PRICING / REAL-TIME PRICE: delegators to PricingManager
@@ -4349,7 +4381,7 @@ class ChargeDischargeController:
         )
         return held_power
 
-    def _apply_zero_cross_hold(self, new_power, error):
+    def _apply_zero_cross_hold(self, new_power, error, stale_recalc=False):
         """ZERO-CROSS HOLD (direction-flip dwell).
 
         On a downward load step the discharging battery keeps delivering its old
@@ -4374,8 +4406,17 @@ class ChargeDischargeController:
         min-power floor, so a suppressed flip can never be bootstrapped up to
         pd_min_charge_power; the relay dwell downstream then decides whether the
         previous battery holds at minimum power or drops to 0.
+
+        ``stale_recalc`` marks the safety recalculation that runs on a silent
+        sensor: its 0 W command is the frozen previous command, not a fresh idle
+        decision, so the armed timer must survive it.
         """
         requested_sign = 1 if new_power > 0 else (-1 if new_power < 0 else 0)
+        if stale_recalc and requested_sign == 0 and self._zero_cross_since is not None:
+            # Issue #117: on a sensor slower than the stale window (~30s), every
+            # stale recalc in between cleared the timer, so the flip re-armed at
+            # 0.0s on each fresh sample and could never accumulate the window.
+            return new_power
         if (
             self.last_output_sign == 0
             or requested_sign == 0
@@ -4411,6 +4452,59 @@ class ChargeDischargeController:
             new_power, error, held_s, window_s,
         )
         return 0
+
+    def _check_sensor_cadence(self, sensor_elapsed_s):
+        """Raise a repair when the main sensor cadence is unsupported.
+
+        Sensor compatibility is deliberately independent from the stale watchdog:
+        the former is a control-quality contract, while the latter rechecks structural
+        state after an unexpected telemetry outage. Only positive, real update intervals
+        reach the debounce; watchdog ticks report 0 and must not reset its streak.
+
+        Debounced over consecutive intervals: a single long gap is far more likely to be
+        an outage or a restart than the configured cadence, because the stored sensor
+        timestamp is not advanced while the sensor reads unavailable, so the first sample
+        after any downtime measures the whole gap.
+        """
+        if sensor_elapsed_s is None or sensor_elapsed_s <= 0:
+            return
+
+        issue_id = f"slow_main_sensor_{self.config_entry.entry_id}"
+        if sensor_elapsed_s < MAX_SUPPORTED_SENSOR_INTERVAL_S:
+            self._slow_sensor_intervals = 0
+            self._fast_sensor_intervals += 1
+            if self._fast_sensor_intervals == SLOW_SENSOR_WARN_INTERVALS:
+                ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+                self._slow_sensor_warned = False
+            return
+
+        self._fast_sensor_intervals = 0
+        self._slow_sensor_intervals += 1
+        if self._slow_sensor_intervals < SLOW_SENSOR_WARN_INTERVALS or self._slow_sensor_warned:
+            return
+        self._slow_sensor_warned = True
+        _LOGGER.warning(
+            "Main sensor %s updates every ~%.0fs; intervals of %.0fs or more are "
+            "unsupported. Configure a faster grid power sensor (~1-2s recommended).",
+            self.consumption_sensor,
+            sensor_elapsed_s,
+            MAX_SUPPORTED_SENSOR_INTERVAL_S,
+        )
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            is_persistent=True,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="slow_main_sensor",
+            translation_placeholders={
+                "sensor": self.consumption_sensor,
+                "observed_interval": f"{sensor_elapsed_s:.0f}",
+                "max_interval": f"{MAX_SUPPORTED_SENSOR_INTERVAL_S:.0f}",
+            },
+        )
 
     async def _run_control_cycle(self, now=None):
         """Update the charge/discharge power of the batteries."""
@@ -4550,6 +4644,12 @@ class ChargeDischargeController:
             (sensor_update_time - previous_update_time).total_seconds()
             if previous_update_time is not None else None
         )
+
+        # Watchdog ticks have elapsed=0 and are not cadence observations. Feeding
+        # them into the debounce reset the slow streak between every pair of real
+        # samples, so a 60 s sensor could never reach the warning threshold.
+        if not is_stale:
+            self._check_sensor_cadence(sensor_elapsed_s)
 
         # Generic safety recalc on a silent sensor must re-evaluate structural state
         # (SOC/limits/blockers) but must NOT integrate the P term: the grid error is
@@ -4860,7 +4960,9 @@ class ChargeDischargeController:
         # settle window before it becomes a real opposite-direction command (see
         # _apply_zero_cross_hold). Must run before _apply_min_power so a clamped
         # flip cannot be raised to the minimum charge power.
-        new_power = self._apply_zero_cross_hold(new_power, error)
+        new_power = self._apply_zero_cross_hold(
+            new_power, error, stale_recalc=stale_safety_recalc
+        )
 
         # Final commanded direction (feeds last_output_sign at end of cycle). In the
         # PD path the hysteresis inside _compute_pd_new_power already zeroed new_power
@@ -5023,6 +5125,12 @@ class ChargeDischargeController:
                         await self._consumption_tracker.maybe_save_grid_at_min_soc_history()
 
         if not available_batteries:
+            # NOTE: this path ends the cycle before the end-of-cycle PD state update,
+            # so last_output_sign stays latched at the last real flow direction. That
+            # is deliberate: the battery may still be ramping down (or the 0W write may
+            # not have landed on an unreachable battery), so the next flip must still
+            # prove itself against the zero-cross settle window. Issue #117 was the
+            # settle timer being cleared underneath that latch, not the latch itself.
             _LOGGER.debug("ChargeDischargeController: No available batteries, setting all to 0.")
             for coordinator in self.coordinators:
                 if self._is_active_balance_mode_running(coordinator):
@@ -5484,6 +5592,11 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _device_owns_initial_config(brand: str) -> bool:
+    """Return whether setup must preserve configuration stored by the device."""
+    return brand == "zendure"
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Omnibattery from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -5492,7 +5605,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _async_register_frontend_panel(hass, entry)
 
     # Migration: Add default version for existing installations
-    from .const import CONF_BATTERY_VERSION, DEFAULT_VERSION, CONF_SLAVE_ID, DEFAULT_SLAVE_ID, CONF_SERIAL_PORT, CONF_QUEUED_GATEWAY_COMPATIBILITY
+    from .const import CONF_BATTERY_VERSION, DEFAULT_VERSION, CONF_SLAVE_ID, DEFAULT_SLAVE_ID, CONF_SERIAL_PORT
 
     for battery_config in entry.data["batteries"]:
         if CONF_BATTERY_VERSION not in battery_config:
@@ -5565,9 +5678,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             brand=battery_config.get("brand", "marstek"),
             zendure_model=battery_config.get("zendure_model", "2400ac_pro"),
             serial_port=battery_config.get(CONF_SERIAL_PORT) or None,
-            queued_gateway_compatibility=battery_config.get(
-                CONF_QUEUED_GATEWAY_COMPATIBILITY, False
-            ),
             esphome_device_id=battery_config.get("esphome_device_id"),
         )
 
@@ -5585,6 +5695,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator.commanded_discharge_power = coordinator.manual_set_discharge_power
         coordinator.user_max_charge_power = battery_config.get(
             "user_max_charge_power", coordinator.max_charge_power
+        )
+        coordinator.user_max_discharge_power = battery_config.get(
+            "user_max_discharge_power", coordinator.max_discharge_power
         )
         coordinator.active_balance_mode_started_ts = battery_config.get("active_balance_mode_started_ts")
         coordinator.active_balance_mode_run_date = battery_config.get("active_balance_mode_run_date")
@@ -5661,7 +5774,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 # device-set values on every restart and re-arm the full-charge
                 # taper/hysteresis machinery. The device is the source of truth and
                 # the coordinator syncs soc_set/min_soc back from the poll.
-                if coordinator.needs_software_manual_control:
+                if _device_owns_initial_config(coordinator.brand):
                     _LOGGER.info("Skipping initial SOC config write for %s (registerless driver; device flash holds the user values)",
                                battery_config[CONF_NAME])
                 else:

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -23,6 +23,7 @@ from ..const import (
 from ..drivers.esphome import EsphomeEntityDriver
 from ..drivers.marstek import MarstekModbusDriver
 from ..drivers.zendure import ZendureLocalDriver, ZENDURE_MODEL_2400AC_PRO
+from ..drivers.anker import AnkerModbusDriver
 from ..drivers.base import SetpointResult
 from .alarm_notifier import AlarmNotifier
 
@@ -33,6 +34,21 @@ _LOGGER = logging.getLogger(__name__)
 # group is boosted to the transient fast-poll cadence only if it contains one of
 # these — the burst poll must not accelerate unrelated registers.
 _DELIVERED_POWER_KEYS = frozenset({"ac_power", "battery_power"})
+
+# Register groups that directly govern control safety. A device can keep its BMS
+# registers alive while the inverter-facing groups are frozen; treating one BMS
+# success as proof that the whole connection is healthy leaves stale SOC/power and
+# set-point echoes in the control loop indefinitely (issue #26).
+_CRITICAL_CONTROL_KEYS = frozenset({
+    "ac_power",
+    "battery_power",
+    "battery_soc",
+    "force_mode",
+    "inverter_state",
+    "set_charge_power",
+    "set_discharge_power",
+})
+_CRITICAL_GROUP_FAILURES_BEFORE_RECONNECT = 3
 
 
 def group_scan_interval_s(
@@ -95,7 +111,6 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                  brand: str = "marstek",
                  zendure_model: str = ZENDURE_MODEL_2400AC_PRO,
                  serial_port: str | None = None,
-                 queued_gateway_compatibility: bool = False,
                  esphome_device_id: str | None = None) -> None:
         """Initialize the data update coordinator."""
         super().__init__(
@@ -114,7 +129,7 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         self.serial_port = serial_port
         self.consumption_sensor = consumption_sensor
         self.brand = brand
-        if self.brand == "zendure":
+        if self.brand in ("zendure", "anker"):
             full_charge_voltage_taper_enabled = False
             active_balance_mode_enabled = False
 
@@ -157,9 +172,11 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         self.commanded_charge_power = 0
         self.commanded_discharge_power = 0
         # Software charge-power ceiling for drivers whose reported max_charge_power
-        # is a read-only device cap (Zendure chargeMaxLimit). Caps PD allocation
-        # below the device limit; default = device max (no extra cap). Persisted.
+        # is a read-only device cap (Zendure chargeMaxLimit / Anker 10036). Caps PD
+        # allocation below the device limit; default = device max (no extra cap).
+        # Persisted. Same idea for discharge on Anker (10038).
         self.user_max_charge_power = max_charge_power
+        self.user_max_discharge_power = max_discharge_power
         self.allow_charge = allow_charge
         self.allow_discharge = allow_discharge
         self.active_balance_mode_enabled = active_balance_mode_enabled
@@ -207,9 +224,11 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         # path, surfaced by health_snapshot / diagnostics). Initialised here so a
         # read before the first write returns None rather than raising.
         self._last_write_failure_reason = None
+        self._last_rs485_reenable_success = None
 
         # Timestamp-based update tracking
         self._last_update_times = {}
+        self._critical_group_failures = {}
         # Last-written select values that override buggy register readbacks.
         # Repopulated from persisted battery_config after construction; initialised
         # here so get_shadow_select before that assignment returns None instead of
@@ -249,24 +268,21 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 max_charge_power_w=self.max_charge_power,
                 max_discharge_power_w=self.max_discharge_power,
             )
+        elif self.brand == "anker":
+            self.driver = AnkerModbusDriver(
+                self.host,
+                self.port,
+                self.slave_id,
+                max_charge_power_w=self.max_charge_power,
+                max_discharge_power_w=self.max_discharge_power,
+            )
         else:
             self.driver = MarstekModbusDriver(
                 self.host, self.port, self.battery_version, self.slave_id,
                 max_charge_power_w=self.max_charge_power,
                 max_discharge_power_w=self.max_discharge_power,
                 serial_port=self.serial_port,
-                queued_gateway_compatibility=queued_gateway_compatibility,
             )
-
-        # Effective queued-gateway mode (mirrors the transport client's own
-        # narrowing: Marstek Modbus TCP only — v3-family and serial are excluded;
-        # non-Marstek drivers expose no such flag). Drives the control loop's
-        # re-assert-every-cycle so a dropped write on a lossy queueing gateway
-        # self-heals like the legacy MVEM path instead of skip-if-unchanged
-        # starving it (issue #77).
-        self.queued_gateway_compatibility = bool(
-            getattr(self.driver, "queued_gateway_compatibility", False)
-        )
 
         # Fast key -> definition lookup so the poll loop can scale each raw value by
         # its definition's scale/precision/state_class. The driver returns raw
@@ -330,10 +346,31 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
 
     @property
     def needs_software_max_charge(self) -> bool:
-        """True when max_charge_power is a read-only device cap rather than a
-        writable register, so a software ceiling entity governs it (e.g. Zendure
-        chargeMaxLimit)."""
-        return not any(d["key"] == "max_charge_power" for d in self.number_definitions)
+        """True when max_charge_power has no writable register and no sensor.
+
+        Zendure exposes chargeMaxLimit only as telemetry, so a software ceiling
+        number entity governs it. Anker exposes 10036 as a read-only sensor —
+        PD follows the device value directly, with no soft-max entity.
+        """
+        if any(d["key"] == "max_charge_power" for d in self.number_definitions):
+            return False
+        if any(d["key"] == "max_charge_power" for d in self.sensor_definitions):
+            return False
+        return True
+
+    @property
+    def needs_software_max_discharge(self) -> bool:
+        """True when max_discharge_power has no writable register and no sensor.
+
+        Anker exposes 10038 as a read-only sensor (no soft-max entity). Zendure
+        exposes inverse_max_power as a writable number, so it reports False.
+        """
+        writable_keys = {d["key"] for d in self.number_definitions}
+        if {"max_discharge_power", "inverse_max_power"} & writable_keys:
+            return False
+        if any(d["key"] == "max_discharge_power" for d in self.sensor_definitions):
+            return False
+        return True
 
     @property
     def is_available(self) -> bool:
@@ -363,8 +400,16 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         return {
             "identifiers": {(DOMAIN, f"{self.device_key}")},
             "name": self.name,
-            "manufacturer": "Zendure" if self.brand == "zendure" else "Marstek",
-            "model": self.driver.model_label or ("Zendure" if self.brand == "zendure" else "Venus"),
+            "manufacturer": (
+                "Zendure" if self.brand == "zendure"
+                else "Anker" if self.brand == "anker"
+                else "Marstek"
+            ),
+            "model": self.driver.model_label or (
+                "Zendure" if self.brand == "zendure"
+                else "Solarbank Max AC" if self.brand == "anker"
+                else "Venus"
+            ),
         }
 
     async def connect(self) -> bool:
@@ -403,7 +448,12 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 self._consecutive_failures = 0
                 self._is_connected = True
                 self._suspension_reset_time = None
+                # Force every group to be read again over the new client and
+                # start a fresh partial-staleness episode.
+                getattr(self, "_last_update_times", {}).clear()
+                getattr(self, "_critical_group_failures", {}).clear()
                 _LOGGER.info("[%s] Fresh reconnection successful", self.name)
+                self._last_rs485_reenable_success = None
 
                 # Re-enable RS485 control mode after reconnection.
                 # A new TCP connection may reset the battery's RS485 state,
@@ -411,10 +461,15 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 # Skip if the user explicitly disabled RS485 via the switch.
                 # Already inside self.lock, so call the driver directly (the
                 # set_rs485_control wrapper would re-acquire the lock and deadlock).
-                if not self.rs485_user_disabled:
+                if (
+                    self.capabilities.has_rs485_control
+                    and not self.rs485_user_disabled
+                ):
                     if await self.driver.set_rs485_control(True):
+                        self._last_rs485_reenable_success = True
                         _LOGGER.info("[%s] RS485 control mode re-enabled after reconnection", self.name)
                     else:
+                        self._last_rs485_reenable_success = False
                         _LOGGER.warning("[%s] Failed to re-enable RS485 after reconnection", self.name)
             else:
                 self._is_connected = False
@@ -523,6 +578,8 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
 
         now = utcnow()
         updated_data = {}
+        critical_groups_attempted = set()
+        critical_groups_succeeded = set()
 
         if self._is_shutting_down:
             _LOGGER.debug("[%s] Shutdown in progress, skipping poll", self.name)
@@ -593,7 +650,7 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             fetch_keys = []
             for key in group.keys:
                 sensor = self._def_by_key.get(key, {})
-                entity_type = self._get_entity_type(sensor)
+                entity_type = self._get_entity_type(sensor, fallback_key=key)
                 registry_entry = None
                 for unique_id in (
                     f"{self.device_key}_{key}",   # current format (post-migration)
@@ -639,6 +696,9 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Lock ensures reads don't interleave with control loop writes.
             sensors_attempted += 1
+            critical_keys_requested = _CRITICAL_CONTROL_KEYS.intersection(fetch_keys)
+            if critical_keys_requested:
+                critical_groups_attempted.add(group.keys)
             try:
                 async with self.lock:
                     # The driver resolves the logical keys to their registers (using
@@ -658,6 +718,9 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 if not self._is_shutting_down:
                     _LOGGER.warning("[%s] Failed to read %s", self.name, list(fetch_keys))
                 continue
+
+            if critical_keys_requested.intersection(snapshot):
+                critical_groups_succeeded.add(group.keys)
 
             sensors_succeeded += 1
             stored = 0
@@ -698,6 +761,21 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             if stored:
                 self._last_update_times[group.keys] = now
 
+        # Track critical groups independently from overall connection health.
+        # Any successful BMS group still keeps the TCP connection available, but
+        # it must no longer hide a repeatedly failing inverter/SOC/control group.
+        for group_keys in critical_groups_attempted:
+            if group_keys in critical_groups_succeeded:
+                self._critical_group_failures.pop(group_keys, None)
+            else:
+                self._critical_group_failures[group_keys] = (
+                    self._critical_group_failures.get(group_keys, 0) + 1
+                )
+
+        stale_critical_groups = [
+            keys for keys, failures in self._critical_group_failures.items()
+            if failures >= _CRITICAL_GROUP_FAILURES_BEFORE_RECONNECT
+        ]
         # === CONNECTION HEALTH TRACKING ===
         # Only track failures when we actually attempted reads (not when all sensors
         # were simply skipped because their polling interval hasn't elapsed yet)
@@ -742,6 +820,19 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                     self.name, self._consecutive_failures
                 )
 
+        # Run the partial-staleness recovery after the aggregate health decision,
+        # so a failed reconnect cannot be overwritten by an unrelated successful
+        # BMS read from the old polling pass above.
+        if stale_critical_groups:
+            _LOGGER.warning(
+                "[%s] Critical telemetry groups failed %d consecutive polls: %s; "
+                "attempting fresh reconnection",
+                self.name,
+                _CRITICAL_GROUP_FAILURES_BEFORE_RECONNECT,
+                stale_critical_groups,
+            )
+            await self.async_reconnect_fresh()
+
         # Defensive check
         if self.data is None:
             self.data = {}
@@ -784,15 +875,19 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             self.min_soc = int(self.data["min_soc"])
         if "max_charge_power" in self.data:
             device_cap = int(self.data["max_charge_power"])
-            # When max_charge_power is a read-only device cap (Zendure), honour the
-            # user's software ceiling on top of it; otherwise the polled register
-            # value is itself the user setting.
+            # When max_charge_power is a soft-capped telemetry value (Zendure),
+            # honour the user's software ceiling on top of it; otherwise the
+            # polled register/sensor value is itself the effective limit.
             self.max_charge_power = (
                 min(device_cap, self.user_max_charge_power)
                 if self.needs_software_max_charge else device_cap
             )
         if "max_discharge_power" in self.data:
-            self.max_discharge_power = int(self.data["max_discharge_power"])
+            device_cap = int(self.data["max_discharge_power"])
+            self.max_discharge_power = (
+                min(device_cap, self.user_max_discharge_power)
+                if self.needs_software_max_discharge else device_cap
+            )
 
         if updated_data:
             _LOGGER.debug(
@@ -810,9 +905,17 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
 
         return self.data
 
-    def _get_entity_type(self, sensor_definition: dict) -> str:
-        """Determine entity type based on sensor definition."""
-        key = sensor_definition["key"]
+    def _get_entity_type(self, sensor_definition: dict, fallback_key: str | None = None) -> str:
+        """Determine entity type based on sensor definition.
+
+        Telemetry-only keys (present in driver field/read groups but not in any
+        entity definition list — e.g. Anker max_charge/discharge power caps used
+        for soft-max clamping) resolve via ``fallback_key`` and default to
+        ``sensor`` so the poll loop does not KeyError on an empty stub dict.
+        """
+        key = sensor_definition.get("key", fallback_key)
+        if not key:
+            return "sensor"
 
         # Check which definition list this sensor belongs to by key
         if key in [s["key"] for s in self.sensor_definitions]:
@@ -826,7 +929,7 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         elif key in [s["key"] for s in self.binary_sensor_definitions]:
             return "binary_sensor"
         else:
-            # Default to sensor if not found
+            # Default to sensor if not found (telemetry-only / soft-max keys)
             return "sensor"
 
     async def write_control(self, key: str, value: int, do_refresh: bool = True):

--- a/custom_components/omnibattery/sensor.py
+++ b/custom_components/omnibattery/sensor.py
@@ -101,9 +101,11 @@ from .sensors.calculated_sensors import (
     MarstekVenusSolarPowerSensor,
     MarstekVenusBatteryCellPowerSensor,
     SyntheticEnergySensor,
+    CumulativeDailyEnergySensor,
     SyntheticCapacitySensor,
     ZendurePackSensor,
     SYNTHETIC_ENERGY_SENSOR_DEFINITIONS,
+    CUMULATIVE_DAILY_ENERGY_SENSOR_DEFINITIONS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -153,6 +155,9 @@ async def async_setup_entry(
             for definition in SYNTHETIC_ENERGY_SENSOR_DEFINITIONS:
                 entities.append(SyntheticEnergySensor(coordinator, definition))
             entities.append(SyntheticCapacitySensor(coordinator))
+        elif not coordinator.capabilities.has_daily_energy_counters:
+            for definition in CUMULATIVE_DAILY_ENERGY_SENSOR_DEFINITIONS:
+                entities.append(CumulativeDailyEnergySensor(coordinator, definition))
         pack_specs = getattr(coordinator.driver, "pack_field_specs", None)
         if pack_specs:
             data = coordinator.data or {}
@@ -289,7 +294,15 @@ class MarstekVenusSensor(CoordinatorEntity, SensorEntity):
         
         # Map numeric values to state names if available
         if "states" in self.definition:
-            return self.definition["states"].get(value, value)
+            states = self.definition["states"]
+            if value in states:
+                return states[value]
+            # Coordinators may store ints as floats after scale/round; try int key.
+            try:
+                ivalue = int(value)
+            except (TypeError, ValueError):
+                return value
+            return states.get(ivalue, value)
         
         # For bit-described values, show which bits are active
         if "bit_descriptions" in self.definition:
@@ -1264,13 +1277,19 @@ class NonResponsiveBatteriesSensor(SensorEntity):
         now = dt_util.utcnow()
         attrs = {}
         for coordinator in self._coordinators:
+            # Use the tracker's authoritative check here as well as in the
+            # controller pool. It expires cooldowns before attributes are built,
+            # preventing state="None" alongside excluded=true/0 minutes.
+            currently_excluded = self._controller._non_responsive.is_excluded(
+                coordinator
+            )
             info = self._controller._non_responsive_batteries.get(coordinator)
             unreachable = (
                 not coordinator.is_available
                 and not getattr(coordinator, "_is_shutting_down", False)
                 and getattr(coordinator, "_consecutive_failures", 0) > 0
             )
-            if info and info.get("excluded_at") is not None:
+            if currently_excluded and info:
                 cooldown_min = self._controller._non_responsive.cooldown_min
                 elapsed_min = (now - info["excluded_at"]).total_seconds() / 60
                 remaining_min = max(0.0, cooldown_min - elapsed_min)

--- a/tests/test_set_battery_power_skip.py
+++ b/tests/test_set_battery_power_skip.py
@@ -85,7 +85,6 @@ def _controller():
         _idle_commanded_started={},
         _non_responsive=SimpleNamespace(
             record_non_delivery=lambda *a, **k: False,
-            record_comm_failure=lambda *a, **k: None,
             clear=lambda c: None,
             set_wake_attempted=lambda *a, **k: None,
         ),
@@ -228,7 +227,7 @@ async def test_skip_when_discharge_unchanged_and_delivering():
         "force_mode": 2,
         "set_charge_power": 0,
         "set_discharge_power": 300,
-        "battery_power": -300,  # delivering (sign-agnostic via abs())
+        "battery_power": -300,  # negative is delivered discharge
     })
     ctrl = _controller()
 
@@ -236,6 +235,29 @@ async def test_skip_when_discharge_unchanged_and_delivering():
 
     assert result is True
     coord.apply_power.assert_not_called()
+
+
+async def test_discharge_wrong_direction_is_not_treated_as_delivery():
+    """Positive battery power is charging, so it must not satisfy discharge."""
+    coord = _Coord({
+        "force_mode": 2,
+        "set_charge_power": 0,
+        "set_discharge_power": 300,
+        "battery_power": 300,
+        "battery_soc": 80,
+        "inverter_state": None,
+    })
+    coord.apply_power = AsyncMock(return_value=_ok(-300, battery_power_w=300))
+    ctrl = _controller()
+    ctrl._last_commanded_net_sign[coord] = -1
+    record = MagicMock(return_value=None)
+    ctrl._non_responsive.record_non_delivery = record
+
+    result = await ChargeDischargeController._set_battery_power(ctrl, coord, 0, 300)
+
+    assert result is True
+    coord.apply_power.assert_awaited_once()
+    record.assert_called_once()
 
 
 async def test_skip_when_charge_unchanged():
@@ -246,41 +268,6 @@ async def test_skip_when_charge_unchanged():
 
     assert result is True
     coord.apply_power.assert_not_called()
-
-
-async def test_queued_gateway_reasserts_unchanged_setpoint():
-    """Queued-gateway mode disables skip-if-unchanged: the setpoint is re-written
-    every cycle so a dropped write on a lossy gateway self-heals (#77)."""
-    coord = _Coord({"force_mode": 1, "set_charge_power": 500, "set_discharge_power": 0})
-    coord.queued_gateway_compatibility = True
-    coord.apply_power = AsyncMock(return_value=_ok(500, battery_power_w=500))
-    ctrl = _controller()
-
-    result = await ChargeDischargeController._set_battery_power(ctrl, coord, 500, 0)
-
-    assert result is True
-    coord.apply_power.assert_called_once()
-
-
-async def test_queued_gateway_no_resend_on_failure():
-    """Queued mode sends the write once on failure — no immediate resend under a
-    fresh transaction ID (would orphan late gateway replies); recovery is left to
-    the next control cycle (#77). Standard mode still retries twice."""
-    coord = _Coord({"force_mode": 2, "set_charge_power": 0, "set_discharge_power": 300})
-    coord.queued_gateway_compatibility = True
-    coord._is_shutting_down = False
-    coord.apply_power = AsyncMock(
-        return_value=SetpointResult(
-            ok=False, net_power_w=-300, confirmed=False,
-            failure_reason="feedback_timeout",
-        )
-    )
-    ctrl = _controller()
-
-    result = await ChargeDischargeController._set_battery_power(ctrl, coord, 0, 300)
-
-    assert result is False
-    coord.apply_power.assert_called_once()
 
 
 async def test_no_skip_when_discharge_unchanged_but_not_delivering():
@@ -336,12 +323,7 @@ async def test_no_record_during_discharge_engage_grace():
 
 
 async def test_high_soc_standby_after_taper_reaches_wake_and_exclusion():
-    """Issue #26: a previous top-charge pause must not exempt a stuck discharge.
-
-    The engage grace has already elapsed here. The battery ACKs the discharge
-    set-point but remains at 0 W in standby, so it must accumulate failures, get
-    the one-shot wake, and eventually be excluded.
-    """
+    """A previous top-charge pause must not exempt a stalled discharge (#26)."""
     coord = _Coord({
         "force_mode": 2,
         "set_charge_power": 0,
@@ -353,8 +335,6 @@ async def test_high_soc_standby_after_taper_reaches_wake_and_exclusion():
     ctrl = _controller()
     ctrl._non_responsive = NonResponsiveTracker(fail_threshold=3)
     ctrl._attempt_wake = AsyncMock(return_value=True)
-    # The charge-side anti-ping-pong latch remains active after reaching the top;
-    # it must not suppress discharge-side non-delivery recovery.
     ctrl._normal_balance_pause_latch_soc = {coord: 99.0}
 
     for _ in range(3):
@@ -368,6 +348,51 @@ async def test_high_soc_standby_after_taper_reaches_wake_and_exclusion():
 
     assert ctrl._non_responsive.is_excluded(coord) is True
     assert ctrl._non_responsive.excluded_names() == ["BAT1"]
+
+
+async def test_recovery_standby_preserves_episode_until_exclusion():
+    """The wake path's internal standby must not re-arm wake forever (#26)."""
+    coord = _Coord({
+        "force_mode": 2,
+        "set_charge_power": 0,
+        "set_discharge_power": 600,
+        "battery_power": 0,
+        "battery_soc": 99,
+        "inverter_state": 1,
+    })
+    coord.apply_power = AsyncMock(return_value=_ok(0, battery_power_w=0))
+    ctrl = _controller()
+    ctrl._non_responsive = NonResponsiveTracker(fail_threshold=3)
+    ctrl._last_commanded_net_sign[coord] = -1
+
+    async def recovery_standby(_coord, *, is_standby=False):
+        assert is_standby is True
+        await ChargeDischargeController._set_battery_power(
+            ctrl, coord, 0, 0,
+            bypass_blockers=True,
+            force_write=True,
+            preserve_non_responsive_episode=True,
+        )
+        return True
+
+    ctrl._attempt_wake = AsyncMock(side_effect=recovery_standby)
+
+    for _ in range(3):
+        await ctrl._check_non_delivery(coord, 600, 0, attempt=0)
+
+    assert ctrl._last_commanded_net_sign[coord] == -1
+    assert ctrl._non_responsive.is_excluded(coord) is False
+
+    # The next discharge is still the same episode, so the second threshold
+    # crossing excludes instead of granting another wake round.
+    await ChargeDischargeController._set_battery_power(ctrl, coord, 0, 600)
+    # The first real command after recovery can be a deliberately write-only
+    # cadence slot, so count three explicit settled observations here.
+    for _ in range(3):
+        await ctrl._check_non_delivery(coord, 600, 0, attempt=0)
+
+    assert ctrl._attempt_wake.await_count == 1
+    assert ctrl._non_responsive.is_excluded(coord) is True
 
 
 async def test_no_skip_when_setpoints_differ():


### PR DESCRIPTION
Fixes a recovery loop in the non-responsive battery handling related to #26.

When a battery acknowledged a discharge command but remained in Standby, the recovery path created a fresh connection and sent an internal Standby command. On the following discharge cycle, this was treated as a new discharge episode and cleared the failure counter and wake state.

As a result, the affected battery could repeatedly reconnect without ever being marked as non-responsive.

Changes

Preserve the non-responsive episode during the recovery Standby command.

Ensure that charging power cannot be mistaken for delivered discharge power.

Monitor critical inverter and control telemetry separately from successful BMS reads.

Refresh all telemetry groups after reconnecting.

Report a failed RS485 re-enable as an unsuccessful wake attempt.

Keep non-responsive diagnostic attributes consistent after cooldown expiry.

Add regression tests for the recovery loop and wrong-direction power feedback.

Testing

773 tests passed

10 tests skipped

0 tests failed

Related to #26