### PR TITLE
Surface unusable price and forecast data as Repairs issues

### DIFF
--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -147,6 +147,7 @@ from .const import (
     SLOW_SENSOR_WARNING_INTERVAL_S,
     MAX_SENSOR_STALE_S,
     SLOW_SENSOR_WARN_INTERVALS,
+    FORECAST_DATA_ISSUE_DELAY_S,
     FAST_ACTUATOR_MAX_LATENCY_S,
     DISCHARGE_ENGAGE_GRACE_S,
     IDLE_RUNAWAY_POWER_W,
@@ -630,6 +631,13 @@ class ChargeDischargeController:
         self._dp_eval_retry_count = 0  # Retry counter if tomorrow prices not available at 23:00
         self._dp_pre_evaluated_slots: dict = {}  # slot.start (datetime) → should_charge (bool)
         self._price_data_status = "not_evaluated"
+        self._price_health_last_check = None      # monotonic ts of last health poll
+        self._price_data_bad_since = None         # monotonic ts price parsing started failing
+        self._price_data_issue_created = False    # at most one Repairs creation per controller run
+        self._price_data_issue_cleared = False    # first healthy check clears an issue persisted from an earlier run
+        self._solar_forecast_bad_since = None     # monotonic ts the forecast sensor became unreadable
+        self._solar_forecast_issue_created = False
+        self._solar_forecast_issue_cleared = False
         self._dp_evening_reevaluated_date = None  # Prevent multiple evening re-evaluations per day
         self._dp_last_eval_soc = None  # avg SOC at last DP (re)eval; SOC-drop reeval reference (#411)
         self._pricing_mgr = PricingManager(hass, self)
@@ -4484,6 +4492,72 @@ class ChargeDischargeController:
         )
         return 0
 
