### PR TITLE
fix: complete Sessy configuration flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.0b2] - 2026-07-28
+
+### Fixed
+- **Sessy configuration flows completed**: Sessy is now available from the Options Flow battery selector and uses its dedicated local HTTP connection form for both options and reconfiguration, including connection probing and existing-value defaults. Charge and discharge limits are capped consistently at the 2200 W hardware ceiling. Nominal capacity is required for Sessy without inventing a fallback value for legacy entries, so stored-energy and cycle calculations use the real battery capacity. Setup, options and reconfiguration labels and capacity guidance are included in all supported translations.
+
 ## [1.2.0b1] - 2026-07-27
 
 ### Added

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -585,6 +585,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             _LOGGER.info("Probing Zendure device at %s:%s", host, port)
             result, _ = await ZendureLocalDriver.probe(host, port)
         elif brand == "sessy":
+            _LOGGER.info("Probing Sessy device at %s:%s", host, port)
             result = await SessyLocalDriver.probe(host, port)
         elif brand == "anker":
             _LOGGER.info("Probing Anker Solarbank at %s:%s slave %s", host, port, slave_id)
@@ -927,6 +928,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         errors = {}
         if user_input is not None:
             host, port = user_input[CONF_HOST], int(user_input.get(CONF_PORT, 80))
+            _LOGGER.info("Probing Sessy device at %s:%s", host, port)
             if await SessyLocalDriver.probe(host, port):
                 self._current_battery_data.update({CONF_NAME: user_input[CONF_NAME], CONF_HOST: host, CONF_PORT: port, "brand": "sessy"})
                 return await self.async_step_battery_limits()
@@ -1093,7 +1095,11 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         })
         if brand not in ("zendure", "anker", "sessy", "hoymiles"):
             _schema[vol.Required(CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED, default=DEFAULT_FULL_CHARGE_VOLTAGE_TAPER_ENABLED)] = bool
-        if brand in ("zendure", "sessy", "hoymiles"):
+        if brand == "sessy":
+            _schema[vol.Required("battery_capacity_kwh")] = NumberSelector(
+                NumberSelectorConfig(min=0.01, max=100, step=0.01, unit_of_measurement="kWh", mode=NumberSelectorMode.BOX)
+            )
+        elif brand in ("zendure", "hoymiles"):
             _schema[vol.Optional("battery_capacity_kwh", default=2.24 if brand == "hoymiles" else 0.0)] = NumberSelector(
                 NumberSelectorConfig(min=0.01 if brand == "hoymiles" else 0, max=100, step=0.01, unit_of_measurement="kWh", mode=NumberSelectorMode.BOX)
             )
@@ -1766,6 +1772,8 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             return await self.async_step_reconfigure_battery_esphome(user_input)
         if current.get("brand", "marstek") == "anker":
             return await self.async_step_reconfigure_battery_anker(user_input)
+        if current.get("brand", "marstek") == "sessy":
+            return await self.async_step_reconfigure_battery_sessy(user_input)
         if current.get("brand", "marstek") == "hoymiles":
             return await self.async_step_reconfigure_battery_hoymiles(user_input)
 
@@ -1922,6 +1930,60 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                     vol.Required(CONF_PORT, default=defaults[CONF_PORT]): int,
                 }
             ),
+            errors=errors,
+            description_placeholders={"battery_num": str(battery_num)},
+        )
+
+    async def async_step_reconfigure_battery_sessy(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Update connection settings for a Sessy battery during reconfiguration."""
+        entry = self._get_reconfigure_entry()
+        current_batteries = entry.data.get("batteries", [])
+        battery_num = self.battery_index + 1
+        current = (
+            current_batteries[self.battery_index]
+            if self.battery_index < len(current_batteries)
+            else {}
+        )
+        errors = {}
+
+        if user_input is not None:
+            new_host = user_input[CONF_HOST]
+            new_port = int(user_input.get(CONF_PORT, 80))
+            _LOGGER.info("Probing Sessy device at %s:%s", new_host, new_port)
+            if not await SessyLocalDriver.probe(new_host, new_port):
+                errors["base"] = "cannot_connect"
+            else:
+                old_host = current.get(CONF_HOST)
+                old_port = current.get(CONF_PORT)
+                if old_host and old_port and (old_host != new_host or old_port != new_port):
+                    self._migrate_battery_registry_ids(
+                        entry, old_host, old_port, new_host, new_port
+                    )
+
+                updated = dict(current)
+                updated.update({
+                    CONF_NAME: user_input[CONF_NAME],
+                    CONF_HOST: new_host,
+                    CONF_PORT: new_port,
+                    "brand": "sessy",
+                })
+                self._reconfigure_batteries.append(updated)
+                self.battery_index += 1
+                if self.battery_index >= len(current_batteries):
+                    return self.async_update_reload_and_abort(
+                        entry, data_updates={"batteries": self._reconfigure_batteries}
+                    )
+                return await self.async_step_reconfigure_battery()
+
+        return self.async_show_form(
+            step_id="reconfigure_battery_sessy",
+            data_schema=vol.Schema({
+                vol.Required(CONF_NAME, default=current.get(CONF_NAME, f"Sessy {battery_num}")): str,
+                vol.Required(CONF_HOST, default=current.get(CONF_HOST, "")): str,
+                vol.Required(CONF_PORT, default=current.get(CONF_PORT, 80)): int,
+            }),
             errors=errors,
             description_placeholders={"battery_num": str(battery_num)},
         )
@@ -2311,6 +2373,8 @@ class OptionsFlowHandler(OptionsFlow):
                 return await self.async_step_battery_connection_esphome()
             if brand == "anker":
                 return await self.async_step_battery_connection_anker()
+            if brand == "sessy":
+                return await self.async_step_battery_connection_sessy()
             if brand == "hoymiles":
                 return await self.async_step_battery_connection_hoymiles()
             return await self.async_step_battery_connection()
@@ -2326,6 +2390,7 @@ class OptionsFlowHandler(OptionsFlow):
                                 {"value": "zendure", "label": "Zendure SolarFlow"},
                                 {"value": "esphome", "label": "Marstek via LilyGo RS485 (ESPHome)"},
                                 {"value": "anker", "label": "Anker SOLIX Solarbank Max AC / 4 E5000 Pro"},
+                                {"value": "sessy", "label": "Sessy"},
                                 {"value": "hoymiles", "label": "Hoymiles MS-A2"},
                             ],
                             mode=SelectSelectorMode.DROPDOWN,
@@ -2479,6 +2544,45 @@ class OptionsFlowHandler(OptionsFlow):
                     vol.Optional(CONF_PORT, default=defaults[CONF_PORT]): int,
                 }
             ),
+            errors=errors,
+            description_placeholders={"battery_num": str(battery_num)},
+        )
+
+    async def async_step_battery_connection_sessy(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Configure a Sessy through its local dongle HTTP API."""
+        errors = {}
+        battery_num = self.battery_index + 1
+        current_batteries = self.config_entry.data.get("batteries", [])
+        current_battery = (
+            current_batteries[self.battery_index]
+            if self.battery_index < len(current_batteries)
+            else {}
+        )
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            port = int(user_input.get(CONF_PORT, 80))
+            _LOGGER.info("Probing Sessy device at %s:%s", host, port)
+            if await SessyLocalDriver.probe(host, port):
+                self._current_battery_data.update({
+                    CONF_NAME: user_input[CONF_NAME],
+                    CONF_HOST: host,
+                    CONF_PORT: port,
+                    "brand": "sessy",
+                })
+                return await self.async_step_battery_limits()
+            errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="battery_connection_sessy",
+            data_schema=vol.Schema({
+                vol.Required(
+                    CONF_NAME,
+                    default=current_battery.get(CONF_NAME, f"Sessy {battery_num}"),
+                ): str,
+                vol.Required(CONF_HOST, default=current_battery.get(CONF_HOST, "")): str,
+                vol.Optional(CONF_PORT, default=current_battery.get(CONF_PORT, 80)): int,
+            }),
             errors=errors,
             description_placeholders={"battery_num": str(battery_num)},
         )
