### PR TITLE
fix: preserve non-responsive recovery episodes (#26)

### DIFF
--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -3151,12 +3151,17 @@ class ChargeDischargeController:
         ignore_discharge_blockers: set[str] | None = None,
         bypass_blockers: bool = False,
         force_write: bool = False,
+        preserve_non_responsive_episode: bool = False,
     ) -> bool:
         """Set charge/discharge power for a single battery with ACK verification.
 
         ``force_write`` bypasses the bus-load skip-write so the command is always
         written, even when the battery's set-points already match — used by the
         non-responsive recovery to re-pin a battery that has slipped its control.
+
+        ``preserve_non_responsive_episode`` marks the recovery path's internal
+        standby write. It must not turn the following discharge command into a
+        new episode that clears the existing failure count and wake budget.
 
         Returns True if command was acknowledged, False otherwise.
         """
@@ -3265,7 +3270,11 @@ class ChargeDischargeController:
         # so the flip is seen even on a cycle that skips the write, and the tracker
         # is reset on the flip so a stale count from a prior session can't carry over.
         net_sign = 1 if net_power > 0 else -1 if net_power < 0 else 0
-        if net_sign == -1 and self._last_commanded_net_sign.get(coordinator) != -1:
+        if (
+            not preserve_non_responsive_episode
+            and net_sign == -1
+            and self._last_commanded_net_sign.get(coordinator) != -1
+        ):
             self._discharge_engage_started[coordinator] = dt_util.utcnow()
             self._non_responsive.clear(coordinator)
         # Mirror stamp for the opposite transition: a flip from a move into idle
@@ -3273,9 +3282,14 @@ class ChargeDischargeController:
         # battery idle from the start (no prior commanded move) gets no grace —
         # there is no ramp-down to wait out, and a genuine runaway found at
         # startup (the original #434 case) should trip immediately.
-        if net_sign == 0 and self._last_commanded_net_sign.get(coordinator, 0) != 0:
+        if (
+            not preserve_non_responsive_episode
+            and net_sign == 0
+            and self._last_commanded_net_sign.get(coordinator, 0) != 0
+        ):
             self._idle_commanded_started[coordinator] = dt_util.utcnow()
-        self._last_commanded_net_sign[coordinator] = net_sign
+        if not preserve_non_responsive_episode:
+            self._last_commanded_net_sign[coordinator] = net_sign
         if net_sign != 0:
             # Commanding a move ends any idle-runaway episode.
             self._idle_runaway_handled.pop(coordinator, None)
@@ -3364,7 +3378,7 @@ class ChargeDischargeController:
                 batt_power = data.get("battery_power")
                 skip_write = (
                     batt_power is not None
-                    and abs(float(batt_power)) >= 0.10 * abs(net_power)
+                    and float(batt_power) <= -0.10 * abs(net_power)
                 )
                 # Slow actuators (Zendure HTTP) never read back per-write, so the
                 # ACK-path non-delivery detection further down never runs for them.