+    def _check_solar_forecast_health(self):
+        """Raise one repair per run when the solar forecast stays unreadable.
+
+        Every consumer degrades quietly on its own: the charge delay unlocks for the
+        rest of the day, ``_should_activate_grid_charging`` switches to conservative
+        mode and books grid slots as if the day had no sun, and
+        ``_remaining_solar_today_kwh`` simply returns 0. So a dead forecast sensor
+        costs money without ever surfacing anywhere the user looks.
+
+        Only a sensor that IS configured can be broken; leaving it unset is a
+        deliberate choice that merely disables the features above. The delay is long
+        enough to ride out a provider outage or the midnight rollover gap that
+        ``_forecast_grace_s`` already covers for the delay latch itself.
+        """
+        issue_id = f"solar_forecast_unusable_{self.config_entry.entry_id}"
+
+        usable = False
+        if self.solar_forecast_sensor:
+            state = self.hass.states.get(self.solar_forecast_sensor)
+            if state is not None and state.state not in ("unknown", "unavailable"):
+                try:
+                    float(state.state)
+                    usable = True
+                except (ValueError, TypeError):
+                    usable = False
+
+        if usable or not self.solar_forecast_sensor:
+            self._solar_forecast_bad_since = None
+            if not self._solar_forecast_issue_cleared:
+                self._solar_forecast_issue_cleared = True
+                self._solar_forecast_issue_created = False
+                ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            return
+
+        mono = time.monotonic()
+        if self._solar_forecast_bad_since is None:
+            self._solar_forecast_bad_since = mono
+            return
+        if (
+            self._solar_forecast_issue_created
+            or mono - self._solar_forecast_bad_since < FORECAST_DATA_ISSUE_DELAY_S
+        ):
+            return
+
+        self._solar_forecast_issue_created = True
+        self._solar_forecast_issue_cleared = False
+        _LOGGER.warning(
+            "Solar forecast sensor %s unreadable for over %.0f minutes - charge delay, "
+            "grid-charge decisions and remaining-solar estimates are running blind",
+            self.solar_forecast_sensor, FORECAST_DATA_ISSUE_DELAY_S / 60,
+        )
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            is_persistent=True,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="solar_forecast_unusable",
+            translation_placeholders={
+                "sensor": self.solar_forecast_sensor,
+                "minutes": f"{FORECAST_DATA_ISSUE_DELAY_S / 60:.0f}",
+            },
+        )
+
     def _check_sensor_cadence(self, sensor_elapsed_s):
         """Raise one repair per run when the main sensor cadence is slow.
 
@@ -4582,6 +4656,14 @@ class ChargeDischargeController:
         if self._balance_monitor is not None:
             for coordinator in self.coordinators:
                 await self._balance_monitor.async_process(coordinator)
+
+        # === PRICE FEED HEALTH ===
+        # Slow-timer poll that raises/clears the price-data repair. Like the
+        # accumulators above it must not sit behind an early return: manual mode,
+        # a max-SOC charge taking ownership or a price-independent predictive mode
+        # would otherwise starve it, and a persistent issue raised earlier could
+        # never be cleared. Self-throttled, so running it every cycle is cheap.
+        self._pricing_mgr.maybe_check_price_data_health()
 
         # === MANUAL MODE CHECK (highest priority) ===
         # If manual mode is enabled, skip all automatic control logic
@@ -4698,6 +4780,10 @@ class ChargeDischargeController:
         # samples, so a 60 s sensor could never reach the warning threshold.
         if not is_stale:
             self._check_sensor_cadence(sensor_elapsed_s)
+
+        # Same cadence, different failure: a configured solar-forecast sensor that
+        # stops reading. Cheap state lookup, so no extra throttle.
+        self._check_solar_forecast_health()
 
         # Generic safety recalc on a silent sensor must re-evaluate structural state
         # (SOC/limits/blockers) but must NOT integrate the P term: the grid error is

--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -279,6 +279,22 @@ MAX_SENSOR_STALE_S = 65.0
 # gap from flagging an otherwise fast sensor.
 SLOW_SENSOR_WARN_INTERVALS = 3
 
+# How often the dynamic-pricing handler re-parses the price sensor purely to
+# refresh _price_data_status for the health check. The parse itself is cheap but
+# pointless every 2.5 s control cycle, and price attributes change hourly at most.
+PRICE_HEALTH_CHECK_INTERVAL_S = 900.0
+
+# How long price parsing must keep failing before a Repairs issue is raised.
+# Long enough to ride out an integration reload, a provider outage or the
+# day-ahead publication gap; short enough that a broken sensor is noticed the
+# same day instead of silently disabling price-aware charging for weeks.
+PRICE_DATA_ISSUE_DELAY_S = 7200.0
+
+# How long a configured solar-forecast sensor must stay unreadable before a
+# Repairs issue is raised. Same reasoning as the price feed: long enough to ride
+# out a provider outage, short enough to catch a dead sensor the same day.
+FORECAST_DATA_ISSUE_DELAY_S = 7200.0
+
 # An actuator at or below this latency (seconds, DriverCapabilities.actuator_latency_s)
 # reaches its setpoint and reflects it in telemetry within one poll. Such drivers do
 # the hot-path readback and use the measured-power feedforward; slower ones (Zendure

--- a/custom_components/omnibattery/pricing/engine.py
+++ b/custom_components/omnibattery/pricing/engine.py
@@ -17,9 +17,15 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta
+from time import monotonic
 from typing import TYPE_CHECKING, Any, Optional
 
+from homeassistant.helpers import issue_registry as ir
+
 from ..const import (
+    DOMAIN,
+    PRICE_DATA_ISSUE_DELAY_S,
+    PRICE_HEALTH_CHECK_INTERVAL_S,
     PRICE_INTEGRATION_NORDPOOL,
     PRICE_INTEGRATION_PVPC,
     PRICE_INTEGRATION_CKW,
@@ -50,6 +56,16 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
+
+# Sensor attributes each integration expects to hold a LIST of price entries.
+# Used only to detect an attribute that arrived as a string; PVPC is absent
+# because it reads scalar per-hour attributes, not a list.
+_PRICE_LIST_ATTRS = {
+    PRICE_INTEGRATION_NORDPOOL: ("raw_today", "raw_tomorrow"),
+    PRICE_INTEGRATION_CKW: ("prices",),
+    PRICE_INTEGRATION_EPEX: ("data",),
+    PRICE_INTEGRATION_ENTSOE: ("prices_today", "prices_tomorrow"),
+}
 
 
 class PricingManager:
@@ -330,6 +346,119 @@ class PricingManager:
         await self._maybe_refresh_tibber_prices(force=force)
         await self._maybe_refresh_nordpool_prices(force=force)
 
+    def maybe_check_price_data_health(self) -> None:
+        """Periodically re-parse prices and raise/clear the price-data Repairs issue.
+
+        ``_price_data_status`` is only refreshed when something actually asks for
+        prices. In dynamic-pricing mode that is the 00:05 evaluation and whatever
+        the control loop happens to need, so a price sensor that stops delivering
+        usable slots can go unnoticed for days: charging silently falls back to its
+        no-price behaviour and only an attribute buried on the predictive-charging
+        binary sensor says why. Poll it on a slow timer instead and surface a
+        sustained failure in Repairs.
+        """
+        ctrl = self._controller
+        mono = monotonic()
+
+        if not self._prices_are_load_bearing():
+            # Feature off, or a mode that does not consume price slots: prices
+            # cannot be "broken" here. Clear a stale issue (it is persistent, so it
+            # can outlive the run that raised it) and stop tracking.
+            ctrl._price_data_bad_since = None
+            self._clear_price_data_issue()
+            return
+
+        last = ctrl._price_health_last_check
+        if last is not None and mono - last < PRICE_HEALTH_CHECK_INTERVAL_S:
+            return
+        ctrl._price_health_last_check = mono
+        self._parse_price_data(quiet=True)  # refreshes _price_data_status
+        self._update_price_data_issue(mono)
+
+    def _prices_are_load_bearing(self) -> bool:
+        """Whether something in this configuration actually consumes price slots.
+
+        Dynamic pricing schedules from them directly. Real-time price mode charges
+        off the scalar current price, so slots only matter there for the charge
+        delay's price-aware release — without it a slot-less sensor is no defect
+        and must not raise a repair.
+        """
+        ctrl = self._controller
+        if not getattr(ctrl, "predictive_charging_enabled", False):
+            return False
+        mode = getattr(ctrl, "predictive_charging_mode", None)
+        if mode == PREDICTIVE_MODE_DYNAMIC_PRICING:
+            return True
+        return mode == PREDICTIVE_MODE_REALTIME_PRICE and bool(
+            getattr(ctrl, "charge_delay_enabled", False)
+        )
+
+    def _clear_price_data_issue(self) -> None:
+        """Delete the price-data issue, at most once per controller run.
+
+        The issue is created with ``is_persistent=True``, so it survives a restart
+        while ``_price_data_issue_created`` does not. Keying the delete on that flag
+        would therefore strand an issue raised in an earlier run forever. Key it on
+        a separate "already cleared this run" flag instead, so the first healthy
+        check after any start removes a stale issue.
+        """
+        ctrl = self._controller
+        if ctrl._price_data_issue_cleared:
+            return
+        ctrl._price_data_issue_cleared = True
+        ctrl._price_data_issue_created = False
+        ir.async_delete_issue(
+            ctrl.hass, DOMAIN, f"price_data_unusable_{ctrl.config_entry.entry_id}"
+        )
+
+    def _update_price_data_issue(self, mono: float) -> None:
+        """Create or clear the Repairs issue for unusable price data.
+
+        Only a failure sustained for ``PRICE_DATA_ISSUE_DELAY_S`` raises the issue,
+        so an integration reload, a provider outage or the day-ahead publication gap
+        does not flap it. Mirrors the slow-sensor repair: at most one creation per
+        controller run, cleared as soon as prices parse again.
+        """
+        ctrl = self._controller
+        status = ctrl._price_data_status or ""
+
+        if status.startswith("ok"):
+            ctrl._price_data_bad_since = None
+            self._clear_price_data_issue()
+            return
+
+        if ctrl._price_data_bad_since is None:
+            ctrl._price_data_bad_since = mono
+            return
+        if (
+            ctrl._price_data_issue_created
+            or mono - ctrl._price_data_bad_since < PRICE_DATA_ISSUE_DELAY_S
+        ):
+            return
+
+        ctrl._price_data_issue_created = True
+        ctrl._price_data_issue_cleared = False
+        _LOGGER.warning(
+            "Dynamic pricing: price data unusable (%s) for over %.0f minutes - "
+            "price-aware charging is inactive",
+            status, PRICE_DATA_ISSUE_DELAY_S / 60,
+        )
+        ir.async_create_issue(
+            ctrl.hass,
+            DOMAIN,
+            f"price_data_unusable_{ctrl.config_entry.entry_id}",
+            is_fixable=False,
+            is_persistent=True,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="price_data_unusable",
+            translation_placeholders={
+                "sensor": ctrl.price_sensor or "-",
+                "status": status,
+                "minutes": f"{PRICE_DATA_ISSUE_DELAY_S / 60:.0f}",
+            },
+        )
+
     def get_future_price_slots(self, horizon_end=None) -> list:
         """Public accessor for parsed future PriceSlots (today, future-only).
 