@@ -2638,6 +2742,8 @@ class OptionsFlowHandler(OptionsFlow):
                     self._current_battery_data
                 )
                 max_power = max(max_charge_power, max_discharge_power)
+            elif brand == "sessy":
+                max_power = max_charge_power = max_discharge_power = _SESSY_MAX_POWER_W
             elif brand == "hoymiles":
                 max_charge_power, max_discharge_power = _hoymiles_power_ceilings(self._current_battery_data)
                 max_power = max(max_charge_power, max_discharge_power)
@@ -2762,7 +2868,17 @@ class OptionsFlowHandler(OptionsFlow):
         })
         if brand not in ("zendure", "anker", "sessy", "hoymiles"):
             _schema[vol.Required(CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED, default=defaults[CONF_FULL_CHARGE_VOLTAGE_TAPER_ENABLED])] = bool
-        if brand in ("zendure", "sessy", "hoymiles"):
+        if brand == "sessy":
+            saved_capacity = float(defaults["battery_capacity_kwh"])
+            capacity_field = (
+                vol.Required("battery_capacity_kwh", default=saved_capacity)
+                if saved_capacity > 0
+                else vol.Required("battery_capacity_kwh")
+            )
+            _schema[capacity_field] = NumberSelector(
+                NumberSelectorConfig(min=0.01, max=100, step=0.01, unit_of_measurement="kWh", mode=NumberSelectorMode.BOX)
+            )
+        elif brand in ("zendure", "hoymiles"):
             _schema[vol.Optional("battery_capacity_kwh", default=defaults["battery_capacity_kwh"])] = NumberSelector(
                 NumberSelectorConfig(min=0.01 if brand == "hoymiles" else 0, max=100, step=0.01, unit_of_measurement="kWh", mode=NumberSelectorMode.BOX)
             )

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -51,7 +51,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -87,6 +87,12 @@
           "host": "IP address of the Zendure device on your local network",
           "port": "HTTP port (default 80)"
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configure battery {battery_num} — Connection (Sessy)",
+        "description": "Enter connection details for the Sessy battery {battery_num}.",
+        "data": {"name": "Name", "host": "IP Address", "port": "HTTP Port"},
+        "data_description": {"name": "Descriptive name to identify this battery", "host": "IP address of the Sessy device on your local network", "port": "HTTP port (default 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
@@ -143,7 +149,7 @@
           "charge_hysteresis_percent": "Always on (minimum 2%). After reaching the top, the battery won't charge again until SOC drops to (Max SOC − hysteresis). Ex: Max SOC 100% with 2% = no charge until 98%.",
           "backup_offgrid_threshold": "Offgrid load above this value is treated as an active backup event, excluding the battery from PD control. Set higher if you have permanent loads (router, cameras) on the offgrid port.",
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 95 W from 3.48 V max cell voltage and stop at 3.58 V to measure imbalance after 60 seconds.",
-          "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Leave at 0 if unknown."
+          "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown."
         }
       },
       "time_slots": {
@@ -515,6 +521,12 @@
           "port": "HTTP port (default 80)"
         }
       },
+      "reconfigure_battery_sessy": {
+        "title": "Reconfigure battery {battery_num} — Connection (Sessy)",
+        "description": "Update connection details for the Sessy battery {battery_num}. All other settings are preserved.",
+        "data": {"name": "Name", "host": "IP Address", "port": "HTTP Port"},
+        "data_description": {"name": "Descriptive name to identify this battery", "host": "IP address of the Sessy device on your local network", "port": "HTTP port (default 80)"}
+      },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
         "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
