### PR TITLE
docs: add Spanish updates for PR 221

### DIFF
--- a/site-docs/configuration/advanced.es.md
+++ b/site-docs/configuration/advanced.es.md
@@ -1,6 +1,6 @@
 # Opciones avanzadas
 
-Tras configurar la carga predictiva, el asistente ofrece cinco pasos opcionales adicionales que ajustan el comportamiento de la integración en situaciones específicas.
+Tras la configuración inicial, el dashboard de Omnibattery ofrece controles opcionales para funciones que ajustan el comportamiento de la integración en situaciones específicas.
 
 ---
 

--- a/site-docs/configuration/advanced.md
+++ b/site-docs/configuration/advanced.md
@@ -1,6 +1,6 @@
 # Advanced options
 
-After configuring predictive charging, the wizard offers five additional optional steps that adjust the integration's behaviour in specific situations.
+After the initial setup, the Omnibattery Dashboard exposes optional controls for features that adjust the integration's behaviour in specific situations.
 
 ---
 

--- a/site-docs/configuration/batteries.es.md
+++ b/site-docs/configuration/batteries.es.md
@@ -64,6 +64,14 @@ Si elevas el **SOC máximo** de una batería al `100 %`, esa batería usa protec
 
 ---
 
+## Límites de potencia del sistema (todas las baterías combinadas)
+
+Configura estos límites desde el dashboard de Omnibattery. Activa el interruptor para limitar la potencia combinada de carga o descarga de todas las baterías activas. El límite individual de cada batería se sigue aplicando; establecer cualquiera de los límites del sistema en `0 W` desactiva ese límite.
+
+![Límites de potencia del sistema](../assets/screenshots/configuration/battery-system-power-limits-config.png){ width="650" style="display: block; margin: 0 auto;"}
+
+---
+
 ## Umbral offgrid backup en tiempo de ejecución
 
 La entidad numérica **Umbral Offgrid Backup** (visible en la tarjeta de dispositivo de cada batería, entre las entidades de configuración) permite ajustar el umbral en cualquier momento sin entrar al flujo de opciones. Auméntalo si tu batería tiene cargas permanentes pequeñas en el puerto offgrid — como un switch PoE, router o cámaras IP — que de otro modo mantendrían la batería permanentemente excluida del control PD.

--- a/site-docs/configuration/batteries.md
+++ b/site-docs/configuration/batteries.md
@@ -74,6 +74,8 @@ If you raise a battery's **Max SOC** to `100 %`, that battery uses voltage-based
 
 ## System power limits (all batteries combined)
 
+Configure these limits from the Omnibattery Dashboard. Enable the switch to cap the combined charge or discharge power of all active batteries. Each battery's individual limit still applies, and setting either system cap to `0 W` disables that cap.
+
 ![system power limits](../assets/screenshots/configuration/battery-system-power-limits-config.png){ width="650"  style="display: block; margin: 0 auto;"}
 
 ---

--- a/site-docs/configuration/index.es.md
+++ b/site-docs/configuration/index.es.md
@@ -1,12 +1,15 @@
 # Configuración
 
-La integración se configura íntegramente desde la interfaz de Home Assistant mediante un asistente de varios pasos.
+La integración se configura mediante dos interfaces:
 
-## Pasos del asistente
+- La interfaz de Home Assistant, a través de un asistente de varios pasos.
+- El dashboard de Omnibattery.
+
+## Configuración del asistente de Home Assistant
 
 ```mermaid
 flowchart TD
-    A[1. Sensor principal] --> B[2. Número de baterías]
+    A[1. Config. del sensor principal] --> B[2. Número de baterías]
     B --> C[3. Config. por batería]
     C --> D{¿Franjas horarias?}
     D -- Sí --> E[4. Franjas horarias]
@@ -17,29 +20,15 @@ flowchart TD
     G --> H{¿Carga predictiva?}
     H -- Sí --> I[6. Modo de carga predictiva]
     H -- No --> J
-    I --> J{¿Carga semanal completa?}
-    J -- Sí --> K[7. Día de carga semanal completa]
-    J -- No --> L
-    K --> L{¿Retraso de carga solar?}
-    L -- Sí --> M[8. Config. retraso de carga solar]
-    L -- No --> N
-    M --> N{¿Protección de capacidad?}
-    N -- Sí --> O[9. Config. protección de capacidad]
-    N -- No --> P
-    O --> P{¿Balance neto horario?}
-    P -- Sí --> Q[10. Config. balance neto horario]
-    P -- No --> R
-    Q --> R{¿Controlador PD avanzado?}
-    R -- Sí --> S[11. Config. controlador PD avanzado]
-    R -- No --> T[Fin]
-    S --> T
+    I --> J
+    J[Fin]
 ```
 
