### PR TITLE
fix(anker): Manual Mode release, Max Charge soft-max, E5000 Pro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - Marstek Venus E and C (v2 and v3), Venus D and Venus A via Modbus TCP
 - Zendure Solarflow 2400 AC+, Solarflow 2400 Pro (Local API)
-- Anker SOLIX Solarbank Max AC via Modbus TCP
+- Anker SOLIX Solarbank Max AC and Solarbank 4 E5000 Pro via Modbus TCP
 
 It provides advanced energy management features including predictive grid charging, customizable time slots for discharge control, and device load exclusion logic.
 
@@ -52,8 +52,8 @@ Full documentation (configuration, features, entities, troubleshooting) is avail
 
 | Requirement | Details |
 |---|---|
-| Battery | Marstek Venus E v2/v3, Venus A, Venus D, Zendure Solarflow 2400 AC+, Solarflow 2400 Pro, Anker SOLIX Solarbank Max AC |
-| Modbus bridge | Elfin-EW11 or compatible RS485-to-TCP converter. Venus E v3, Venus A and Venus D can also be connected via Ethernet with native Modbus TCP support. Anker Solarbank Max AC uses native Modbus TCP (enable in the Anker app under Third-Party Control; only one Modbus client at a time). |
+| Battery | Marstek Venus E v2/v3, Venus A, Venus D, Zendure Solarflow 2400 AC+, Solarflow 2400 Pro, Anker SOLIX Solarbank Max AC / 4 E5000 Pro |
+| Modbus bridge | Elfin-EW11 or compatible RS485-to-TCP converter. Venus E v3, Venus A and Venus D can also be connected via Ethernet with native Modbus TCP support. Anker Solarbank Max AC and 4 E5000 Pro use native Modbus TCP (enable in the Anker app under Third-Party Control; only one Modbus client at a time). |
 | Wireless connection | Required for Zendure Solarflow 2400 AC+ and Solarflow 2400 Pro |
 | Grid sensor | HA sensor measuring total grid consumption (e.g. Shelly EM3, Neurio, smart meter) |
 | Network | Battery reachable by IP from Home Assistant |

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -3125,11 +3125,16 @@ class ChargeDischargeController:
 
     async def _apply_software_manual_setpoints(self) -> None:
         """Assert the per-battery manual setpoint for drivers without manual
-        registers (Zendure) while global manual mode is active.
+        registers (Zendure/Anker) while global manual mode is active.
 
         Register-based batteries (Marstek) are driven by the user's own register
-        writes, so they are skipped here. The setpoint is re-asserted every cycle;
-        _set_battery_power's skip-if-unchanged guard avoids redundant writes.
+        writes, so they are skipped here. Charge/Discharge setpoints are
+        re-asserted every cycle; _set_battery_power's skip-if-unchanged guard
+        avoids redundant writes.
+
+        Idle (None) does not reassert 0 W: Manual Mode turn-on already idles
+        once, and reasserting would force Anker Third-Party Control every cycle
+        — fighting Solix app modes the user may select while paused.
         """
         for coordinator in self.coordinators:
             if not coordinator.needs_software_manual_control:
@@ -3139,8 +3144,7 @@ class ChargeDischargeController:
                 await self._set_battery_power(coordinator, coordinator.manual_set_charge_power, 0, bypass_blockers=True)
             elif mode == "Discharge":
                 await self._set_battery_power(coordinator, 0, coordinator.manual_set_discharge_power, bypass_blockers=True)
-            else:
-                await self._set_battery_power(coordinator, 0, 0)
+            # Idle: leave device alone (no 0 W reassert / no mode force).
 
     async def _set_battery_power(
         self,

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -695,7 +695,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                                 {"value": "marstek", "label": "Marstek Venus"},
                                 {"value": "zendure", "label": "Zendure SolarFlow"},
                                 {"value": "esphome", "label": "Marstek via LilyGo RS485 (ESPHome)"},
-                                {"value": "anker", "label": "Anker SOLIX Solarbank Max AC"},
+                                {"value": "anker", "label": "Anker SOLIX Solarbank Max AC / 4 E5000 Pro"},
                             ],
                             mode=SelectSelectorMode.DROPDOWN,
                         )),