@@ -631,7 +643,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -701,7 +713,7 @@
           "charge_hysteresis_percent": "Always on (minimum 2%). After reaching the top, the battery won't charge again until SOC drops to (Max SOC − hysteresis). Ex: Max SOC 100% with 2% = no charge until 98%.",
           "backup_offgrid_threshold": "Offgrid load above this value is treated as an active backup event, excluding the battery from PD control. Set higher if you have permanent loads (router, cameras) on the offgrid port.",
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 95 W from 3.48 V max cell voltage and stop at 3.58 V to measure imbalance after 60 seconds.",
-          "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Leave at 0 if unknown."
+          "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown."
         }
       },
       "time_slots": {
@@ -1038,6 +1050,12 @@
           "hourly_balance_deadband_wh": "Tolerance band around the target. No correction is applied when the net balance is within ±N kWh of the target. 0 = exact correction.",
           "hourly_balance_hysteresis_w": "Minimum change in offset required before a new correction is applied. Prevents micro-adjustments every cycle. 0 = apply every cycle. Default: 15 W."
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configure battery {battery_num} — Connection (Sessy)",
+        "description": "Modify connection details for the Sessy battery {battery_num}.",
+        "data": {"name": "Name", "host": "IP Address", "port": "HTTP Port"},
+        "data_description": {"name": "Descriptive name to identify this battery", "host": "IP address of the Sessy device on your local network", "port": "HTTP port (default 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -51,7 +51,7 @@
           "brand": "Marca de la bateria"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -127,7 +127,7 @@
           "charge_hysteresis_percent": "Sempre activa (mínim 2%). En arribar al màxim, la bateria no tornarà a carregar fins que el SOC baixi a (SOC màx − histèresi). Ex: SOC màx 100% amb 2% = no carrega fins a 98%.",
           "backup_offgrid_threshold": "Una càrrega offgrid superior a aquest valor es considera un esdeveniment de backup actiu, excloent la bateria del control PD. Augmenta'l si tens càrregues permanents (router, càmeres) al port offgrid.",
           "full_charge_voltage_taper_enabled": "Quan l'objectiu és 100%, limita la càrrega a 95 W des de 3,48 V de cel·la màxima i s'atura a 3,58 V per mesurar el desbalanç durant 60 segons.",
-          "battery_capacity_kwh": "Capacitat usable nominal del pack de bateries. S'usa per calcular l'energia emmagatzemada i l'eficiència a partir del SOC. Deixa en 0 si no la coneixes."
+          "battery_capacity_kwh": "Capacitat útil nominal del pack de bateries. Es fa servir per calcular energia emmagatzemada i eficiència a partir del SOC. Per a Sessy, introdueix la capacitat real; per a altres bateries, deixa 0 si no la coneixes."
         }
       },
       "time_slots": {
@@ -507,6 +507,12 @@
           "port": "Port HTTP (per defecte 80)"
         }
       },
+      "reconfigure_battery_sessy": {
+        "title": "Reconfigura la bateria {battery_num} — Connexió (Sessy)",
+        "description": "Actualitza les dades de connexió de la bateria Sessy {battery_num}. La resta de configuració es conserva.",
+        "data": {"name": "Nom", "host": "Adreça IP", "port": "Port HTTP"},
+        "data_description": {"name": "Nom descriptiu per identificar aquesta bateria", "host": "Adreça IP del dispositiu Sessy a la xarxa local", "port": "Port HTTP (per defecte 80)"}
+      },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
         "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
@@ -546,6 +552,12 @@
         "data": {
           "restore": "Restaura la configuració anterior"
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configura la bateria {battery_num} — Connexió (Sessy)",
+        "description": "Introdueix les dades de connexió de la bateria Sessy {battery_num}.",
+        "data": {"name": "Nom", "host": "Adreça IP", "port": "Port HTTP"},
+        "data_description": {"name": "Nom descriptiu per identificar aquesta bateria", "host": "Adreça IP del dispositiu Sessy a la xarxa local", "port": "Port HTTP (per defecte 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
@@ -640,7 +652,7 @@
           "brand": "Marca de la bateria"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -710,7 +722,7 @@
           "charge_hysteresis_percent": "Sempre activa (mínim 2%). En arribar al màxim, la bateria no tornarà a carregar fins que el SOC baixi a (SOC màx − histèresi). Ex: SOC màx 100% amb 2% = no carrega fins a 98%.",
           "backup_offgrid_threshold": "Una càrrega offgrid superior a aquest valor es considera un esdeveniment de backup actiu, excloent la bateria del control PD. Augmenta'l si tens càrregues permanents (router, càmeres) al port offgrid.",
           "full_charge_voltage_taper_enabled": "Quan l'objectiu és 100%, limita la càrrega a 95 W des de 3,48 V de cel·la màxima i s'atura a 3,58 V per mesurar el desbalanç durant 60 segons.",
-          "battery_capacity_kwh": "Capacitat utilizable nominal del pack de bateries. S'usa per calcular l'energia emmagatzemada i l'eficiència a partir del SOC. Deixa en 0 si no la coneixes."
+          "battery_capacity_kwh": "Capacitat útil nominal del pack de bateries. Es fa servir per calcular energia emmagatzemada i eficiència a partir del SOC. Per a Sessy, introdueix la capacitat real; per a altres bateries, deixa 0 si no la coneixes."
         }
       },
       "time_slots": {
@@ -1055,6 +1067,12 @@
           "hourly_balance_deadband_wh": "Tolerància al voltant de l'objectiu. No s'aplica correcció si el balanç net està dins de ±N kWh de l'objectiu. 0 = correcció exacta.",
           "hourly_balance_hysteresis_w": "Canvi mínim en el desplaçament necessari per aplicar una nova correcció. Evita micro-ajustos cada cicle. 0 = aplicar sempre. Per defecte: 15 W."
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configura la bateria {battery_num} — Connexió (Sessy)",
+        "description": "Modifica les dades de connexió de la bateria Sessy {battery_num}.",
+        "data": {"name": "Nom", "host": "Adreça IP", "port": "Port HTTP"},
+        "data_description": {"name": "Nom descriptiu per identificar aquesta bateria", "host": "Adreça IP del dispositiu Sessy a la xarxa local", "port": "Port HTTP (per defecte 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -51,7 +51,7 @@
           "brand": "Batteriemarke"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -127,7 +127,7 @@
           "charge_hysteresis_percent": "Immer aktiv (mindestens 2%). Nach Erreichen des Maximums lädt die Batterie erst wieder, wenn der SOC auf (Max SOC − Hysterese) fällt. Bsp.: Max SOC 100% mit 2% = kein Laden bis 98%.",
           "backup_offgrid_threshold": "Eine Offgrid-Last über diesem Wert wird als aktives Backup-Ereignis behandelt und schließt die Batterie aus der PD-Regelung aus. Erhöhen, wenn dauerhafte Lasten (Router, Kameras) am Offgrid-Port angeschlossen sind.",
           "full_charge_voltage_taper_enabled": "Wenn das Ziel 100% ist, wird die Ladung ab 3.48 V maximaler Zellspannung auf 95 W begrenzt und bei 3.58 V gestoppt, um den Zellversatz nach 60 Sekunden zu messen.",
-          "battery_capacity_kwh": "Nominale nutzbare Kapazität des Batteriepacks. Wird zur Berechnung der gespeicherten Energie und Effizienz aus dem SOC verwendet. Bei 0 lassen, wenn unbekannt."
+          "battery_capacity_kwh": "Nominale nutzbare Kapazität des Batteriepacks. Sie dient zur Berechnung der gespeicherten Energie und Effizienz aus dem SOC. Für Sessy ist die tatsächliche Kapazität erforderlich; bei anderen Batterien kann 0 verwendet werden, wenn sie unbekannt ist."
         }
       },
       "time_slots": {
@@ -507,6 +507,12 @@
           "port": "HTTP-Port (Standard 80)"
         }
       },