-| Paso | Descripción | Obligatorio |
+| Sección | Descripción | Obligatorio |
 |------|-------------|:-----------:|
-| [Sensor principal](main-sensor.md) | Sensor de consumo de red y sensor solar (el consumo del hogar se deriva) | ✅ |
+| [Sensores](main-sensor.md) | Sensor de consumo de red y sensor solar (el consumo del hogar se deriva) | ✅ |
 | Baterías | Número de unidades | ✅ |
-| [Baterías](batteries.md) | Config. por batería: nombre, IP, puerto, versión, límites de potencia y SOC | ✅ |
+| [Baterías](batteries.md) | Configuración por batería: nombre, IP, puerto, versión, límites de potencia y SOC | ✅ |
 | [Franjas horarias](time-slots.md) | Ventanas de descarga/carga con parámetros por franja | ❌ |
 | [Dispositivos excluidos](excluded-devices.md) | Cargas pesadas a ignorar | ❌ |
 | [Carga predictiva](predictive-charging/index.md) | Carga desde la red cuando la previsión solar es insuficiente | ❌ |
@@ -47,6 +36,7 @@ flowchart TD
 | [Retraso de carga solar](advanced.md) | Evita cargar las baterías por la mañana si la producción solar prevista será suficiente | ❌ |
 | [Protección de capacidad](advanced.md) | Reserva una parte de la capacidad de batería para picos de demanda (peak shaving) | ❌ |
 | [Balance neto horario](advanced.md) | Establece el balance neto de importación/exportación horario a un objetivo específico (por defecto 0 Wh) | ❌ |
+| [Límites de potencia del sistema](batteries.md#limites-de-potencia-del-sistema-todas-las-baterias-combinadas) | Limita la potencia combinada de carga/descarga de todas las baterías activas | ❌ |
 | [Controlador PD (avanzado)](advanced.md) | Ajuste fino del controlador PD para mantener el flujo de red en el objetivo configurado | ❌ |
 
 ## Modificar la configuración
@@ -54,4 +44,4 @@ flowchart TD
 Una vez instalada, puedes modificar cualquier parámetro en:
 **Ajustes → Dispositivos y servicios → Omnibattery → Configurar**
 
-![Reconfigure Omnibattery](../assets/screenshots/configuration/reconfigure-marstek-venus-energy-manager.png){ width="650" style="display: block; margin: 0 auto;"}
+![Reconfigurar Omnibattery](../assets/screenshots/configuration/reconfigure-omnibattery.png){ width="650" style="display: block; margin: 0 auto;"}

--- a/site-docs/configuration/index.md
+++ b/site-docs/configuration/index.md
@@ -1,8 +1,9 @@
 # Configuration
 
-The integration is configured from :
- - the Home Assistant UI through a multi-step wizard
- - the Omnibattery Dashboard
+The integration is configured through two interfaces:
+
+- the Home Assistant UI through a multi-step wizard
+- the Omnibattery Dashboard
 
 ## Home Assistant wizard configuration
 
@@ -23,11 +24,11 @@ flowchart TD
     J[Done]
 ```
 
-| Features | Description | Required |
+| Section | Description | Required |
 |------|-------------|:--------:|
 | [Sensors](main-sensor.md) | Grid consumption sensor and solar sensor (home consumption is derived) | ✅ |
 | Batteries | Number of battery units | ✅ |
-| [Batteries](batteries.md) | Per-battery config : name, IP, port, version, power limits and SOC | ✅ |
+| [Batteries](batteries.md) | Per-battery configuration: name, IP, port, version, power limits and SOC | ✅ |
 | [Time slots](time-slots.md) | Discharge/charge windows with per-slot parameters | ❌ |
 | [Excluded devices](excluded-devices.md) | Heavy loads to ignore | ❌ |
 | [Predictive charging](predictive-charging/index.md) | Grid charging when solar forecast is insufficient | ❌ |
@@ -41,6 +42,7 @@ flowchart TD
 | [Temperature charge limit](advanced.md) | Linear derate charge/discharge power based on battery temperature | ❌ |
 | [Capacity protection](advanced.md) | Reserves a portion of battery capacity for demand spikes (peak shaving) | ❌ |
 | [Hourly net balance](advanced.md) | Sets the hourly net import/export energy to a specific target (default 0 Wh) | ❌ |
+| [System power limits](batteries.md#system-power-limits-all-batteries-combined) | Caps combined charge/discharge power across all active batteries | ❌ |
 | [PD controller (advanced)](advanced.md) | Finetune the PD controller to keep the grid flow to the configured target | ❌ |
 
 ## Modifying the configuration


### PR DESCRIPTION
Mirror the configuration wizard and dashboard documentation in Spanish, including the system-wide power-limit controls and updated reconfiguration screenshot. Align the English pages with the current dashboard-driven setup flow and document the combined-limit behavior.