@@ -856,7 +856,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
     async def async_step_battery_connection_anker(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Step 3b (Anker): Connection details for Solarbank Max AC."""
+        """Step 3b (Anker): Connection details for Solarbank Max AC / 4 E5000 Pro."""
         errors = {}
         battery_num = self.battery_index + 1
 
@@ -2177,7 +2177,7 @@ class OptionsFlowHandler(OptionsFlow):
                                 {"value": "marstek", "label": "Marstek Venus"},
                                 {"value": "zendure", "label": "Zendure SolarFlow"},
                                 {"value": "esphome", "label": "Marstek via LilyGo RS485 (ESPHome)"},
-                                {"value": "anker", "label": "Anker SOLIX Solarbank Max AC"},
+                                {"value": "anker", "label": "Anker SOLIX Solarbank Max AC / 4 E5000 Pro"},
                             ],
                             mode=SelectSelectorMode.DROPDOWN,
                         )),
@@ -2390,7 +2390,7 @@ class OptionsFlowHandler(OptionsFlow):
 
 
     async def async_step_battery_connection_anker(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        """Configure connection details for an Anker Solarbank Max AC."""
+        """Configure connection details for an Anker Solarbank Max AC / 4 E5000 Pro."""
         errors = {}
 
         try:

--- a/custom_components/omnibattery/drivers/__init__.py
+++ b/custom_components/omnibattery/drivers/__init__.py
@@ -10,7 +10,7 @@ Drivers:
   - ``marstek``: Modbus-TCP, register based, polled (the original hardware).
   - ``zendure``: local HTTP REST, property based, polled (SolarFlow series).
   - ``esphome``: HA-entity based, push (Marstek behind a LilyGo RS485 bridge).
-  - ``anker``: Modbus-TCP, register based, polled (SOLIX Solarbank Max AC).
+  - ``anker``: Modbus-TCP, register based, polled (SOLIX Solarbank Max AC / 4 E5000 Pro).
 
 See ``docs/plans/driver_abstraction.md`` for the phased extraction plan.
 """

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -327,15 +327,11 @@ class AnkerModbusDriver(BatteryDriver):
         # Register 10071 is write-only. A new connection may mean the battery
         # restarted and lost the previous command, so do not expose its stale
         # in-memory echo as observable device state.
+        # Do not force Third-Party Control here: mode is ensured only when a
+        # setpoint is written via apply_setpoint(), so Manual Mode idle can
+        # leave Solix app modes alone without reconnect fighting them.
         self._last_net_power_w = None
         self._client.unit_id = self._slave_id
-        mode_ok = await self._ensure_third_party_mode()
-        if not mode_ok:
-            _LOGGER.warning(
-                "Anker %s:%s connected but failed to set third_party_control mode",
-                self._host,
-                self._port,
-            )
         return True
 
     async def close(self) -> None:

--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -1,9 +1,15 @@
-"""Anker SOLIX Solarbank Max AC Modbus TCP driver.
+"""Anker SOLIX Solarbank Modbus TCP driver.
 
-Implements :class:`BatteryDriver` for the Solarbank Max AC over Modbus TCP.
+Implements :class:`BatteryDriver` for Solarbank Max AC, Solarbank 4 E5000 Pro,
+and Solarbank XE AC over Modbus TCP (identical register map; identity differs
+only by product code).
 
 Register map source of truth (FC03/FC04 batch ranges and write addresses):
 https://raw.githubusercontent.com/anker-charging/ha-anker-solix-official/refs/heads/main/custom_components/anker_solix_official/config/8fcbb87c685781b1d70d784a79eb923098955df2aaf199095ce7767bb70b913d.yaml
+(Solarbank Max AC; also aliases XE AC)
+
+https://raw.githubusercontent.com/anker-charging/ha-anker-solix-official/refs/heads/main/custom_components/anker_solix_official/config/58f0132b5f7979b2cfa43a0eb1fca770053288032386ff6a4da5ed2d72d4ea35.yaml
+(Solarbank 4 E5000 Pro — same map below ``product_info``)
 
 Sign conventions:
   Omnibattery net power: +charge / −discharge
@@ -36,8 +42,23 @@ _ADDR_CHARGE_SOC_LIMIT = 60000
 _ADDR_DISCHARGE_SOC_LIMIT = 60001
 _ADDR_BATTERY_SOC = 10014
 
+# Family continuous envelope (Max AC). Live caps come from 10036/10038; this is
+# only an upper clamp so peak/aggregate readings cannot inflate PD limits.
 _HW_MAX_POWER_W = 3500
 _MIN_OPERATING_POWER_W = 100
+
+# Official product_code_mapping (Max AC YAML + E5000 Pro YAML).
+_PRODUCT_LABELS: dict[str, str] = {
+    "DN7M": "Solarbank 4 E5000 Pro",
+    "DPM4": "Solarbank 4 E5000 Pro",
+    "DMWH": "Solarbank Max AC",
+    "DMXU": "Solarbank Max AC",
+    "E25H": "Solarbank Max AC",
+    "DNMS": "Solarbank XE AC",
+    "DPP4": "Solarbank XE AC",
+    "DNN3": "Solarbank XE AC",
+}
+_DEFAULT_MODEL_LABEL = "Solarbank Max AC"
 
 # Normalize Anker's battery-status codes to the shared Marstek inverter-state
 # contract consumed by the controller and dashboard.
@@ -68,6 +89,8 @@ _BATCH_READ_RANGES: dict[str, list[tuple[int, int]]] = {
 # Fields decoded from batch buffers. register_type must match the YAML range.
 # invert: negate value to Omnibattery +charge/−discharge convention.
 _FIELD_SPECS: list[dict] = [
+    {"key": "device_model", "address": 32768, "register_type": "input",
+     "data_type": "char", "count": 5},
     {"key": "battery_status", "address": 10001, "register_type": "input",
      "data_type": "uint16", "count": 1},
     {"key": "battery_power", "address": 10008, "register_type": "input",
@@ -207,8 +230,16 @@ def _clamp_soc(value: float, lo: int, hi: int) -> int:
     return max(lo, min(hi, int(round(value))))
 
 
+def _label_for_product_code(code: Optional[str]) -> str:
+    """Map an official product code to a short model label."""
+    if not code:
+        return _DEFAULT_MODEL_LABEL
+    key = str(code).strip().upper()
+    return _PRODUCT_LABELS.get(key, _DEFAULT_MODEL_LABEL)
+
+
 class AnkerModbusDriver(BatteryDriver):
-    """Modbus TCP driver for Anker SOLIX Solarbank Max AC."""
+    """Modbus TCP driver for Anker SOLIX Solarbank Max AC / 4 E5000 Pro / XE AC."""
 
     def __init__(
         self,
@@ -225,6 +256,7 @@ class AnkerModbusDriver(BatteryDriver):
         self._slave_id = slave_id
         self._client = client or AnkerModbusClient(host, port, slave_id=slave_id)
         self._last_net_power_w: Optional[int] = None
+        self._product_code: Optional[str] = None
         self._dynamic_max_charge_w = _HW_MAX_POWER_W
         self._dynamic_max_discharge_w = _HW_MAX_POWER_W
         # User limits are enforced upstream; capability envelope is hardware max.
@@ -277,7 +309,7 @@ class AnkerModbusDriver(BatteryDriver):
 
     @property
     def model_label(self) -> Optional[str]:
-        return "Solarbank Max AC"
+        return _label_for_product_code(self._product_code)
 
     @property
     def sensor_definitions(self) -> list[dict]:
@@ -332,7 +364,18 @@ class AnkerModbusDriver(BatteryDriver):
         # leave Solix app modes alone without reconnect fighting them.
         self._last_net_power_w = None
         self._client.unit_id = self._slave_id
+        await self._refresh_product_code()
         return True
+
+    async def _refresh_product_code(self) -> None:
+        """Read device_model (input 32768, 5 regs) for product-code → label."""
+        regs = await self._client.async_read_input_block(32768, 5)
+        if not regs:
+            return
+        value = decode_registers(regs, "char")
+        if isinstance(value, str) and value.strip():
+            code = value.strip().upper()
+            self._product_code = code[:4] if len(code) >= 4 else code
 
     async def close(self) -> None:
         await self._client.async_close()
@@ -379,10 +422,14 @@ class AnkerModbusDriver(BatteryDriver):
                 if field.get("invert"):
                     value = -int(value)
                 snapshot[field["key"]] = value
+                if field["key"] == "device_model" and isinstance(value, str) and value:
+                    # Official product codes are short SKUs prefixes (e.g. DN7M).
+                    code = value.strip().upper()
+                    self._product_code = code[:4] if len(code) >= 4 else code
                 if field["key"] == "max_charge_power" and isinstance(value, (int, float)):
-                    # Cap at the static envelope so peak/aggregate readings
-                    # (e.g. 7000 W) do not inflate the PD clamp beyond the
-                    # Solarbank Max AC continuous rating.
+                    # Cap at the static family envelope so peak/aggregate readings
+                    # (e.g. 7000 W) do not inflate the PD clamp beyond continuous
+                    # rating; live 10036/10038 still set the effective device cap.
                     capped = max(0, min(_HW_MAX_POWER_W, int(value)))
                     snapshot[field["key"]] = capped or _HW_MAX_POWER_W
                     self._dynamic_max_charge_w = snapshot[field["key"]]

--- a/custom_components/omnibattery/frontend/marstek-panel.js
+++ b/custom_components/omnibattery/frontend/marstek-panel.js
@@ -3241,12 +3241,18 @@ class MarstekVenusPanel extends HTMLElement {
     const list = [];
     for (const [dev, ids] of byDevice) {
       const byTk = {};
-      const idByTk = {}; // translation_key -> entity_id (for control service calls)
+      // translation_key -> entity_id (last wins; used for sensors/metrics).
+      // Controls also need domain-qualified lookup so Anker's read-only
+      // max_charge_power sensor is not mistaken for the soft-max number.
+      const idByTk = {};
+      const idByTkDomain = {}; // `${domain}:${translation_key}` -> entity_id
       for (const id of ids) {
         const e = hass.entities[id];
         if (e && e.translation_key) {
           byTk[e.translation_key] = hass.states[id];
           idByTk[e.translation_key] = id;
+          const domain = id.split(".")[0];
+          idByTkDomain[`${domain}:${e.translation_key}`] = id;
         }
       }
       const socObj = byTk[K.batterySoc];
@@ -3313,6 +3319,7 @@ class MarstekVenusPanel extends HTMLElement {
         mppt,
         hasMppt,
         entIds: idByTk,
+        entIdsDomain: idByTkDomain,
         info: {
           sw: this._sval(byTk[K.softwareVersion]),
           serial: (devReg && devReg.serial_number) || null,
@@ -3753,8 +3760,13 @@ class MarstekVenusPanel extends HTMLElement {
 
   _syncControls(r, b) {
     const hass = this._hass;
+    const controlId = (c) =>
+      (b.entIdsDomain && b.entIdsDomain[`${c.domain}:${c.key}`]) ||
+      (b.entIds[c.key] && b.entIds[c.key].startsWith(c.domain + ".")
+        ? b.entIds[c.key]
+        : null);
     const avail = BAT_CONTROLS.filter((c) => {
-      const id = b.entIds[c.key];
+      const id = controlId(c);
       const st = id && hass.states[id];
       // Hide controls with no live value (e.g. stale registry entities left from
       // re-adding a device under a different driver) — their slider is dead anyway.
@@ -3776,7 +3788,7 @@ class MarstekVenusPanel extends HTMLElement {
     }
     for (const c of avail) {
       const w = r.controls[c.key];
-      if (w) this._patchControlRow(w, hass.states[b.entIds[c.key]]);
+      if (w) this._patchControlRow(w, hass.states[controlId(c)]);
     }
   }
 
@@ -3784,8 +3796,12 @@ class MarstekVenusPanel extends HTMLElement {
    *  full-width button), so the parent .bat-ctl-grid aligns labels/controls
    *  across rows and every slider gets the same width. */
   _buildControlRow(r, b, c) {
-    const id = b.entIds[c.key];
-    const state = this._hass.states[id];
+    const id =
+      (b.entIdsDomain && b.entIdsDomain[`${c.domain}:${c.key}`]) ||
+      (b.entIds[c.key] && b.entIds[c.key].startsWith(c.domain + ".")
+        ? b.entIds[c.key]
+        : null);
+    const state = id && this._hass.states[id];
     const frag = document.createDocumentFragment();
 
     const cLabel = this._t(c.lk);

--- a/custom_components/omnibattery/infra/anker_modbus_client.py
+++ b/custom_components/omnibattery/infra/anker_modbus_client.py
@@ -1,4 +1,4 @@
-"""Async Modbus TCP client for Anker SOLIX Solarbank Max AC.
+"""Async Modbus TCP client for Anker SOLIX Solarbank (Max AC / 4 E5000 Pro).
 
 Reads use only FC03 (holding) and FC04 (input) as defined by Anker's official
 ``batch_read_ranges``. Writes target holding addresses with FC06 (uint16) and

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -345,29 +345,27 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
 
     @property
     def needs_software_max_charge(self) -> bool:
-        """True when max_charge_power has no writable register and no sensor.
+        """True when max_charge_power has no writable number entity.
 
-        Zendure exposes chargeMaxLimit only as telemetry, so a software ceiling
-        number entity governs it. Anker exposes 10036 as a read-only sensor —
-        PD follows the device value directly, with no soft-max entity.
+        Zendure exposes chargeMaxLimit only as telemetry (no sensor entity), so a
+        software ceiling number governs it. Anker exposes 10036 as a read-only
+        sensor — still needs a soft-max number so Control Options can set a user
+        ceiling under the hardware cap (PD uses min(device_cap, user limit)).
         """
         if any(d["key"] == "max_charge_power" for d in self.number_definitions):
-            return False
-        if any(d["key"] == "max_charge_power" for d in self.sensor_definitions):
             return False
         return True
 
     @property
     def needs_software_max_discharge(self) -> bool:
-        """True when max_discharge_power has no writable register and no sensor.
+        """True when max_discharge_power has no writable number entity.
 
-        Anker exposes 10038 as a read-only sensor (no soft-max entity). Zendure
-        exposes inverse_max_power as a writable number, so it reports False.
+        Anker exposes 10038 as a read-only sensor and still needs a soft-max
+        number. Zendure exposes inverse_max_power as a writable number, so it
+        reports False.
         """
         writable_keys = {d["key"] for d in self.number_definitions}
         if {"max_discharge_power", "inverse_max_power"} & writable_keys:
-            return False
-        if any(d["key"] == "max_discharge_power" for d in self.sensor_definitions):
             return False
         return True
 
@@ -876,9 +874,9 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             self.min_soc = int(self.data["min_soc"])
         if "max_charge_power" in self.data:
             device_cap = int(self.data["max_charge_power"])
-            # When max_charge_power is a soft-capped telemetry value (Zendure),
-            # honour the user's software ceiling on top of it; otherwise the
-            # polled register/sensor value is itself the effective limit.
+            # Soft-max drivers (Zendure telemetry, Anker read-only sensor) honour
+            # the user's software ceiling on top of the device/hardware cap;
+            # otherwise the polled register value is itself the effective limit.
             self.max_charge_power = (
                 min(device_cap, self.user_max_charge_power)
                 if self.needs_software_max_charge else device_cap

--- a/custom_components/omnibattery/number.py
+++ b/custom_components/omnibattery/number.py
@@ -75,9 +75,9 @@ async def async_setup_entry(
             entities.append(MarstekManualSetPowerNumber(coordinator, "charge"))
             entities.append(MarstekManualSetPowerNumber(coordinator, "discharge"))
 
-        # Drivers whose max_charge_power is telemetry-only with no sensor entity
-        # (Zendure chargeMaxLimit) get a software charge-power ceiling. Anker
-        # exposes 10036/10038 as sensors instead — no soft-max numbers.
+        # Drivers whose max_charge_power is not a writable register (Zendure
+        # chargeMaxLimit telemetry, Anker 10036 read-only sensor) get a software
+        # charge-power ceiling under the device/hardware cap.
         if coordinator.needs_software_max_charge:
             entities.append(MarstekSoftMaxChargeNumber(coordinator))
         if coordinator.needs_software_max_discharge:
@@ -775,8 +775,8 @@ class MarstekManualSetPowerNumber(CoordinatorEntity, NumberEntity):
 
 
 class MarstekSoftMaxChargeNumber(CoordinatorEntity, NumberEntity):
-    """Software charge-power ceiling for drivers whose max_charge_power is
-    telemetry-only with no sensor entity (Zendure chargeMaxLimit).
+    """Software charge-power ceiling when max_charge_power is not writable
+    (Zendure chargeMaxLimit telemetry, Anker input 10036 sensor).
 
     Stores a user limit on the coordinator; the poll loop applies
     min(device_cap, user limit) to coordinator.max_charge_power, which the PD
@@ -825,9 +825,8 @@ class MarstekSoftMaxChargeNumber(CoordinatorEntity, NumberEntity):
 
 
 class MarstekSoftMaxDischargeNumber(CoordinatorEntity, NumberEntity):
-    """Software discharge-power ceiling when max_discharge_power has no register
-    or sensor entity. Anker exposes 10038 as a sensor (no soft-max); this
-    remains for drivers that need a software discharge ceiling.
+    """Software discharge-power ceiling when max_discharge_power has no writable
+    register (Anker input 10038 sensor, or other telemetry-only drivers).
     """
 
     def __init__(self, coordinator: MarstekVenusDataUpdateCoordinator) -> None:

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -43,7 +43,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -82,7 +82,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -503,7 +503,7 @@
       },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
-        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -612,7 +612,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -1022,7 +1022,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",

--- a/custom_components/omnibattery/switch.py
+++ b/custom_components/omnibattery/switch.py
@@ -1340,7 +1340,10 @@ class ManualModeSwitch(SwitchEntity):
                     "Automatic charge/discharge control is paused. "
                     "All batteries have been set to idle (0W). "
                     "You can now manually control each battery using the "
-                    "'Set Forcible Charge/Discharge Power' controls.\n\n"
+                    "'Set Forcible Charge/Discharge Power' controls, or — "
+                    "for Anker — select another operating mode in the "
+                    "official Anker Solix integration without OmniBattery "
+                    "reverting it.\n\n"
                     "Turn off Manual Mode to resume automatic control."
                 ),
                 "notification_id": f"{NOTIFICATION_ID_PREFIX}manual_mode_active",

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -43,7 +43,7 @@
           "brand": "Marca de la bateria"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -495,7 +495,7 @@
       },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
-        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -530,7 +530,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -621,7 +621,7 @@
           "brand": "Marca de la bateria"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -1039,7 +1039,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -43,7 +43,7 @@
           "brand": "Batteriemarke"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -495,7 +495,7 @@
       },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
-        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -530,7 +530,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -621,7 +621,7 @@
           "brand": "Batteriemarke"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -1039,7 +1039,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -43,7 +43,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -489,7 +489,7 @@
       },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
-        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -524,7 +524,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -615,7 +615,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -1027,7 +1027,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -43,7 +43,7 @@
           "brand": "Marca de la batería"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -495,7 +495,7 @@
       },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
-        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -530,7 +530,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -621,7 +621,7 @@
           "brand": "Marca de la batería"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -1039,7 +1039,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -43,7 +43,7 @@
           "brand": "Marque de la batterie"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -495,7 +495,7 @@
       },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
-        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -530,7 +530,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -621,7 +621,7 @@
           "brand": "Marque de la batterie"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -1039,7 +1039,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -43,7 +43,7 @@
           "brand": "Batterijmerk"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -495,7 +495,7 @@
       },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
-        "description": "Update connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. All other settings are preserved.",
+        "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -530,7 +530,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Enter connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Enter connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -621,7 +621,7 @@
           "brand": "Batterijmerk"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
         }
       },
       "battery_connection": {
@@ -1039,7 +1039,7 @@
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
-        "description": "Modify connection details for Anker SOLIX Solarbank Max AC battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
+        "description": "Modify connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. Enable Modbus TCP under Third-Party Control in the Anker app first. Only one Modbus client can connect at a time.",
         "data": {
           "name": "Name",
           "host": "IP Address",

--- a/site-docs/index.es.md
+++ b/site-docs/index.es.md
@@ -1,6 +1,6 @@
 ![Omnibattery](assets/logo-github.png){ width="420" }
 
-**Omnibattery** es una integración personalizada para Home Assistant que monitoriza y controla baterías solares enchufables — Marstek Venus (series E v2/v3, Venus A y Venus D), Zendure SolarFlow (2400 AC+ / AC Pro) y Anker SOLIX Solarbank Max AC — mediante Modbus TCP o HTTP local.
+**Omnibattery** es una integración personalizada para Home Assistant que monitoriza y controla baterías solares enchufables — Marstek Venus (series E v2/v3, Venus A y Venus D), Zendure SolarFlow (2400 AC+ / AC Pro) y Anker SOLIX Solarbank Max AC / 4 E5000 Pro — mediante Modbus TCP o HTTP local.
 
 <div class="grid cards" markdown>
 

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,6 +1,6 @@
 ![Omnibattery](assets/logo-github.png){ width="420" }
 
-**Omnibattery** is a custom Home Assistant integration to monitor and control pluggable solar batteries — Marstek Venus (E v2/v3, Venus A and Venus D series), Zendure SolarFlow (2400 AC+ / AC Pro), and Anker SOLIX Solarbank Max AC — via Modbus TCP or local HTTP.
+**Omnibattery** is a custom Home Assistant integration to monitor and control pluggable solar batteries — Marstek Venus (E v2/v3, Venus A and Venus D series), Zendure SolarFlow (2400 AC+ / AC Pro), and Anker SOLIX Solarbank Max AC / 4 E5000 Pro — via Modbus TCP or local HTTP.
 
 <div class="grid cards" markdown>
 

--- a/site-docs/installation.es.md
+++ b/site-docs/installation.es.md
@@ -6,8 +6,8 @@
 
 | Componente | Descripción |
 |---|---|
-| Batería | Marstek Venus E v2/v3, Venus A, Venus D **o** Zendure SolarFlow 2400 AC+ / AC Pro **o** Anker SOLIX Solarbank Max AC |
-| Conversor Modbus | Dispositivo RS485 → Modbus TCP (p. ej. Elfin-EW11) — **solo necesario para Marstek Venus E v2**. Las Venus E v3, Venus A y Venus D se conectan por Ethernet y soportan Modbus TCP de forma nativa. Anker Solarbank Max AC usa Modbus TCP nativo (activar en la app Anker bajo Third-Party Control; solo un cliente Modbus a la vez). No necesario para Zendure (HTTP local). |
+| Batería | Marstek Venus E v2/v3, Venus A, Venus D **o** Zendure SolarFlow 2400 AC+ / AC Pro **o** Anker SOLIX Solarbank Max AC / 4 E5000 Pro |
+| Conversor Modbus | Dispositivo RS485 → Modbus TCP (p. ej. Elfin-EW11) — **solo necesario para Marstek Venus E v2**. Las Venus E v3, Venus A y Venus D se conectan por Ethernet y soportan Modbus TCP de forma nativa. Anker Solarbank Max AC y 4 E5000 Pro usan Modbus TCP nativo (activar en la app Anker bajo Third-Party Control; solo un cliente Modbus a la vez). No necesario para Zendure (HTTP local). |
 | Adaptador serie *(opcional)* | Adaptador USB–RS485 para conexión serie directa (Modbus RTU) a baterías Marstek. |
 | Sensor de red | Sensor HA que mide el consumo total de la red (p. ej. Shelly EM3, Neurio, contador inteligente) |
 

--- a/site-docs/installation.md
+++ b/site-docs/installation.md
@@ -6,8 +6,8 @@
 
 | Component | Description |
 |---|---|
-| Battery | Marstek Venus E v2/v3, Venus A, Venus D **or** Zendure SolarFlow 2400 AC+ / AC Pro **or** Anker SOLIX Solarbank Max AC |
-| Modbus converter | RS485 → Modbus TCP device (e.g. Elfin-EW11) — **Marstek Venus E v2 only**. Venus E v3, Venus A and Venus D connect via Ethernet and support Modbus TCP natively. Anker Solarbank Max AC uses native Modbus TCP (enable under Third-Party Control in the Anker app; only one Modbus client at a time). Not required for Zendure (local HTTP). |
+| Battery | Marstek Venus E v2/v3, Venus A, Venus D **or** Zendure SolarFlow 2400 AC+ / AC Pro **or** Anker SOLIX Solarbank Max AC / 4 E5000 Pro |
+| Modbus converter | RS485 → Modbus TCP device (e.g. Elfin-EW11) — **Marstek Venus E v2 only**. Venus E v3, Venus A and Venus D connect via Ethernet and support Modbus TCP natively. Anker Solarbank Max AC and 4 E5000 Pro use native Modbus TCP (enable under Third-Party Control in the Anker app; only one Modbus client at a time). Not required for Zendure (local HTTP). |
 | Serial adapter *(optional)* | USB–RS485 adapter for direct serial (Modbus RTU) connection to Marstek batteries. |
 | Grid sensor | HA sensor measuring total grid consumption (e.g. Shelly EM3, Neurio, smart meter integration) |
 

--- a/site-docs/reference/architecture.es.md
+++ b/site-docs/reference/architecture.es.md
@@ -43,7 +43,7 @@ subpaquetes por responsabilidad.
 | `drivers/base.py` | `BatteryDriver`, `DriverCapabilities` | El contrato del driver y el dataclass de rasgos estáticos |
 | `drivers/marstek.py` | `MarstekModbusDriver` | Marstek Venus (v2/v3/vA/vD) por Modbus TCP / RTU |
 | `drivers/zendure.py` | `ZendureLocalDriver` | Zendure SolarFlow por HTTP local |
-| `drivers/anker.py` | `AnkerModbusDriver` | Anker SOLIX Solarbank Max AC por Modbus TCP (lecturas FC03/FC04) |
+| `drivers/anker.py` | `AnkerModbusDriver` | Anker SOLIX Solarbank Max AC / 4 E5000 Pro por Modbus TCP (lecturas FC03/FC04) |
 | `infra/coordinator.py` | `MarstekVenusDataUpdateCoordinator` | Polling periódico de telemetría (vía el driver), actualización de entidades |
 | `infra/modbus_client.py` | `MarstekModbusClient` | Transporte Modbus TCP/RTU asíncrono con pymodbus, reintentos con backoff |
 | `infra/anker_modbus_client.py` | `AnkerModbusClient` | Modbus TCP asíncrono para Anker (lecturas FC03/FC04, escrituras FC06/FC16) |

--- a/site-docs/reference/architecture.md
+++ b/site-docs/reference/architecture.md
@@ -43,7 +43,7 @@ subpackages by responsibility.
 | `drivers/base.py` | `BatteryDriver`, `DriverCapabilities` | The driver contract and the static-traits dataclass |
 | `drivers/marstek.py` | `MarstekModbusDriver` | Marstek Venus (v2/v3/vA/vD) over Modbus TCP / RTU |
 | `drivers/zendure.py` | `ZendureLocalDriver` | Zendure SolarFlow over local HTTP |
-| `drivers/anker.py` | `AnkerModbusDriver` | Anker SOLIX Solarbank Max AC over Modbus TCP (FC03/FC04 reads) |
+| `drivers/anker.py` | `AnkerModbusDriver` | Anker SOLIX Solarbank Max AC / 4 E5000 Pro over Modbus TCP (FC03/FC04 reads) |
 | `infra/coordinator.py` | `MarstekVenusDataUpdateCoordinator` | Periodic telemetry polling (via the driver), entity updates |
 | `infra/modbus_client.py` | `MarstekModbusClient` | Async Modbus TCP/RTU transport via pymodbus, retries with backoff |
 | `infra/anker_modbus_client.py` | `AnkerModbusClient` | Async Modbus TCP for Anker (FC03/FC04 reads, FC06/FC16 writes) |

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -61,8 +61,9 @@ def test_model_label():
 
 def test_power_caps_are_read_only_sensors():
     """Hardware max charge/discharge (10036/10038) are sensors only — not
-    writable numbers and not setup sliders. Soft-max entities must not claim
-    the same unique_ids."""
+    writable driver number definitions. Soft-max number entities are created
+    separately by the coordinator (needs_software_max_*) under the hardware cap.
+    """
     from custom_components.omnibattery.drivers import anker as anker_mod
 
     sensor_keys = {d["key"] for d in anker_mod.SENSOR_DEFINITIONS}
@@ -109,21 +110,15 @@ def test_encode_int32_roundtrip():
 # connect / mode
 # ----------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_connect_sets_third_party_mode_when_needed():
+async def test_connect_does_not_force_third_party_mode():
+    """Connect must not write operating mode — Manual Mode idle can leave Solix
+    modes alone; Third-Party is ensured only on apply_setpoint."""
     client = _fake_client()
     client.async_read_holding_register = AsyncMock(return_value=0)
     drv = _driver(client=client)
     assert await drv.connect() is True
-    client.async_write_register.assert_awaited_with(10064, 3)
-
-
-@pytest.mark.asyncio
-async def test_connect_skips_mode_write_when_already_third_party():
-    client = _fake_client()
-    client.async_read_holding_register = AsyncMock(return_value=3)
-    drv = _driver(client=client)
-    assert await drv.connect() is True
     client.async_write_register.assert_not_awaited()
+    client.async_read_holding_register.assert_not_awaited()
 
 
 # ----------------------------------------------------------------------
@@ -251,6 +246,17 @@ async def test_read_telemetry_uses_fc03_for_operating_mode_and_soc_limits():
 # ----------------------------------------------------------------------
 # apply_setpoint
 # ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_apply_setpoint_ensures_third_party_mode_when_needed():
+    client = _fake_client()
+    client.async_read_holding_register = AsyncMock(return_value=0)
+    drv = _driver(client=client)
+    result = await drv.apply_setpoint(500)
+    assert result.ok is True
+    client.async_write_register.assert_awaited_with(10064, 3)
+    client.async_write_registers_int32.assert_awaited_with(10071, -500)
+
+
 @pytest.mark.asyncio
 async def test_apply_setpoint_charge_writes_negative_wire_value():
     client = _fake_client()

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Anker Solarbank Max AC Modbus driver."""
+"""Unit tests for the Anker Solarbank Max AC / 4 E5000 Pro Modbus driver."""
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, call
@@ -59,6 +59,17 @@ def test_model_label():
     assert _driver().model_label == "Solarbank Max AC"
 
 
+def test_label_for_product_code_maps_official_skus():
+    from custom_components.omnibattery.drivers.anker import _label_for_product_code
+
+    assert _label_for_product_code("DN7M") == "Solarbank 4 E5000 Pro"
+    assert _label_for_product_code("dpm4") == "Solarbank 4 E5000 Pro"
+    assert _label_for_product_code("DMWH") == "Solarbank Max AC"
+    assert _label_for_product_code("DNMS") == "Solarbank XE AC"
+    assert _label_for_product_code(None) == "Solarbank Max AC"
+    assert _label_for_product_code("ZZZZ") == "Solarbank Max AC"
+
+
 def test_power_caps_are_read_only_sensors():
     """Hardware max charge/discharge (10036/10038) are sensors only — not
     writable driver number definitions. Soft-max number entities are created
@@ -115,10 +126,22 @@ async def test_connect_does_not_force_third_party_mode():
     modes alone; Third-Party is ensured only on apply_setpoint."""
     client = _fake_client()
     client.async_read_holding_register = AsyncMock(return_value=0)
+    client.async_read_input_block = AsyncMock(return_value=[0x444E, 0x374D, 0, 0, 0])  # DN7M
     drv = _driver(client=client)
     assert await drv.connect() is True
     client.async_write_register.assert_not_awaited()
     client.async_read_holding_register.assert_not_awaited()
+    assert drv.model_label == "Solarbank 4 E5000 Pro"
+
+
+@pytest.mark.asyncio
+async def test_connect_maps_max_ac_product_code():
+    client = _fake_client()
+    # DMWH
+    client.async_read_input_block = AsyncMock(return_value=[0x444D, 0x5748, 0, 0, 0])
+    drv = _driver(client=client)
+    assert await drv.connect() is True
+    assert drv.model_label == "Solarbank Max AC"
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_coordinator_driver_capabilities.py
+++ b/tests/test_coordinator_driver_capabilities.py
@@ -31,6 +31,53 @@ def test_inverse_max_power_is_a_hardware_discharge_limit():
     )
 
 
+def test_anker_needs_software_max_despite_read_only_sensors():
+    """Anker exposes 10036/10038 as sensors; soft-max numbers still gate PD."""
+    from custom_components.omnibattery.drivers import anker as anker_mod
+
+    coordinator = SimpleNamespace(
+        number_definitions=list(anker_mod.NUMBER_DEFINITIONS),
+        sensor_definitions=list(anker_mod.SENSOR_DEFINITIONS),
+        select_definitions=list(anker_mod.SELECT_DEFINITIONS),
+    )
+
+    assert (
+        MarstekVenusDataUpdateCoordinator.needs_software_max_charge.fget(coordinator)
+        is True
+    )
+    assert (
+        MarstekVenusDataUpdateCoordinator.needs_software_max_discharge.fget(
+            coordinator
+        )
+        is True
+    )
+    assert (
+        MarstekVenusDataUpdateCoordinator.needs_software_manual_control.fget(
+            coordinator
+        )
+        is True
+    )
+
+
+def test_marstek_writable_max_charge_skips_software_max():
+    coordinator = SimpleNamespace(
+        number_definitions=[{"key": "max_charge_power"}, {"key": "max_discharge_power"}],
+        sensor_definitions=[],
+        select_definitions=[{"key": "force_mode"}],
+    )
+
+    assert (
+        MarstekVenusDataUpdateCoordinator.needs_software_max_charge.fget(coordinator)
+        is False
+    )
+    assert (
+        MarstekVenusDataUpdateCoordinator.needs_software_max_discharge.fget(
+            coordinator
+        )
+        is False
+    )
+
+
 async def test_reconnect_skips_rs485_for_driver_without_capability():
     driver = SimpleNamespace(connect=AsyncMock(return_value=True))
     coordinator = SimpleNamespace(

--- a/tests/test_software_manual_idle.py
+++ b/tests/test_software_manual_idle.py
@@ -1,0 +1,66 @@
+"""Manual Mode idle must not reassert 0 W (Anker Third-Party release)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.omnibattery import ChargeDischargeController
+
+
+@pytest.mark.asyncio
+async def test_software_manual_idle_skips_zero_watt_reassert():
+    """Idle force mode must not call _set_battery_power — that would force
+    Anker Third-Party Control every control cycle while Manual Mode is on."""
+    controller = ChargeDischargeController.__new__(ChargeDischargeController)
+    coord = SimpleNamespace(
+        needs_software_manual_control=True,
+        manual_force_mode=None,
+        manual_set_charge_power=0,
+        manual_set_discharge_power=0,
+    )
+    controller.coordinators = [coord]
+    controller._set_battery_power = AsyncMock()
+
+    await ChargeDischargeController._apply_software_manual_setpoints(controller)
+
+    controller._set_battery_power.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_software_manual_charge_still_asserts_setpoint():
+    controller = ChargeDischargeController.__new__(ChargeDischargeController)
+    coord = SimpleNamespace(
+        needs_software_manual_control=True,
+        manual_force_mode="Charge",
+        manual_set_charge_power=1200,
+        manual_set_discharge_power=0,
+    )
+    controller.coordinators = [coord]
+    controller._set_battery_power = AsyncMock()
+
+    await ChargeDischargeController._apply_software_manual_setpoints(controller)
+
+    controller._set_battery_power.assert_awaited_once_with(
+        coord, 1200, 0, bypass_blockers=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_software_manual_discharge_still_asserts_setpoint():
+    controller = ChargeDischargeController.__new__(ChargeDischargeController)
+    coord = SimpleNamespace(
+        needs_software_manual_control=True,
+        manual_force_mode="Discharge",
+        manual_set_charge_power=0,
+        manual_set_discharge_power=800,
+    )
+    controller.coordinators = [coord]
+    controller._set_battery_power = AsyncMock()
+
+    await ChargeDischargeController._apply_software_manual_setpoints(controller)
+
+    controller._set_battery_power.assert_awaited_once_with(
+        coord, 0, 800, bypass_blockers=True
+    )


### PR DESCRIPTION
## Summary
- Stop re-forcing Anker Third-Party Control while Manual Mode is idle so Solix app modes stick (feedback on #134).
- Add a real watt soft-max Max Charge/Discharge slider for Anker instead of binding the read-only sensor as a broken 0–100 control.
- Advertise Solarbank 4 E5000 Pro on the shared Anker Modbus map with product-code model labels.

Fixes #134

## Test plan
- [ ] Anker Max AC: enable Manual Mode, switch operating mode in official Anker Solix integration — mode should not snap back to Third-Party within ~10s
- [ ] Anker Max AC: Control Options Max Charge slider stays in watts with device min/max; lowering persists and clamps PD charge power
- [ ] Add Solarbank 4 E5000 Pro via Anker brand option; model label resolves from product code; charge/discharge control works
- [ ] Unit tests: `pytest tests/test_anker_driver.py tests/test_coordinator_driver_capabilities.py tests/test_software_manual_idle.py`


Made with [Cursor](https://cursor.com)