+      "reconfigure_battery_sessy": {
+        "title": "Batterie {battery_num} neu konfigurieren — Verbindung (Sessy)",
+        "description": "Aktualisieren Sie die Verbindungsdaten für die Sessy-Batterie {battery_num}. Alle übrigen Einstellungen bleiben erhalten.",
+        "data": {"name": "Name", "host": "IP-Adresse", "port": "HTTP-Port"},
+        "data_description": {"name": "Beschreibender Name zur Identifizierung dieser Batterie", "host": "IP-Adresse des Sessy-Geräts im lokalen Netzwerk", "port": "HTTP-Port (Standard 80)"}
+      },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
         "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
@@ -546,6 +552,12 @@
         "data": {
           "restore": "Vorherige Konfiguration wiederherstellen"
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Batterie {battery_num} konfigurieren — Verbindung (Sessy)",
+        "description": "Geben Sie die Verbindungsdaten für die Sessy-Batterie {battery_num} ein.",
+        "data": {"name": "Name", "host": "IP-Adresse", "port": "HTTP-Port"},
+        "data_description": {"name": "Beschreibender Name zur Identifizierung dieser Batterie", "host": "IP-Adresse des Sessy-Geräts im lokalen Netzwerk", "port": "HTTP-Port (Standard 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
@@ -640,7 +652,7 @@
           "brand": "Batteriemarke"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -710,7 +722,7 @@
           "charge_hysteresis_percent": "Immer aktiv (mindestens 2%). Nach Erreichen des Maximums lädt die Batterie erst wieder, wenn der SOC auf (Max SOC − Hysterese) fällt. Bsp.: Max SOC 100% mit 2% = kein Laden bis 98%.",
           "backup_offgrid_threshold": "Eine Offgrid-Last über diesem Wert wird als aktives Backup-Ereignis behandelt und schließt die Batterie aus der PD-Regelung aus. Erhöhen, wenn dauerhafte Lasten (Router, Kameras) am Offgrid-Port angeschlossen sind.",
           "full_charge_voltage_taper_enabled": "Wenn das Ziel 100% ist, wird die Ladung ab 3.48 V maximaler Zellspannung auf 95 W begrenzt und bei 3.58 V gestoppt, um den Zellversatz nach 60 Sekunden zu messen.",
-          "battery_capacity_kwh": "Nominale nutzbare Kapazität des Batteriepacks. Wird zur Berechnung der gespeicherten Energie und Effizienz aus dem SOC verwendet. Bei 0 lassen, wenn unbekannt."
+          "battery_capacity_kwh": "Nominale nutzbare Kapazität des Batteriepacks. Sie dient zur Berechnung der gespeicherten Energie und Effizienz aus dem SOC. Für Sessy ist die tatsächliche Kapazität erforderlich; bei anderen Batterien kann 0 verwendet werden, wenn sie unbekannt ist."
         }
       },
       "time_slots": {
@@ -1055,6 +1067,12 @@
           "hourly_balance_deadband_wh": "Toleranzband um den Zielwert. Keine Korrektur, wenn die Nettobilanz innerhalb von ±N kWh liegt. 0 = exakte Korrektur.",
           "hourly_balance_hysteresis_w": "Minimale Änderung des Versatzes, bevor eine neue Korrektur angewendet wird. Verhindert Mikro-Anpassungen jeden Zyklus. 0 = immer anwenden. Standard: 15 W."
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Batterie {battery_num} konfigurieren — Verbindung (Sessy)",
+        "description": "Ändern Sie die Verbindungsdaten für die Sessy-Batterie {battery_num}.",
+        "data": {"name": "Name", "host": "IP-Adresse", "port": "HTTP-Port"},
+        "data_description": {"name": "Beschreibender Name zur Identifizierung dieser Batterie", "host": "IP-Adresse des Sessy-Geräts im lokalen Netzwerk", "port": "HTTP-Port (Standard 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -51,7 +51,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -127,7 +127,7 @@
           "charge_hysteresis_percent": "Always on (minimum 2%). After reaching the top, the battery won't charge again until SOC drops to (Max SOC − hysteresis). Ex: Max SOC 100% with 2% = no charge until 98%.",
           "backup_offgrid_threshold": "Offgrid load above this value is treated as an active backup event, excluding the battery from PD control. Set higher if you have permanent loads (router, cameras) on the offgrid port.",
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 95 W from 3.48 V max cell voltage and stop at 3.58 V to measure imbalance after 60 seconds.",
-          "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Leave at 0 if unknown."
+          "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown."
         }
       },
       "time_slots": {
@@ -501,6 +501,12 @@
           "port": "HTTP port (default 80)"
         }
       },