@@ -376,6 +505,27 @@ class PricingManager:
                 return []
 
             attrs = state.attributes
+            # A template-built price sensor whose attribute renders to something
+            # Home Assistant cannot literal_eval (e.g. a list containing datetime
+            # objects) lands here as a plain string. Iterating it would walk single
+            # characters, and every per-entry parse failure is debug-level, so the
+            # integration would silently run without prices. Catch the type here.
+            stringified = [
+                key
+                for key in _PRICE_LIST_ATTRS.get(self._controller.price_integration_type, ())
+                if isinstance(attrs.get(key), str)
+            ]
+            if stringified:
+                _warn(
+                    "Dynamic pricing: price sensor %s exposes attribute(s) %s as a string "
+                    "instead of a list — the sensor's template most likely renders values "
+                    "(e.g. datetimes) that Home Assistant cannot convert back to a list. "
+                    "Emit ISO-8601 strings instead.",
+                    self._controller.price_sensor, ", ".join(stringified),
+                )
+                self._controller._price_data_status = "bad_format"
+                return []
+
             if self._controller.price_integration_type == PRICE_INTEGRATION_PVPC:
                 raw_slots = calculations.parse_pvpc_prices(attrs)
             elif self._controller.price_integration_type == PRICE_INTEGRATION_CKW:
@@ -403,7 +553,16 @@ class PricingManager:
         end_of_day = now.replace(hour=23, minute=59, second=59, microsecond=0)
         effective_horizon = horizon_end if horizon_end is not None else end_of_day
         filtered = [s for s in raw_slots if s.end > now and s.start <= effective_horizon]