@@ -3566,8 +3580,8 @@ class ChargeDischargeController:
         silently stalled registerless battery in a pool is excluded, not
         re-commanded forever.
         """
-        actual_abs = abs(actual_power)
-        if actual_abs >= 0.10 * discharge_power:
+        delivered_discharge = max(0.0, -float(actual_power))
+        if delivered_discharge >= 0.10 * discharge_power:
             self._non_responsive.clear(coordinator)
             return
         engage_started = self._discharge_engage_started.get(coordinator)
@@ -3624,7 +3638,7 @@ class ChargeDischargeController:
         # and must reach the wake/reconnect recovery path (issue #26).
         reason = "standby_no_delivery" if is_standby else "non_delivery"
         outcome = self._non_responsive.record_non_delivery(
-            coordinator, discharge_power, actual_abs,
+            coordinator, discharge_power, delivered_discharge,
             reason=reason, retry_attempted=attempt > 0,
         )
         # First threshold-cross: a one-shot wake nudge (reconnect/re-assert), but
@@ -3671,8 +3685,11 @@ class ChargeDischargeController:
             ok = await coordinator.async_reconnect_fresh()
             await self._set_battery_power(
                 coordinator, 0, 0, bypass_blockers=True, force_write=True,
+                preserve_non_responsive_episode=True,
             )
-            return ok
+            return ok and getattr(
+                coordinator, "_last_rs485_reenable_success", True
+            ) is not False
         _LOGGER.info(
             "[%s] Non-delivery — re-asserting RS485 control + forcing standby",
             coordinator.name,
@@ -3684,15 +3701,22 @@ class ChargeDischargeController:
         # is why an HA restart recovers the battery. If the re-assert didn't
         # take, do that restart-equivalent here. Read error (None) is left to the
         # read-failure health path; only a definitive "still disabled" escalates.
+        reconnected = False
         if await coordinator.rs485_control_enabled() is False:
             _LOGGER.warning(
                 "[%s] RS485 re-assert didn't take over the live connection — "
                 "reconnecting fresh (restart-equivalent)", coordinator.name,
             )
             ok = await coordinator.async_reconnect_fresh()
+            reconnected = True
         await self._set_battery_power(
             coordinator, 0, 0, bypass_blockers=True, force_write=True,
+            preserve_non_responsive_episode=True,
         )
+        if reconnected and getattr(
+            coordinator, "_last_rs485_reenable_success", True
+        ) is False:
+            return False
         return ok
 
     # =========================================================================

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -35,6 +35,19 @@ _LOGGER = logging.getLogger(__name__)
 # these — the burst poll must not accelerate unrelated registers.
 _DELIVERED_POWER_KEYS = frozenset({"ac_power", "battery_power"})
 
+# Register groups that directly govern control safety. Successful BMS reads must
+# not hide a frozen inverter/SOC/control group indefinitely (issue #26).
+_CRITICAL_CONTROL_KEYS = frozenset({
+    "ac_power",
+    "battery_power",
+    "battery_soc",
+    "force_mode",
+    "inverter_state",
+    "set_charge_power",
+    "set_discharge_power",
+})
+_CRITICAL_GROUP_FAILURES_BEFORE_RECONNECT = 3
+
 
 def group_scan_interval_s(
     group_keys: tuple[str, ...],
@@ -209,9 +222,11 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         # path, surfaced by health_snapshot / diagnostics). Initialised here so a
         # read before the first write returns None rather than raising.
         self._last_write_failure_reason = None
+        self._last_rs485_reenable_success = None
 
         # Timestamp-based update tracking
         self._last_update_times = {}
+        self._critical_group_failures = {}
         # Last-written select values that override buggy register readbacks.
         # Repopulated from persisted battery_config after construction; initialised
         # here so get_shadow_select before that assignment returns None instead of
@@ -422,6 +437,7 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             "[%s] Creating fresh connection to %s:%s (consecutive failures: %d)",
             self.name, self.host, self.port, self._consecutive_failures
         )
+        self._last_rs485_reenable_success = None
 
         async with self.lock:
             # driver.connect() internally closes the old client and creates a new one
@@ -431,6 +447,10 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 self._consecutive_failures = 0
                 self._is_connected = True
                 self._suspension_reset_time = None
+                # A fresh client must refresh every telemetry group. Also start a
+                # new partial-staleness episode for the new connection.
+                getattr(self, "_last_update_times", {}).clear()
+                getattr(self, "_critical_group_failures", {}).clear()
                 _LOGGER.info("[%s] Fresh reconnection successful", self.name)
 
                 # Re-enable RS485 control mode after reconnection.
@@ -444,8 +464,10 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                     and not self.rs485_user_disabled
                 ):
                     if await self.driver.set_rs485_control(True):
+                        self._last_rs485_reenable_success = True
                         _LOGGER.info("[%s] RS485 control mode re-enabled after reconnection", self.name)
                     else:
+                        self._last_rs485_reenable_success = False
                         _LOGGER.warning("[%s] Failed to re-enable RS485 after reconnection", self.name)
             else:
                 self._is_connected = False
@@ -554,6 +576,8 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
 
         now = utcnow()
         updated_data = {}
+        critical_groups_attempted = set()
+        critical_groups_succeeded = set()
 
         if self._is_shutting_down:
             _LOGGER.debug("[%s] Shutdown in progress, skipping poll", self.name)
@@ -670,6 +694,9 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Lock ensures reads don't interleave with control loop writes.
             sensors_attempted += 1
+            critical_keys_requested = _CRITICAL_CONTROL_KEYS.intersection(fetch_keys)
+            if critical_keys_requested:
+                critical_groups_attempted.add(group.keys)
             try:
                 async with self.lock:
                     # The driver resolves the logical keys to their registers (using
@@ -689,6 +716,9 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 if not self._is_shutting_down:
                     _LOGGER.warning("[%s] Failed to read %s", self.name, list(fetch_keys))
                 continue
+
+            if critical_keys_requested.intersection(snapshot):
+                critical_groups_succeeded.add(group.keys)
 
             sensors_succeeded += 1
             stored = 0
@@ -729,7 +759,24 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             if stored:
                 self._last_update_times[group.keys] = now
 
+        # Aggregate connection health considers any successful group sufficient.
+        # Keep a separate streak for safety-critical groups so unrelated BMS
+        # telemetry cannot mask frozen control feedback.
+        for group_keys in critical_groups_attempted:
+            if group_keys in critical_groups_succeeded:
+                self._critical_group_failures.pop(group_keys, None)
+            else:
+                self._critical_group_failures[group_keys] = (
+                    self._critical_group_failures.get(group_keys, 0) + 1
+                )
+
+        stale_critical_groups = [
+            keys for keys, failures in self._critical_group_failures.items()
+            if failures >= _CRITICAL_GROUP_FAILURES_BEFORE_RECONNECT
+        ]
+
         # === CONNECTION HEALTH TRACKING ===
+        aggregate_reconnect_attempted = False
         # Only track failures when we actually attempted reads (not when all sensors
         # were simply skipped because their polling interval hasn't elapsed yet)
         if sensors_attempted == 0:
@@ -762,6 +809,7 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                     "[%s] %d consecutive failures - attempting fresh reconnection",
                     self.name, self._consecutive_failures
                 )
+                aggregate_reconnect_attempted = True
                 await self.async_reconnect_fresh()
 
             if self._consecutive_failures >= self._max_failures_before_suspend:
@@ -772,6 +820,18 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                     "Will retry in 2 minutes.",
                     self.name, self._consecutive_failures
                 )
+
+        # Recover partial staleness after the aggregate health decision so a
+        # successful unrelated group cannot overwrite the reconnect result.
+        if stale_critical_groups and not aggregate_reconnect_attempted:
+            _LOGGER.warning(
+                "[%s] Critical telemetry groups failed %d consecutive polls: %s; "
+                "attempting fresh reconnection",
+                self.name,
+                _CRITICAL_GROUP_FAILURES_BEFORE_RECONNECT,
+                stale_critical_groups,
+            )
+            await self.async_reconnect_fresh()
 
         # Defensive check
         if self.data is None:

--- a/custom_components/omnibattery/sensor.py
+++ b/custom_components/omnibattery/sensor.py
@@ -1287,13 +1287,18 @@ class NonResponsiveBatteriesSensor(SensorEntity):
         now = dt_util.utcnow()
         attrs = {}
         for coordinator in self._coordinators:
+            # This check also expires a completed cooldown before attributes are
+            # rendered, avoiding state="None" with excluded=true/0 minutes.
+            currently_excluded = self._controller._non_responsive.is_excluded(
+                coordinator
+            )
             info = self._controller._non_responsive_batteries.get(coordinator)
             unreachable = (
                 not coordinator.is_available
                 and not getattr(coordinator, "_is_shutting_down", False)
                 and getattr(coordinator, "_consecutive_failures", 0) > 0
             )
-            if info and info.get("excluded_at") is not None:
+            if currently_excluded and info:
                 cooldown_min = self._controller._non_responsive.cooldown_min
                 elapsed_min = (now - info["excluded_at"]).total_seconds() / 60
                 remaining_min = max(0.0, cooldown_min - elapsed_min)

--- a/tests/test_attempt_wake.py
+++ b/tests/test_attempt_wake.py
@@ -42,6 +42,17 @@ async def test_standby_reconnects_fresh():
     ctrl._set_battery_power.assert_awaited_once()
 
 
+async def test_standby_reports_failed_rs485_reenable():
+    coord = _coord(_last_rs485_reenable_success=False)
+    ctrl = _controller()
+
+    result = await ChargeDischargeController._attempt_wake(
+        ctrl, coord, is_standby=True
+    )
+
+    assert result is False
+
+
 async def test_non_standby_reasserts_without_disabling():
     """Issue #434 regression guard: must never write RS485=False for an awake
     battery that might be exporting under its own internal logic."""
@@ -53,6 +64,19 @@ async def test_non_standby_reasserts_without_disabling():
     assert result is True
     coord.set_rs485_control.assert_awaited_once_with(True)
     ctrl._set_battery_power.assert_awaited_once()
+
+
+async def test_non_standby_live_reassert_ignores_old_reconnect_failure():
+    """A stale reconnect diagnostic must not poison a successful live reassert."""
+    coord = _coord(_last_rs485_reenable_success=False)
+    ctrl = _controller()
+
+    result = await ChargeDischargeController._attempt_wake(
+        ctrl, coord, is_standby=False
+    )
+
+    assert result is True
+    coord.async_reconnect_fresh.assert_not_awaited()
 
 
 async def test_non_standby_reconnects_fresh_when_reassert_does_not_take():

--- a/tests/test_coordinator_critical_telemetry.py
+++ b/tests/test_coordinator_critical_telemetry.py
@@ -1,0 +1,98 @@
+"""Regression tests for partial critical-telemetry failures (issue #26)."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from custom_components.omnibattery.drivers.base import ReadGroup
+from custom_components.omnibattery.infra.coordinator import (
+    MarstekVenusDataUpdateCoordinator,
+)
+
+
+def _coordinator(
+    *,
+    critical_succeeds: bool,
+    other_succeeds: bool = True,
+    reconnect_threshold: int = 99,
+):
+    critical_group = ReadGroup("high", ("battery_soc",))
+    other_group = ReadGroup("high", ("temperature",))
+
+    async def read_telemetry(keys):
+        if keys == ["battery_soc"]:
+            return {"battery_soc": 80} if critical_succeeds else {}
+        return {"temperature": 25} if other_succeeds else {}
+
+    driver = SimpleNamespace(
+        read_groups=[critical_group, other_group],
+        read_telemetry=read_telemetry,
+        control_dependency_keys=set(),
+    )
+    registry = SimpleNamespace(
+        async_get_entity_id=lambda *args: None,
+        entities={},
+    )
+    coordinator = SimpleNamespace(
+        name="Battery",
+        host="192.0.2.10",
+        device_key="192.0.2.10_1",
+        driver=driver,
+        _def_by_key={
+            "battery_soc": {"key": "battery_soc"},
+            "temperature": {"key": "temperature"},
+        },
+        _get_entity_type=lambda definition, fallback_key=None: "sensor",
+        _entity_registry=registry,
+        _is_shutting_down=False,
+        _suspension_reset_time=None,
+        _last_update_times={},
+        _critical_group_failures={},
+        boost_fast_poll_until=0.0,
+        lock=asyncio.Lock(),
+        _consecutive_failures=0,
+        _max_failures_before_reconnect=reconnect_threshold,
+        _max_failures_before_suspend=100,
+        _is_connected=True,
+        data={},
+        async_reconnect_fresh=AsyncMock(return_value=True),
+        capabilities=SimpleNamespace(has_energy_counters=True),
+        battery_capacity_kwh=0,
+        _alarm_notifier=SimpleNamespace(check=AsyncMock()),
+    )
+    return coordinator, critical_group
+
+
+async def test_successful_bms_group_does_not_hide_failed_critical_group():
+    coordinator, _ = _coordinator(critical_succeeds=False)
+
+    for _ in range(3):
+        coordinator._last_update_times.clear()
+        await MarstekVenusDataUpdateCoordinator._async_update_data(coordinator)
+
+    assert coordinator._consecutive_failures == 0
+    coordinator.async_reconnect_fresh.assert_awaited_once()
+
+
+async def test_critical_group_success_clears_its_failure_streak():
+    coordinator, critical_group = _coordinator(critical_succeeds=True)
+    coordinator._critical_group_failures[critical_group.keys] = 2
+
+    await MarstekVenusDataUpdateCoordinator._async_update_data(coordinator)
+
+    assert critical_group.keys not in coordinator._critical_group_failures
+    coordinator.async_reconnect_fresh.assert_not_awaited()
+
+
+async def test_aggregate_and_critical_failures_trigger_only_one_reconnect():
+    coordinator, _ = _coordinator(
+        critical_succeeds=False,
+        other_succeeds=False,
+        reconnect_threshold=3,
+    )
+
+    for _ in range(3):
+        await MarstekVenusDataUpdateCoordinator._async_update_data(coordinator)
+
+    coordinator.async_reconnect_fresh.assert_awaited_once()

--- a/tests/test_coordinator_driver_capabilities.py
+++ b/tests/test_coordinator_driver_capabilities.py
@@ -44,6 +44,8 @@ async def test_reconnect_skips_rs485_for_driver_without_capability():
         driver=driver,
         capabilities=SimpleNamespace(has_rs485_control=False),
         rs485_user_disabled=False,
+        _last_update_times={("battery_soc",): object()},
+        _critical_group_failures={("battery_soc",): 2},
     )
 
     result = await MarstekVenusDataUpdateCoordinator.async_reconnect_fresh(
@@ -52,3 +54,34 @@ async def test_reconnect_skips_rs485_for_driver_without_capability():
 
     assert result is True
     driver.connect.assert_awaited_once()
+    assert coordinator._last_update_times == {}
+    assert coordinator._critical_group_failures == {}
+    assert coordinator._last_rs485_reenable_success is None
+
+
+async def test_reconnect_records_failed_rs485_reenable():
+    driver = SimpleNamespace(
+        connect=AsyncMock(return_value=True),
+        set_rs485_control=AsyncMock(return_value=False),
+    )
+    coordinator = SimpleNamespace(
+        name="Marstek",
+        host="192.0.2.2",
+        port=502,
+        _consecutive_failures=1,
+        _is_connected=False,
+        _suspension_reset_time=object(),
+        lock=asyncio.Lock(),
+        driver=driver,
+        capabilities=SimpleNamespace(has_rs485_control=True),
+        rs485_user_disabled=False,
+        _last_update_times={},
+        _critical_group_failures={},
+    )
+
+    result = await MarstekVenusDataUpdateCoordinator.async_reconnect_fresh(
+        coordinator
+    )
+
+    assert result is True
+    assert coordinator._last_rs485_reenable_success is False

--- a/tests/test_non_responsive_sensor.py
+++ b/tests/test_non_responsive_sensor.py
@@ -1,0 +1,48 @@
+"""Tests for non-responsive diagnostic sensor consistency."""
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.omnibattery.sensor import NonResponsiveBatteriesSensor
+from custom_components.omnibattery.tracking.non_responsive_tracker import (
+    NonResponsiveTracker,
+)
+from tests.conftest import FakeCoordinator
+
+
+def test_expired_cooldown_is_not_reported_as_excluded():
+    coordinator = FakeCoordinator(
+        name="BAT1",
+        is_available=True,
+    )
+    coordinator._is_shutting_down = False
+    coordinator._consecutive_failures = 0
+    tracker = NonResponsiveTracker(fail_threshold=3, cooldown_min=5)
+    tracker.batteries[coordinator] = {
+        "fail_count": 3,
+        "excluded_at": dt_util.utcnow() - timedelta(minutes=6),
+        "wake_used": True,
+        "reason": "standby_no_delivery",
+        "retry_attempted": False,
+        "wake_attempted": True,
+    }
+    controller = SimpleNamespace(
+        _non_responsive=tracker,
+        _non_responsive_batteries=tracker.batteries,
+        non_responsive_battery_names=[],
+    )
+    sensor = NonResponsiveBatteriesSensor(
+        hass=None,
+        entry=None,
+        controller=controller,
+        coordinators=[coordinator],
+    )
+
+    attributes = sensor.extra_state_attributes["BAT1"]
+
+    assert attributes["excluded"] is False
+    assert attributes["fail_count"] == 0
+    assert "remaining_minutes" not in attributes

--- a/tests/test_set_battery_power_skip.py
+++ b/tests/test_set_battery_power_skip.py
@@ -227,7 +227,7 @@ async def test_skip_when_discharge_unchanged_and_delivering():
         "force_mode": 2,
         "set_charge_power": 0,
         "set_discharge_power": 300,
-        "battery_power": -300,  # delivering (sign-agnostic via abs())
+        "battery_power": -300,  # negative is delivered discharge
     })
     ctrl = _controller()
 
