### PR TITLE
fix: align predictive slot notification with charge target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.0b2] - 2026-07-28
+
+### Fixed
+- **Time-slot predictive-charging notifications could report an incorrect grid-charge amount**: the notification now reports the planned grid energy that actually determines the predictive SOC target. Forecast solar surplus is shown as an energy-balance estimate after expected consumption, rather than as a guaranteed battery top-up.
+
 ## [1.2.0b1] - 2026-07-27
 
 ### Added

--- a/custom_components/omnibattery/pricing/notifications.py
+++ b/custom_components/omnibattery/pricing/notifications.py
@@ -43,7 +43,7 @@ def format_predictive_notification_message(
     )
     effective_power = min(max_contracted_power, max_charge_capacity)
     power_str = (
-        f"{effective_power}W (ICP: {max_contracted_power}W, batteries: {max_charge_capacity}W)"
+        f"{effective_power}W (contracted: {max_contracted_power}W, batteries: {max_charge_capacity}W)"
     )
 
     # Safe mode: no solar forecast
@@ -88,7 +88,7 @@ def format_predictive_notification_message(
             if slot_str else "⏰ Charging now from grid\n"
         )
 
-    grid_charge = decision_data.get("grid_charge_kwh")
+    planned_grid_charge = decision_data.get("planned_grid_charge_kwh")
     solar_surplus = decision_data.get("solar_surplus_kwh")
     if decision_data.get("floor_active"):
         # Charge is driven by the guaranteed-minimum-SOC floor, not the daily
@@ -98,11 +98,15 @@ def format_predictive_notification_message(
         charge_split_line = (
             f"🔌 Grid: {energy_deficit:.2f} kWh to reach guaranteed minimum SOC\n"
         )
-    elif grid_charge is not None and solar_surplus is not None:
-        # solar_surplus is capped at battery headroom, so it's the amount solar
-        # can actually add; grid covers the rest of the gap.
+    elif planned_grid_charge is not None and solar_surplus is not None:
+        # The predictive SOC target is based on planned_grid_charge_kwh.  Do not
+        # report the complementary headroom calculation here: it can differ
+        # from the actual grid target when a grid-charge margin is configured.
+        # Solar surplus is a whole-day energy-balance estimate, not a promise
+        # that the remainder of today's battery headroom will be solar-charged.
         charge_split_line = (
-            f"🔌 Grid: {grid_charge:.2f} kWh — solar will charge the remaining {solar_surplus:.2f} kWh\n"
+            f"🔌 Planned grid charge: {planned_grid_charge:.2f} kWh\n"
+            f"☀️ Forecast solar surplus: {solar_surplus:.2f} kWh (after expected consumption)\n"
         )
     else:
         charge_split_line = f"⚡ Deficit: {energy_deficit:.2f} kWh\n"

--- a/tests/test_pricing_notifications.py
+++ b/tests/test_pricing_notifications.py
@@ -81,7 +81,27 @@ def test_predictive_started():
     )
     assert title == "Predictive Charging: STARTED"
     assert "06:00" in message  # end of charging slot
-    assert "ICP: 5000W, batteries: 3000W" in message
+    assert "contracted: 5000W, batteries: 3000W" in message
+
+
+def test_predictive_started_reports_the_actual_planned_grid_charge():
+    """The notification must match the energy used to calculate the SOC target."""
+    _, message = notifications.format_predictive_notification_message(
+        _decision(
+            should_charge=True,
+            energy_deficit_kwh=4.63,
+            planned_grid_charge_kwh=5.55,
+            # This is the old complementary-headroom value.  It must not be
+            # presented as the grid charge or as a guaranteed solar top-up.
+            grid_charge_kwh=4.03,
+            solar_surplus_kwh=2.99,
+        ),
+        **_CFG,
+    )
+    assert "Planned grid charge: 5.55 kWh" in message
+    assert "Forecast solar surplus: 2.99 kWh (after expected consumption)" in message
+    assert "Grid: 4.03 kWh" not in message
+    assert "solar will charge the remaining" not in message
 
 
 def test_predictive_floor_charge_reports_grid_deficit_not_solar():


### PR DESCRIPTION
Report the planned grid energy used to calculate predictive SOC targets instead of a complementary battery-headroom split. Present forecast solar surplus as an energy-balance estimate rather than a promised battery top-up, and update the contracted-power wording.