+      "reconfigure_battery_sessy": {
+        "title": "Reconfigure battery {battery_num} — Connection (Sessy)",
+        "description": "Update connection details for the Sessy battery {battery_num}. All other settings are preserved.",
+        "data": {"name": "Name", "host": "IP Address", "port": "HTTP Port"},
+        "data_description": {"name": "Descriptive name to identify this battery", "host": "IP address of the Sessy device on your local network", "port": "HTTP port (default 80)"}
+      },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
         "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
@@ -540,6 +546,12 @@
         "data": {
           "restore": "Restore previous configuration"
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configure battery {battery_num} — Connection (Sessy)",
+        "description": "Enter connection details for the Sessy battery {battery_num}.",
+        "data": {"name": "Name", "host": "IP Address", "port": "HTTP Port"},
+        "data_description": {"name": "Descriptive name to identify this battery", "host": "IP address of the Sessy device on your local network", "port": "HTTP port (default 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
@@ -634,7 +646,7 @@
           "brand": "Brand"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -704,7 +716,7 @@
           "charge_hysteresis_percent": "Always on (minimum 2%). After reaching the top, the battery won't charge again until SOC drops to (Max SOC − hysteresis). Ex: Max SOC 100% with 2% = no charge until 98%.",
           "backup_offgrid_threshold": "Offgrid load above this value is treated as an active backup event, excluding the battery from PD control. Set higher if you have permanent loads (router, cameras) on the offgrid port.",
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 95 W from 3.48 V max cell voltage and stop at 3.58 V to measure imbalance after 60 seconds.",
-          "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Leave at 0 if unknown."
+          "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown."
         }
       },
       "time_slots": {
@@ -1043,6 +1055,12 @@
           "hourly_balance_deadband_wh": "Tolerance band around the target. No correction is applied when the net balance is within ±N kWh of the target. 0 = exact correction.",
           "hourly_balance_hysteresis_w": "Minimum change in offset required before a new correction is applied. Prevents micro-adjustments every cycle. 0 = apply every cycle. Default: 15 W."
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configure battery {battery_num} — Connection (Sessy)",
+        "description": "Modify connection details for the Sessy battery {battery_num}.",
+        "data": {"name": "Name", "host": "IP Address", "port": "HTTP Port"},
+        "data_description": {"name": "Descriptive name to identify this battery", "host": "IP address of the Sessy device on your local network", "port": "HTTP port (default 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -51,7 +51,7 @@
           "brand": "Marca de la batería"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -127,7 +127,7 @@
           "charge_hysteresis_percent": "Siempre activa (mínimo 2%). Tras llegar al tope, la batería no volverá a cargar hasta que el SOC baje a (SOC máx − histéresis). Ej: SOC máx 100% con 2% = no carga hasta 98%.",
           "backup_offgrid_threshold": "Una carga offgrid superior a este valor se considera un evento de backup activo, excluyendo la batería del control PD. Auméntalo si tienes cargas permanentes (router, cámaras) en el puerto offgrid.",
           "full_charge_voltage_taper_enabled": "Cuando el objetivo es 100%, limita la carga a 95 W desde 3.48 V de celda maxima y para en 3.58 V para medir el desbalanceo tras 60 segundos.",
-          "battery_capacity_kwh": "Capacidad utilizable nominal del pack de baterías. Se usa para calcular la energía almacenada y la eficiencia a partir del SOC. Deja en 0 si no la conoces."
+          "battery_capacity_kwh": "Capacidad utilizable nominal del pack de baterías. Se usa para calcular la energía almacenada y la eficiencia a partir del SOC. Para Sessy, introduce la capacidad real; en otras baterías puedes dejar 0 si no la conoces."
         }
       },
       "time_slots": {
@@ -507,6 +507,12 @@
           "port": "Puerto HTTP (por defecto 80)"
         }
       },
+      "reconfigure_battery_sessy": {
+        "title": "Reconfigurar batería {battery_num} — Conexión (Sessy)",
+        "description": "Actualiza los datos de conexión de la batería Sessy {battery_num}. El resto de ajustes se conserva.",
+        "data": {"name": "Nombre", "host": "Dirección IP", "port": "Puerto HTTP"},
+        "data_description": {"name": "Nombre descriptivo para identificar esta batería", "host": "Dirección IP del dispositivo Sessy en tu red local", "port": "Puerto HTTP (por defecto 80)"}
+      },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
         "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