@@ -235,6 +235,29 @@ async def test_skip_when_discharge_unchanged_and_delivering():
 
     assert result is True
     coord.apply_power.assert_not_called()
+
+
+async def test_discharge_wrong_direction_is_not_treated_as_delivery():
+    """Positive battery power is charging, so it must not satisfy discharge."""
+    coord = _Coord({
+        "force_mode": 2,
+        "set_charge_power": 0,
+        "set_discharge_power": 300,
+        "battery_power": 300,
+        "battery_soc": 80,
+        "inverter_state": None,
+    })
+    coord.apply_power = AsyncMock(return_value=_ok(-300, battery_power_w=300))
+    ctrl = _controller()
+    ctrl._last_commanded_net_sign[coord] = -1
+    record = MagicMock(return_value=None)
+    ctrl._non_responsive.record_non_delivery = record
+
+    result = await ChargeDischargeController._set_battery_power(ctrl, coord, 0, 300)
+
+    assert result is True
+    coord.apply_power.assert_awaited_once()
+    record.assert_called_once()
 
 
 async def test_skip_when_charge_unchanged():
@@ -325,6 +348,50 @@ async def test_high_soc_standby_after_taper_reaches_wake_and_exclusion():
 
     assert ctrl._non_responsive.is_excluded(coord) is True
     assert ctrl._non_responsive.excluded_names() == ["BAT1"]