-        self._controller._price_data_status = f"ok ({len(filtered)} slots)"
+        # Slots that parse but all lie in the past leave price-aware charging just as
+        # dead as a parse failure (e.g. a template sensor frozen on yesterday's
+        # entries), so this is a distinct status rather than "ok (0 slots)" — the
+        # latter reads as healthy to the health check. In normal operation the
+        # horizon only empties in the last minutes before midnight, far short of the
+        # sustained window that raises a repair.
+        if not filtered:
+            self._controller._price_data_status = "no_future_slots"
+        else:
+            self._controller._price_data_status = f"ok ({len(filtered)} slots)"
         (_LOGGER.debug if quiet else _LOGGER.info)(
             "Dynamic pricing: parsed %d slots (%d within horizon)", len(raw_slots), len(filtered)
         )

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -3,6 +3,14 @@
     "slow_main_sensor": {
       "title": "Grid power sensor updates too slowly",
       "description": "The configured grid sensor {sensor} updates about every {observed_interval} seconds. Updates every {warning_interval} seconds or more are slower than recommended and may reduce regulation quality. Omnibattery still follows the latest reading until it is more than {stale_limit} seconds old. Use a faster sensor if you need tighter real-time control."
+    },
+    "price_data_unusable": {
+      "title": "Price data unusable",
+      "description": "Omnibattery could not parse usable price slots from {sensor} for over {minutes} minutes (status: {status}). Price-aware charging is inactive: dynamic-pricing scheduling and the price-aware charge-delay release fall back to their no-price behaviour. Check that the sensor is available and that its price attribute is a list of entries; a template sensor must emit ISO-8601 timestamps, because a rendered Python datetime cannot be converted back into a list."
+    },
+    "solar_forecast_unusable": {
+      "title": "Solar forecast unusable",
+      "description": "The configured solar forecast sensor {sensor} has been unavailable or unreadable for over {minutes} minutes. Omnibattery keeps running, but every feature that depends on the forecast is now blind: the charge delay unlocks for the rest of the day, grid-charge decisions assume no sun at all and may book grid slots you do not need, and remaining-solar estimates read as 0 kWh. Check the sensor or the integration that provides it."
     }
   },
   "config": {

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -3,6 +3,14 @@
     "slow_main_sensor": {
       "title": "El sensor de potència de xarxa s'actualitza massa lentament",
       "description": "El sensor de xarxa configurat {sensor} s'actualitza aproximadament cada {observed_interval} segons. Els intervals de {warning_interval} segons o més són més lents del recomanat i poden reduir la qualitat de la regulació. Omnibattery segueix l'última lectura fins que supera els {stale_limit} segons d'antiguitat. Utilitza un sensor més ràpid si necessites un control en temps real més precís."
+    },
+    "price_data_unusable": {
+      "title": "Dades de preus inutilitzables",
+      "description": "Omnibattery no ha pogut llegir franges de preu utilitzables de {sensor} durant més de {minutes} minuts (estat: {status}). La càrrega basada en preus està inactiva: la planificació de preus dinàmics i l'alliberament per preu del retard de càrrega tornen al seu comportament sense preus. Comproveu que el sensor estigui disponible i que el seu atribut de preus sigui una llista d'entrades; un sensor de plantilla ha d'emetre marques de temps ISO-8601, perquè un datetime de Python renderitzat no es pot tornar a convertir en una llista."
+    },
+    "solar_forecast_unusable": {
+      "title": "Previsió solar inutilitzable",
+      "description": "El sensor de previsió solar configurat {sensor} fa més de {minutes} minuts que no està disponible o no es pot llegir. Omnibattery continua funcionant, però tot allò que depèn de la previsió va a cegues: el retard de càrrega s'allibera la resta del dia, les decisions de càrrega des de la xarxa assumeixen que no hi haurà sol i poden reservar franges innecessàries, i l'estimació de sol restant marca 0 kWh. Reviseu el sensor o la integració que el proporciona."
     }
   },
   "config": {

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -3,6 +3,14 @@
     "slow_main_sensor": {
       "title": "Der Netzleistungssensor aktualisiert zu langsam",
       "description": "Der konfigurierte Netzsensor {sensor} aktualisiert ungefähr alle {observed_interval} Sekunden. Intervalle von {warning_interval} Sekunden oder mehr sind langsamer als empfohlen und können die Regelqualität verringern. Omnibattery folgt dem letzten Messwert, bis er älter als {stale_limit} Sekunden ist. Verwenden Sie einen schnelleren Sensor, wenn Sie eine präzisere Echtzeitregelung benötigen."
+    },
+    "price_data_unusable": {
+      "title": "Preisdaten unbrauchbar",
+      "description": "Omnibattery konnte über {minutes} Minuten lang keine nutzbaren Preisslots aus {sensor} lesen (Status: {status}). Preisgesteuertes Laden ist dadurch inaktiv: die Planung nach dynamischen Preisen und die preisgesteuerte Freigabe der Ladeverzögerung fallen auf ihr Verhalten ohne Preise zurück. Prüfen Sie, ob der Sensor verfügbar ist und sein Preisattribut eine Liste von Einträgen enthält; ein Template-Sensor muss ISO-8601-Zeitstempel liefern, da ein gerendertes Python-datetime nicht zurück in eine Liste umgewandelt werden kann."
+    },
+    "solar_forecast_unusable": {
+      "title": "Solarprognose unbrauchbar",
+      "description": "Der konfigurierte Solarprognose-Sensor {sensor} ist seit über {minutes} Minuten nicht verfügbar oder nicht lesbar. Omnibattery läuft weiter, aber alles, was auf der Prognose beruht, arbeitet blind: die Ladeverzögerung gibt für den Rest des Tages frei, Entscheidungen zum Netzladen gehen von gar keiner Sonne aus und buchen womöglich unnötige Netzslots, und die Restsonnen-Schätzung liest 0 kWh. Prüfen Sie den Sensor oder die Integration, die ihn liefert."
     }
   },
   "config": {

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -3,6 +3,14 @@
     "slow_main_sensor": {
       "title": "Grid power sensor updates too slowly",
       "description": "The configured grid sensor {sensor} updates about every {observed_interval} seconds. Updates every {warning_interval} seconds or more are slower than recommended and may reduce regulation quality. Omnibattery still follows the latest reading until it is more than {stale_limit} seconds old. Use a faster sensor if you need tighter real-time control."
+    },
+    "price_data_unusable": {
+      "title": "Price data unusable",
+      "description": "Omnibattery could not parse usable price slots from {sensor} for over {minutes} minutes (status: {status}). Price-aware charging is inactive: dynamic-pricing scheduling and the price-aware charge-delay release fall back to their no-price behaviour. Check that the sensor is available and that its price attribute is a list of entries; a template sensor must emit ISO-8601 timestamps, because a rendered Python datetime cannot be converted back into a list."
+    },
+    "solar_forecast_unusable": {
+      "title": "Solar forecast unusable",
+      "description": "The configured solar forecast sensor {sensor} has been unavailable or unreadable for over {minutes} minutes. Omnibattery keeps running, but every feature that depends on the forecast is now blind: the charge delay unlocks for the rest of the day, grid-charge decisions assume no sun at all and may book grid slots you do not need, and remaining-solar estimates read as 0 kWh. Check the sensor or the integration that provides it."
     }
   },
   "config": {

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -3,6 +3,14 @@
     "slow_main_sensor": {
       "title": "El sensor de potencia de red actualiza demasiado despacio",
       "description": "El sensor de red configurado {sensor} actualiza aproximadamente cada {observed_interval} segundos. Los intervalos de {warning_interval} segundos o más son más lentos de lo recomendado y pueden reducir la calidad de la regulación. Omnibattery sigue la última lectura hasta que supera los {stale_limit} segundos de antigüedad. Usa un sensor más rápido si necesitas un control más preciso en tiempo real."
+    },
+    "price_data_unusable": {
+      "title": "Datos de precios inutilizables",
+      "description": "Omnibattery no pudo obtener franjas de precio utilizables de {sensor} durante más de {minutes} minutos (estado: {status}). La carga basada en precios está inactiva: la planificación de precios dinámicos y la liberación por precio del retardo de carga vuelven a su comportamiento sin precios. Compruebe que el sensor está disponible y que su atributo de precios es una lista de entradas; un sensor de plantilla debe emitir marcas de tiempo ISO-8601, porque un datetime de Python renderizado no se puede convertir de nuevo en una lista."
+    },
+    "solar_forecast_unusable": {
+      "title": "Previsión solar inutilizable",
+      "description": "El sensor de previsión solar configurado {sensor} lleva más de {minutes} minutos no disponible o ilegible. Omnibattery sigue funcionando, pero todo lo que depende de la previsión está a ciegas: el retardo de carga se libera durante el resto del día, las decisiones de carga desde red asumen que no habrá sol y pueden reservar franjas innecesarias, y la estimación de sol restante marca 0 kWh. Revise el sensor o la integración que lo proporciona."
     }
   },
   "config": {

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -3,6 +3,14 @@
     "slow_main_sensor": {
       "title": "Le capteur de puissance réseau se met à jour trop lentement",
       "description": "Le capteur réseau configuré {sensor} se met à jour environ toutes les {observed_interval} secondes. Des intervalles de {warning_interval} secondes ou plus sont plus lents que recommandé et peuvent réduire la qualité de régulation. Omnibattery suit la dernière mesure jusqu'à ce qu'elle date de plus de {stale_limit} secondes. Utilisez un capteur plus rapide si vous avez besoin d'un contrôle temps réel plus précis."
+    },
+    "price_data_unusable": {
+      "title": "Données tarifaires inutilisables",
+      "description": "Omnibattery n'a pas pu lire de créneaux tarifaires exploitables depuis {sensor} pendant plus de {minutes} minutes (état : {status}). La charge pilotée par les prix est inactive : la planification en tarification dynamique et la libération du report de charge selon le prix reviennent à leur comportement sans prix. Vérifiez que le capteur est disponible et que son attribut de prix est une liste d'entrées ; un capteur de type template doit produire des horodatages ISO-8601, car un datetime Python rendu ne peut pas être reconverti en liste."
+    },
+    "solar_forecast_unusable": {
+      "title": "Prévision solaire inutilisable",
+      "description": "Le capteur de prévision solaire configuré {sensor} est indisponible ou illisible depuis plus de {minutes} minutes. Omnibattery continue de fonctionner, mais tout ce qui dépend de la prévision avance à l'aveugle : le report de charge se libère pour le reste de la journée, les décisions de charge depuis le réseau supposent une absence totale de soleil et peuvent réserver des créneaux inutiles, et l'estimation du solaire restant indique 0 kWh. Vérifiez le capteur ou l'intégration qui le fournit."
     }
   },
   "config": {

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -3,6 +3,14 @@
     "slow_main_sensor": {
       "title": "De netvermogenssensor werkt te langzaam bij",
       "description": "De geconfigureerde netsensor {sensor} werkt ongeveer elke {observed_interval} seconden bij. Intervallen van {warning_interval} seconden of meer zijn trager dan aanbevolen en kunnen de regelkwaliteit verminderen. Omnibattery volgt de laatste meting totdat deze ouder is dan {stale_limit} seconden. Gebruik een snellere sensor als u een nauwkeurigere realtime regeling nodig hebt."
+    },
+    "price_data_unusable": {
+      "title": "Prijsdata onbruikbaar",
+      "description": "Omnibattery kon langer dan {minutes} minuten geen bruikbare prijsslots uit {sensor} lezen (status: {status}). Prijsgestuurd laden is daardoor inactief: de dynamic-pricing planning en de prijsgestuurde vrijgave van de laadvertraging vallen terug op hun gedrag zonder prijzen. Controleer of de sensor beschikbaar is en of het prijsattribuut een lijst met items is; een template-sensor moet ISO-8601-tijdstempels teruggeven, omdat een gerenderd Python-datetime niet terug naar een lijst kan worden omgezet."
+    },
+    "solar_forecast_unusable": {
+      "title": "Zonneprognose onbruikbaar",
+      "description": "De ingestelde zonneprognose-sensor {sensor} is al meer dan {minutes} minuten niet beschikbaar of onleesbaar. Omnibattery blijft draaien, maar alles wat op de prognose leunt werkt nu blind: de laadvertraging geeft de rest van de dag vrij, beslissingen over netladen gaan uit van geen enkele zon en kunnen onnodig netlaadslots boeken, en de resterende-zon-schatting leest 0 kWh. Controleer de sensor of de integratie die hem levert."
     }
   },
   "config": {

--- a/tests/test_price_data_health.py
+++ b/tests/test_price_data_health.py
@@ -1,0 +1,235 @@
+"""Price-data health: string-typed attributes and the Repairs issue.
+
+A price sensor that stops delivering usable slots used to be invisible: every
+per-entry parse failure is debug-level and the resulting status only shows up as
+an attribute on the predictive-charging binary sensor, so price-aware charging
+could stay silently inactive for weeks. These tests pin the two mechanisms that
+surface it: the ``bad_format`` type check and the sustained-failure Repairs issue.
+
+No hardware, no running Home Assistant: ``PricingManager`` only stores its
+``hass``/``controller`` references, so a SimpleNamespace pair is enough.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.omnibattery.const import (
+    PREDICTIVE_MODE_DYNAMIC_PRICING,
+    PREDICTIVE_MODE_REALTIME_PRICE,
+    PREDICTIVE_MODE_TIME_SLOT,
+    PRICE_DATA_ISSUE_DELAY_S,
+    PRICE_HEALTH_CHECK_INTERVAL_S,
+    PRICE_INTEGRATION_EPEX,
+)
+from custom_components.omnibattery.pricing import engine as pricing_engine
+from custom_components.omnibattery.pricing.engine import PricingManager
+
+
+class _FakeIssueRegistry:
+    """Records Repairs create/delete calls instead of touching a real registry."""
+
+    def __init__(self):
+        self.created: list[tuple] = []
+        self.deleted: list[tuple] = []
+        self.IssueSeverity = SimpleNamespace(WARNING="warning")
+
+    def async_create_issue(self, hass, domain, issue_id, **kwargs):
+        self.created.append((issue_id, kwargs))
+
+    def async_delete_issue(self, hass, domain, issue_id):
+        self.deleted.append(issue_id)
+
+
+@pytest.fixture
+def issues(monkeypatch):
+    fake = _FakeIssueRegistry()
+    monkeypatch.setattr(pricing_engine, "ir", fake)
+    return fake
+
+
+def _epex_entries():
+    """Two hourly EPEX entries spanning now, as ISO strings."""
+    start = datetime.now().replace(minute=0, second=0, microsecond=0)
+    return [
+        {
+            "start_time": (start + timedelta(hours=i)).isoformat(),
+            "end_time": (start + timedelta(hours=i + 1)).isoformat(),
+            "price_per_kwh": 0.10 + i / 100,
+        }
+        for i in range(2)
+    ]
+
+
+def _manager(monkeypatch, data_attr):
+    """PricingManager over an EPEX price sensor exposing ``data_attr``."""
+    monkeypatch.setattr(
+        pricing_engine, "resolve_official_nordpool_source", lambda *_args: None
+    )
+    state = SimpleNamespace(state="0.10", attributes={"data": data_attr})
+    hass = SimpleNamespace(states=SimpleNamespace(get=lambda _entity_id: state))
+    ctrl = SimpleNamespace(
+        hass=hass,
+        config_entry=SimpleNamespace(entry_id="abc123"),
+        price_sensor="sensor.dynamic_price",
+        price_integration_type=PRICE_INTEGRATION_EPEX,
+        _price_data_status="not_evaluated",
+        _price_health_last_check=None,
+        _price_data_bad_since=None,
+        _price_data_issue_created=False,
+        _price_data_issue_cleared=False,
+        predictive_charging_enabled=True,
+        predictive_charging_mode=PREDICTIVE_MODE_DYNAMIC_PRICING,
+        charge_delay_enabled=False,
+    )
+    return PricingManager(hass, ctrl), ctrl
+
+
+# ----------------------------------------------------------------------
+# bad_format detection
+# ----------------------------------------------------------------------
+
+def test_list_attribute_parses_normally(monkeypatch):
+    mgr, ctrl = _manager(monkeypatch, _epex_entries())
+
+    slots = mgr._parse_price_data()
+
+    assert slots
+    assert ctrl._price_data_status.startswith("ok")
+
+
+def test_stringified_attribute_is_reported_as_bad_format(monkeypatch):
+    # What a template sensor produces when its rendered list holds datetime
+    # objects: Home Assistant cannot literal_eval it, so the attribute stays a str.
+    mgr, ctrl = _manager(monkeypatch, str(_epex_entries()))
+
+    slots = mgr._parse_price_data()
+
+    assert slots == []
+    assert ctrl._price_data_status == "bad_format"
+
+
+# ----------------------------------------------------------------------
+# Repairs issue lifecycle
+# ----------------------------------------------------------------------
+
+def test_no_issue_before_the_failure_delay_elapses(monkeypatch, issues):
+    mgr, ctrl = _manager(monkeypatch, str(_epex_entries()))
+    ctrl._price_data_status = "bad_format"
+
+    mgr._update_price_data_issue(1000.0)  # first failure: only starts the clock
+    mgr._update_price_data_issue(1000.0 + PRICE_DATA_ISSUE_DELAY_S - 1)
+
+    assert issues.created == []
+    assert ctrl._price_data_bad_since == 1000.0
+
+
+def test_sustained_failure_creates_one_issue(monkeypatch, issues):
+    mgr, ctrl = _manager(monkeypatch, str(_epex_entries()))
+    ctrl._price_data_status = "bad_format"
+
+    mgr._update_price_data_issue(1000.0)
+    mgr._update_price_data_issue(1000.0 + PRICE_DATA_ISSUE_DELAY_S)
+    mgr._update_price_data_issue(1000.0 + PRICE_DATA_ISSUE_DELAY_S * 2)
+
+    assert len(issues.created) == 1
+    issue_id, kwargs = issues.created[0]
+    assert issue_id == "price_data_unusable_abc123"
+    assert kwargs["translation_key"] == "price_data_unusable"
+    assert kwargs["translation_placeholders"]["sensor"] == "sensor.dynamic_price"
+    assert kwargs["translation_placeholders"]["status"] == "bad_format"
+
+
+def test_recovery_clears_the_issue(monkeypatch, issues):
+    mgr, ctrl = _manager(monkeypatch, str(_epex_entries()))
+    ctrl._price_data_status = "bad_format"
+    mgr._update_price_data_issue(1000.0)
+    mgr._update_price_data_issue(1000.0 + PRICE_DATA_ISSUE_DELAY_S)
+
+    ctrl._price_data_status = "ok (24 slots)"
+    mgr._update_price_data_issue(1000.0 + PRICE_DATA_ISSUE_DELAY_S + 60)
+
+    assert issues.deleted == ["price_data_unusable_abc123"]
+    assert ctrl._price_data_bad_since is None
+    assert ctrl._price_data_issue_created is False
+
+
+def test_healthy_prices_clear_a_stale_issue_once(monkeypatch, issues):
+    # The issue is persistent, so it outlives the run that raised it while
+    # _price_data_issue_created does not. A fresh, healthy run must still clear it,
+    # but only once — not on every poll for the rest of the day.
+    mgr, ctrl = _manager(monkeypatch, _epex_entries())
+    ctrl._price_data_status = "ok (24 slots)"
+
+    mgr._update_price_data_issue(1000.0)
+    mgr._update_price_data_issue(2000.0)
+
+    assert issues.created == []
+    assert issues.deleted == ["price_data_unusable_abc123"]
+
+
+def test_slots_that_all_lie_in_the_past_are_not_ok(monkeypatch):
+    start = datetime.now().replace(minute=0, second=0, microsecond=0) - timedelta(days=1)
+    stale = [
+        {
+            "start_time": start.isoformat(),
+            "end_time": (start + timedelta(hours=1)).isoformat(),
+            "price_per_kwh": 0.10,
+        }
+    ]
+    mgr, ctrl = _manager(monkeypatch, stale)
+
+    assert mgr._parse_price_data() == []
+    assert ctrl._price_data_status == "no_future_slots"
+
+
+# ----------------------------------------------------------------------
+# Health-check throttle
+# ----------------------------------------------------------------------
+
+def test_health_check_is_throttled_to_its_interval(monkeypatch, issues):
+    mgr, ctrl = _manager(monkeypatch, _epex_entries())
+    parses = []
+    monkeypatch.setattr(
+        mgr, "_parse_price_data", lambda **kwargs: parses.append(kwargs) or []
+    )
+    clock = [5000.0]
+    monkeypatch.setattr(pricing_engine, "monotonic", lambda: clock[0])
+
+    mgr.maybe_check_price_data_health()
+    clock[0] += PRICE_HEALTH_CHECK_INTERVAL_S - 1
+    mgr.maybe_check_price_data_health()
+    assert len(parses) == 1
+
+    clock[0] += 2
+    mgr.maybe_check_price_data_health()
+    assert len(parses) == 2
+
+
+def test_health_check_skips_and_clears_when_prices_are_not_used(monkeypatch, issues):
+    # Turning predictive charging off (or switching to time-slot mode) must not
+    # strand a persistent issue that nothing would ever clear again.
+    mgr, ctrl = _manager(monkeypatch, _epex_entries())
+    ctrl.predictive_charging_mode = PREDICTIVE_MODE_TIME_SLOT
+    parses = []
+    monkeypatch.setattr(mgr, "_parse_price_data", lambda **kwargs: parses.append(kwargs) or [])
+
+    mgr.maybe_check_price_data_health()
+
+    assert parses == []
+    assert issues.deleted == ["price_data_unusable_abc123"]
+
+
+def test_realtime_mode_only_checks_prices_when_the_charge_delay_needs_slots(monkeypatch):
+    mgr, ctrl = _manager(monkeypatch, _epex_entries())
+    ctrl.predictive_charging_mode = PREDICTIVE_MODE_REALTIME_PRICE
+
+    # Real-time charging runs off the scalar current price: a slot-less sensor is
+    # no defect, so nothing to report.
+    assert mgr._prices_are_load_bearing() is False
+
+    # ...unless the charge delay's price-aware release consumes the slots.
+    ctrl.charge_delay_enabled = True
+    assert mgr._prices_are_load_bearing() is True

--- a/tests/test_solar_forecast_health.py
+++ b/tests/test_solar_forecast_health.py
@@ -1,0 +1,125 @@
+"""Solar-forecast health: Repairs issue for a configured but dead forecast sensor.
+
+Every consumer degrades quietly on its own (charge delay unlocks, grid-charge
+decisions switch to conservative mode, remaining-solar reads 0 kWh), so a broken
+forecast sensor costs money without surfacing anywhere. These tests pin the
+lifecycle of the issue that makes it visible.
+
+``_check_solar_forecast_health`` only touches ``self.hass``, ``self.config_entry``,
+``self.solar_forecast_sensor`` and its own counters, so it is exercised as an
+unbound method against a lightweight stand-in rather than a real controller.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import custom_components.omnibattery as omnibattery_init
+from custom_components.omnibattery import ChargeDischargeController
+from custom_components.omnibattery.const import FORECAST_DATA_ISSUE_DELAY_S
+
+
+class _FakeIssueRegistry:
+    def __init__(self):
+        self.created: list[tuple] = []
+        self.deleted: list[str] = []
+        self.IssueSeverity = SimpleNamespace(WARNING="warning")
+
+    def async_create_issue(self, hass, domain, issue_id, **kwargs):
+        self.created.append((issue_id, kwargs))
+
+    def async_delete_issue(self, hass, domain, issue_id):
+        self.deleted.append(issue_id)
+
+
+@pytest.fixture
+def issues(monkeypatch):
+    fake = _FakeIssueRegistry()
+    monkeypatch.setattr(omnibattery_init, "ir", fake)
+    return fake
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    now = [1000.0]
+    monkeypatch.setattr(omnibattery_init.time, "monotonic", lambda: now[0])
+    return now
+
+
+def _ctrl(forecast_state, sensor="sensor.solar_forecast_today"):
+    """Controller stand-in exposing only what the health check reads."""
+    state = None if forecast_state is None else SimpleNamespace(state=forecast_state)
+    return SimpleNamespace(
+        hass=SimpleNamespace(states=SimpleNamespace(get=lambda _eid: state)),
+        config_entry=SimpleNamespace(entry_id="abc123"),
+        solar_forecast_sensor=sensor,
+        _solar_forecast_bad_since=None,
+        _solar_forecast_issue_created=False,
+        _solar_forecast_issue_cleared=False,
+    )
+
+
+def _check(ctrl):
+    ChargeDischargeController._check_solar_forecast_health(ctrl)
+
+
+def test_readable_forecast_raises_nothing(issues, clock):
+    ctrl = _ctrl("18.4")
+
+    _check(ctrl)
+
+    assert issues.created == []
+    assert ctrl._solar_forecast_bad_since is None
+
+
+@pytest.mark.parametrize("bad_state", ["unavailable", "unknown", "not-a-number", None])
+def test_sustained_unreadable_forecast_creates_one_issue(issues, clock, bad_state):
+    ctrl = _ctrl(bad_state)
+
+    _check(ctrl)  # first failure only starts the clock
+    assert issues.created == []
+
+    clock[0] += FORECAST_DATA_ISSUE_DELAY_S - 1
+    _check(ctrl)
+    assert issues.created == []
+
+    clock[0] += 2
+    _check(ctrl)
+    clock[0] += FORECAST_DATA_ISSUE_DELAY_S
+    _check(ctrl)
+
+    assert len(issues.created) == 1
+    issue_id, kwargs = issues.created[0]
+    assert issue_id == "solar_forecast_unusable_abc123"
+    assert kwargs["translation_key"] == "solar_forecast_unusable"
+    assert kwargs["translation_placeholders"]["sensor"] == "sensor.solar_forecast_today"
+
+
+def test_recovery_clears_the_issue(issues, clock):
+    ctrl = _ctrl("unavailable")
+    _check(ctrl)
+    clock[0] += FORECAST_DATA_ISSUE_DELAY_S
+    _check(ctrl)
+    assert len(issues.created) == 1
+
+    ctrl.hass.states.get = lambda _eid: SimpleNamespace(state="12.0")
+    _check(ctrl)
+    _check(ctrl)
+
+    assert issues.deleted == ["solar_forecast_unusable_abc123"]
+    assert ctrl._solar_forecast_issue_created is False
+    assert ctrl._solar_forecast_bad_since is None
+
+
+def test_unconfigured_sensor_is_not_a_defect(issues, clock):
+    # Leaving the forecast sensor unset merely disables the features that use it.
+    ctrl = _ctrl(None, sensor=None)
+
+    _check(ctrl)
+    clock[0] += FORECAST_DATA_ISSUE_DELAY_S * 2
+    _check(ctrl)
+
+    assert issues.created == []
+    # A persistent issue from a run where the sensor WAS configured still clears.
+    assert issues.deleted == ["solar_forecast_unusable_abc123"]


### PR DESCRIPTION
A price sensor that stops delivering usable slots is currently invisible. Mine broke for ten days before I noticed.

The template sensor feeding it started rendering datetime objects, Home Assistant could no longer `literal_eval` the attribute back into a list, and stored it as a string. `parse_epex_prices` then walked it character by character. Per-entry failures log at debug, `get_future_price_slots` runs quiet, and `_price_data_status` only lands in an attribute on the predictive-charging binary sensor. Meanwhile dynamic pricing scheduled nothing and the charge delay released four hours after the cheapest hour of the day.

The solar forecast sensor fails the same way and costs more: the charge delay unlocks for the day, `_should_activate_grid_charging` books grid slots for a day the sun would have covered, and `_remaining_solar_today_kwh` returns 0.

Both now raise a Repairs issue after two hours of sustained failure, following `_check_sensor_cadence`. Plus two smaller price fixes: a string-typed attribute reports `bad_format` with a warning that says to emit ISO-8601, and slots that all lie in the past report `no_future_slots` instead of `ok (0 slots)`, which read as healthy.

Two decisions worth a look in review:

- Clearing is keyed on a separate "cleared this run" flag. The issues are persistent, so keying it on the created flag (which resets on start) would strand an issue raised before a restart.
- Prices only count as load-bearing where something consumes slots: dynamic pricing always, real-time price mode only with the charge delay's price release on. Real-time charging runs off the scalar price, so a slot-less sensor there is not a defect. An unconfigured forecast sensor is likewise not a defect, only a configured one that stops reading.

Strings in `strings.json` and all six translations. Tests cover both issue lifecycles including the restart case, the poll throttle and the mode gating.