@@ -546,6 +552,12 @@
         "data": {
           "restore": "Restaurar la configuración anterior"
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configurar batería {battery_num} — Conexión (Sessy)",
+        "description": "Introduce los datos de conexión de la batería Sessy {battery_num}.",
+        "data": {"name": "Nombre", "host": "Dirección IP", "port": "Puerto HTTP"},
+        "data_description": {"name": "Nombre descriptivo para identificar esta batería", "host": "Dirección IP del dispositivo Sessy en tu red local", "port": "Puerto HTTP (por defecto 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
@@ -640,7 +652,7 @@
           "brand": "Marca de la batería"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -710,7 +722,7 @@
           "charge_hysteresis_percent": "Siempre activa (mínimo 2%). Tras llegar al tope, la batería no volverá a cargar hasta que el SOC baje a (SOC máx − histéresis). Ej: SOC máx 100% con 2% = no carga hasta 98%.",
           "backup_offgrid_threshold": "Una carga offgrid superior a este valor se considera un evento de backup activo, excluyendo la batería del control PD. Auméntalo si tienes cargas permanentes (router, cámaras) en el puerto offgrid.",
           "full_charge_voltage_taper_enabled": "Cuando el objetivo es 100%, limita la carga a 95 W desde 3.48 V de celda maxima y para en 3.58 V para medir el desbalanceo tras 60 segundos.",
-          "battery_capacity_kwh": "Capacidad utilizable nominal del pack de baterías. Se usa para calcular la energía almacenada y la eficiencia a partir del SOC. Deja en 0 si no la conoces."
+          "battery_capacity_kwh": "Capacidad utilizable nominal del pack de baterías. Se usa para calcular la energía almacenada y la eficiencia a partir del SOC. Para Sessy, introduce la capacidad real; en otras baterías puedes dejar 0 si no la conoces."
         }
       },
       "time_slots": {
@@ -1055,6 +1067,12 @@
           "hourly_balance_deadband_wh": "Tolerancia alrededor del objetivo. No se aplica corrección si el balance neto está dentro de ±N kWh del objetivo. 0 = corrección exacta.",
           "hourly_balance_hysteresis_w": "Cambio mínimo en el desplazamiento necesario para aplicar una nueva corrección. Evita micro-ajustes cada ciclo. 0 = aplicar siempre. Por defecto: 15 W."
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configurar batería {battery_num} — Conexión (Sessy)",
+        "description": "Modifica los datos de conexión de la batería Sessy {battery_num}.",
+        "data": {"name": "Nombre", "host": "Dirección IP", "port": "Puerto HTTP"},
+        "data_description": {"name": "Nombre descriptivo para identificar esta batería", "host": "Dirección IP del dispositivo Sessy en tu red local", "port": "Puerto HTTP (por defecto 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -51,7 +51,7 @@
           "brand": "Marque de la batterie"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -127,7 +127,7 @@
           "charge_hysteresis_percent": "Toujours active (minimum 2%). Une fois le maximum atteint, la batterie ne se recharge pas tant que le SOC ne descend pas à (SOC max − hystérésis). Ex : SOC max 100% avec 2% = pas de charge avant 98%.",
           "backup_offgrid_threshold": "Une charge hors réseau supérieure à cette valeur est traitée comme un événement de secours actif, excluant la batterie du contrôle PD. Augmenter si des charges permanentes (routeur, caméras) sont connectées au port hors réseau.",
           "full_charge_voltage_taper_enabled": "Lorsque la cible est 100%, limite la charge à 95 W à partir de 3.48 V de tension maximale de cellule et s'arrête à 3.58 V pour mesurer le déséquilibre après 60 secondes.",
-          "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Utilisée pour calculer l'énergie stockée et l'efficacité à partir du SOC. Laisser à 0 si inconnue."
+          "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Elle sert à calculer l'énergie stockée et l'efficacité à partir du SOC. Pour Sessy, saisissez la capacité réelle ; pour les autres batteries, laissez 0 si elle est inconnue."
         }
       },
       "time_slots": {
@@ -507,6 +507,12 @@
           "port": "Port HTTP (par défaut 80)"
         }
       },
+      "reconfigure_battery_sessy": {
+        "title": "Reconfigurer la batterie {battery_num} — Connexion (Sessy)",
+        "description": "Mettez à jour les informations de connexion de la batterie Sessy {battery_num}. Tous les autres réglages sont conservés.",
+        "data": {"name": "Nom", "host": "Adresse IP", "port": "Port HTTP"},
+        "data_description": {"name": "Nom descriptif permettant identifier cette batterie", "host": "Adresse IP du dispositif Sessy sur le réseau local", "port": "Port HTTP (80 par défaut)"}
+      },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
         "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
@@ -546,6 +552,12 @@
         "data": {
           "restore": "Restaurer la configuration précédente"
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configurer la batterie {battery_num} — Connexion (Sessy)",
+        "description": "Saisissez les informations de connexion de la batterie Sessy {battery_num}.",
+        "data": {"name": "Nom", "host": "Adresse IP", "port": "Port HTTP"},
+        "data_description": {"name": "Nom descriptif permettant identifier cette batterie", "host": "Adresse IP du dispositif Sessy sur le réseau local", "port": "Port HTTP (80 par défaut)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
@@ -640,7 +652,7 @@
           "brand": "Marque de la batterie"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -710,7 +722,7 @@
           "charge_hysteresis_percent": "Toujours active (minimum 2%). Une fois le maximum atteint, la batterie ne se recharge pas tant que le SOC ne descend pas à (SOC max − hystérésis). Ex : SOC max 100% avec 2% = pas de charge avant 98%.",
           "backup_offgrid_threshold": "Une charge hors réseau supérieure à cette valeur est traitée comme un événement de secours actif, excluant la batterie du contrôle PD. Augmenter si des charges permanentes (routeur, caméras) sont connectées au port hors réseau.",
           "full_charge_voltage_taper_enabled": "Lorsque la cible est 100%, limite la charge à 95 W à partir de 3.48 V de tension maximale de cellule et s'arrête à 3.58 V pour mesurer le déséquilibre après 60 secondes.",
-          "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Utilisée pour calculer l'énergie stockée et l'efficacité à partir du SOC. Laisser à 0 si inconnue."
+          "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Elle sert à calculer l'énergie stockée et l'efficacité à partir du SOC. Pour Sessy, saisissez la capacité réelle ; pour les autres batteries, laissez 0 si elle est inconnue."
         }
       },
       "time_slots": {
@@ -1055,6 +1067,12 @@
           "hourly_balance_deadband_wh": "Bande de tolérance autour de l objectif. Aucune correction si le bilan net est dans ±N kWh de l objectif. 0 = correction exacte.",
           "hourly_balance_hysteresis_w": "Variation minimale du décalage nécessaire pour appliquer une nouvelle correction. Évite les micro-ajustements à chaque cycle. 0 = appliquer toujours. Par défaut : 15 W."
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Configurer la batterie {battery_num} — Connexion (Sessy)",
+        "description": "Modifiez les informations de connexion de la batterie Sessy {battery_num}.",
+        "data": {"name": "Nom", "host": "Adresse IP", "port": "Port HTTP"},
+        "data_description": {"name": "Nom descriptif permettant identifier cette batterie", "host": "Adresse IP du dispositif Sessy sur le réseau local", "port": "Port HTTP (80 par défaut)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -51,7 +51,7 @@
           "brand": "Batterijmerk"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -127,7 +127,7 @@
           "charge_hysteresis_percent": "Altijd aan (minimaal 2%). Na het bereiken van het maximum laadt de batterij pas weer als de SOC daalt naar (Max SOC − hysterese). Bijv.: Max SOC 100% met 2% = geen laden tot 98%.",
           "backup_offgrid_threshold": "Een offgrid-belasting boven deze waarde wordt behandeld als een actieve back-upgebeurtenis en sluit de batterij uit van PD-regeling. Verhoog dit als er permanente lasten (router, camera's) op de offgrid-poort zijn aangesloten.",
           "full_charge_voltage_taper_enabled": "Wanneer het doel 100% is, wordt laden vanaf 3.48 V maximale celspanning beperkt tot 95 W en gestopt bij 3.58 V om de onbalans na 60 seconden te meten.",
-          "battery_capacity_kwh": "Nominale bruikbare capaciteit van het batterijpakket. Gebruikt om opgeslagen energie en rendement te berekenen vanuit SOC. Laat op 0 als onbekend."
+          "battery_capacity_kwh": "Nominale bruikbare capaciteit van het batterijpakket. Deze wordt gebruikt om opgeslagen energie en efficiëntie uit SOC te berekenen. Voor Sessy is de werkelijke capaciteit verplicht; laat voor andere batterijen 0 staan als deze onbekend is."
         }
       },
       "time_slots": {
@@ -507,6 +507,12 @@
           "port": "HTTP-poort (standaard 80)"
         }
       },