+
+
+async def test_recovery_standby_preserves_episode_until_exclusion():
+    """The wake path's internal standby must not re-arm wake forever (#26)."""
+    coord = _Coord({
+        "force_mode": 2,
+        "set_charge_power": 0,
+        "set_discharge_power": 600,
+        "battery_power": 0,
+        "battery_soc": 99,
+        "inverter_state": 1,
+    })
+    coord.apply_power = AsyncMock(return_value=_ok(0, battery_power_w=0))
+    ctrl = _controller()
+    ctrl._non_responsive = NonResponsiveTracker(fail_threshold=3)
+    ctrl._last_commanded_net_sign[coord] = -1
+
+    async def recovery_standby(_coord, *, is_standby=False):
+        assert is_standby is True
+        await ChargeDischargeController._set_battery_power(
+            ctrl,
+            coord,
+            0,
+            0,
+            bypass_blockers=True,
+            force_write=True,
+            preserve_non_responsive_episode=True,
+        )
+        return True
+
+    ctrl._attempt_wake = AsyncMock(side_effect=recovery_standby)
+
+    for _ in range(3):
+        await ctrl._check_non_delivery(coord, 600, 0, attempt=0)
+
+    assert ctrl._last_commanded_net_sign[coord] == -1
+    assert ctrl._non_responsive.is_excluded(coord) is False
+
+    await ChargeDischargeController._set_battery_power(ctrl, coord, 0, 600)
+    for _ in range(3):
+        await ctrl._check_non_delivery(coord, 600, 0, attempt=0)
+
+    assert ctrl._attempt_wake.await_count == 1
+    assert ctrl._non_responsive.is_excluded(coord) is True
 
 
 async def test_no_skip_when_setpoints_differ():


### PR DESCRIPTION
## Summary

Clean replacement for #140, rebased on `release/v1.0.1-beta` and limited to the issue #26 recovery path.

- preserve the active non-responsive episode across the recovery-only standby write, so the second failure threshold excludes instead of reconnecting forever
- require negative battery power before treating a discharge command as delivered
- track failures of safety-critical telemetry groups independently from successful BMS reads
- refresh every telemetry group after a fresh reconnect and report failed RS485 re-enables accurately
- expire non-responsive diagnostic attributes consistently after cooldown
- preserve the intentional rollback of the issue #77 beta gateway workarounds; this PR does not restore `queued_gateway_compatibility`, while the tolerant power ACK from 1.0.0 remains unchanged

The implementation also avoids two reconnects in the same poll when aggregate and critical-group failure thresholds are crossed together.

## Testing

- `python -m compileall -q custom_components tests`
- focused regression suite: 33 passed
- full pytest suite: 839 passed, 10 skipped

Supersedes #140.
Related to #26.