+      "reconfigure_battery_sessy": {
+        "title": "Batterij {battery_num} opnieuw configureren — Verbinding (Sessy)",
+        "description": "Werk de verbindingsgegevens voor de Sessy-batterij {battery_num} bij. Alle overige instellingen blijven behouden.",
+        "data": {"name": "Naam", "host": "IP-adres", "port": "HTTP-poort"},
+        "data_description": {"name": "Beschrijvende naam om deze batterij te identificeren", "host": "IP-adres van het Sessy-apparaat op het lokale netwerk", "port": "HTTP-poort (standaard 80)"}
+      },
       "reconfigure_battery_anker": {
         "title": "Reconfigure battery {battery_num} — Connection (Anker)",
         "description": "Update connection details for Anker SOLIX Solarbank Max AC / 4 E5000 Pro battery {battery_num}. All other settings are preserved.",
@@ -546,6 +552,12 @@
         "data": {
           "restore": "Vorige configuratie herstellen"
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Batterij {battery_num} configureren — Verbinding (Sessy)",
+        "description": "Voer de verbindingsgegevens voor de Sessy-batterij {battery_num} in.",
+        "data": {"name": "Naam", "host": "IP-adres", "port": "HTTP-poort"},
+        "data_description": {"name": "Beschrijvende naam om deze batterij te identificeren", "host": "IP-adres van het Sessy-apparaat op het lokale netwerk", "port": "HTTP-poort (standaard 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",
@@ -640,7 +652,7 @@
           "brand": "Batterijmerk"
         },
         "data_description": {
-          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time)."
+          "brand": "Marstek Venus: Modbus TCP. Zendure SolarFlow: local HTTP (enable HEMS in the Zendure app first). Anker SOLIX Solarbank Max AC / 4 E5000 Pro: Modbus TCP (enable Modbus TCP under Third-Party Control in the Anker app; only one Modbus client at a time). Sessy: local HTTP."
         }
       },
       "battery_connection": {
@@ -710,7 +722,7 @@
           "charge_hysteresis_percent": "Altijd aan (minimaal 2%). Na het bereiken van het maximum laadt de batterij pas weer als de SOC daalt naar (Max SOC − hysterese). Bijv.: Max SOC 100% met 2% = geen laden tot 98%.",
           "backup_offgrid_threshold": "Een offgrid-belasting boven deze waarde wordt behandeld als een actieve back-upgebeurtenis en sluit de batterij uit van PD-regeling. Verhoog dit als er permanente lasten (router, camera's) op de offgrid-poort zijn aangesloten.",
           "full_charge_voltage_taper_enabled": "Wanneer het doel 100% is, wordt laden vanaf 3.48 V maximale celspanning beperkt tot 95 W en gestopt bij 3.58 V om de onbalans na 60 seconden te meten.",
-          "battery_capacity_kwh": "Nominale bruikbare capaciteit van het batterijpakket. Gebruikt om opgeslagen energie en rendement te berekenen vanuit SOC. Laat op 0 als onbekend."
+          "battery_capacity_kwh": "Nominale bruikbare capaciteit van het batterijpakket. Deze wordt gebruikt om opgeslagen energie en efficiëntie uit SOC te berekenen. Voor Sessy is de werkelijke capaciteit verplicht; laat voor andere batterijen 0 staan als deze onbekend is."
         }
       },
       "time_slots": {
@@ -1055,6 +1067,12 @@
           "hourly_balance_deadband_wh": "Tolerantieband rondom het doel. Geen correctie als het nettosaldo binnen ±N kWh van het doel valt. 0 = exacte correctie.",
           "hourly_balance_hysteresis_w": "Minimale verandering in de verschuiving vereist voordat een nieuwe correctie wordt toegepast. Voorkomt micro-aanpassingen elke cyclus. 0 = altijd toepassen. Standaard: 15 W."
         }
+      },
+      "battery_connection_sessy": {
+        "title": "Batterij {battery_num} configureren — Verbinding (Sessy)",
+        "description": "Wijzig de verbindingsgegevens voor de Sessy-batterij {battery_num}.",
+        "data": {"name": "Naam", "host": "IP-adres", "port": "HTTP-poort"},
+        "data_description": {"name": "Beschrijvende naam om deze batterij te identificeren", "host": "IP-adres van het Sessy-apparaat op het lokale netwerk", "port": "HTTP-poort (standaard 80)"}
       },
       "battery_connection_anker": {
         "title": "Configure battery {battery_num} — Connection (Anker)",

--- a/tests/test_sessy_driver.py
+++ b/tests/test_sessy_driver.py
@@ -1,11 +1,15 @@
 """Tests for the Sessy local HTTP driver."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import voluptuous as vol
 
-from custom_components.omnibattery.config_flow import MarstekVenusConfigFlow
+from custom_components.omnibattery.config_flow import (
+    MarstekVenusConfigFlow,
+    OptionsFlowHandler,
+)
 from custom_components.omnibattery.drivers.sessy import SessyLocalDriver
 from custom_components.omnibattery.sensors.calculated_sensors import (
     MarstekVenusCycleSensor,
@@ -112,6 +116,11 @@ async def test_sessy_configuration_requests_and_persists_nominal_capacity():
     form = await flow.async_step_battery_limits()
     fields = {marker.schema for marker in form["data_schema"].schema}
     assert "battery_capacity_kwh" in fields
+    capacity_marker = next(
+        marker for marker in form["data_schema"].schema if marker.schema == "battery_capacity_kwh"
+    )
+    assert isinstance(capacity_marker, vol.Required)
+    assert form["data_schema"].schema[capacity_marker].config["min"] == 0.01
 
     await flow.async_step_battery_limits(
         {
@@ -126,3 +135,83 @@ async def test_sessy_configuration_requests_and_persists_nominal_capacity():
     )
 
     assert flow.battery_configs[0]["battery_capacity_kwh"] == 5.12
+
+
+@pytest.mark.asyncio
+async def test_options_flow_offers_and_configures_sessy(monkeypatch):
+    entry = SimpleNamespace(entry_id="test-entry", data={"batteries": []})
+    flow = OptionsFlowHandler(entry)
+    flow.hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_known_entry=lambda entry_id: entry if entry_id == entry.entry_id else None
+        )
+    )
+    flow.handler = entry.entry_id
+
+    form = await flow.async_step_battery_brand()
+    selector = next(iter(form["data_schema"].schema.values()))
+    assert {option["value"] for option in selector.config["options"]} >= {"sessy"}
+
+    form = await flow.async_step_battery_brand({"brand": "sessy"})
+    assert form["step_id"] == "battery_connection_sessy"
+
+    flow._current_battery_data = {"brand": "sessy"}
+    limits = await flow.async_step_battery_limits()
+    fields = {
+        marker.schema: selector for marker, selector in limits["data_schema"].schema.items()
+    }
+    assert fields["max_charge_power"].config["max"] == 2200
+    assert fields["max_discharge_power"].config["max"] == 2200
+    capacity_marker = next(
+        marker for marker in limits["data_schema"].schema if marker.schema == "battery_capacity_kwh"
+    )
+    assert isinstance(capacity_marker, vol.Required)
+    assert not callable(capacity_marker.default)
+    assert fields["battery_capacity_kwh"].config["min"] == 0.01
+
+    probe = AsyncMock(return_value=True)
+    monkeypatch.setattr(SessyLocalDriver, "probe", probe)
+    flow.async_step_battery_limits = AsyncMock(return_value={"type": "form"})
+    result = await flow.async_step_battery_connection_sessy(
+        {"name": "Garage Sessy", "host": "sessy.local", "port": 80}
+    )
+
+    assert result == {"type": "form"}
+    probe.assert_awaited_once_with("sessy.local", 80)
+    assert flow._current_battery_data == {
+        "brand": "sessy", "name": "Garage Sessy", "host": "sessy.local", "port": 80
+    }
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_routes_sessy_to_its_http_form(monkeypatch):
+    entry = SimpleNamespace(
+        entry_id="test-entry",
+        data={
+            "batteries": [
+                {"brand": "sessy", "name": "Garage Sessy", "host": "old.local", "port": 80}
+            ]
+        },
+    )
+    flow = MarstekVenusConfigFlow()
+    flow.battery_index = 0
+    flow._reconfigure_batteries = []
+    flow._get_reconfigure_entry = lambda: entry
+    flow._migrate_battery_registry_ids = MagicMock()
+
+    form = await flow.async_step_reconfigure_battery()
+    assert form["step_id"] == "reconfigure_battery_sessy"
+    assert {marker.schema for marker in form["data_schema"].schema} == {"name", "host", "port"}
+
+    probe = AsyncMock(return_value=True)
+    monkeypatch.setattr(SessyLocalDriver, "probe", probe)
+    flow.async_update_reload_and_abort = MagicMock(return_value={"type": "abort"})
+    result = await flow.async_step_reconfigure_battery_sessy(
+        {"name": "Garage Sessy", "host": "new.local", "port": 80}
+    )
+
+    assert result == {"type": "abort"}
+    probe.assert_awaited_once_with("new.local", 80)
+    assert flow._reconfigure_batteries == [
+        {"brand": "sessy", "name": "Garage Sessy", "host": "new.local", "port": 80}
+    ]


### PR DESCRIPTION
Expose Sessy in the options-flow brand selector and route setup, options, and reconfiguration through the dedicated local HTTP connection forms and probe.

Enforce the 2200 W hardware ceiling and require a real nominal capacity without inventing a 0.01 kWh default for legacy or newly converted entries.

Add localized Sessy labels and capacity guidance to every translation catalog, and cover selection, limits, capacity, connection, and reconfiguration with regression tests.