### PR TITLE
feat: add smart anti-curtailment pre-discharge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Smart Pre-discharge / Anti-curtailment for Dynamic Pricing**: an opt-in planner detects forecast PV surplus during configurable negative-injection price windows, creates headroom using the existing PD controller, blocks discharge while the protected window is active, and exposes live controls and diagnostics. Existing installations remain disabled by default.
+
 ## [1.2.0] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **One-Click PD Profiles + Quality Sensor**: Pick a tuning profile (Very smooth → Very aggressive) instead of tuning gains by hand; a control-quality sensor reports whether the result is stable, oscillating or sluggish.
 - **Multi-Battery Support**: Manage up to 6 batteries with intelligent load sharing and SOC-based priority.
 - **Predictive Grid Charging**: Automatically charges from the grid when solar forecast + battery won't cover tomorrow's consumption. Supports fixed time slots, dynamic pricing, and real-time pricing modes. An optional grid-charge margin (%) tops up the grid amount to hedge optimistic solar forecasts.
+- **Smart Pre-discharge / Anti-curtailment**: Optional Dynamic Pricing-only planning creates battery headroom before forecast PV surplus at negative-injection prices, then blocks discharge during the protected window while preserving SOC floors and safety ownership.
 - **Time Slots**: Per-battery windows with independent charge/discharge ticks, optional SOC and power overrides, and a manual mode that forces a fixed charge or discharge power. Up to 8 slots per integration.
 - **Weekly Full Charge**: Forces 100% SOC once a week for LFP cell balancing.
 - **Solar-Aware Charge Delay**: Holds back grid charging while solar can still cover the required energy.

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -117,6 +117,16 @@ from .const import (
     CONF_MIN_ARBITRAGE_MARGIN,
     CONF_ROUND_TRIP_EFFICIENCY,
     DEFAULT_ROUND_TRIP_EFFICIENCY,
+    CONF_SMART_PREDISCHARGE_ENABLED,
+    CONF_NEGATIVE_INJECTION_THRESHOLD,
+    CONF_PREDISCHARGE_RESERVE_SOC,
+    CONF_PREDISCHARGE_MAX_EXPORT_POWER_W,
+    CONF_CURTAILMENT_HEADROOM_MARGIN_PCT,
+    DEFAULT_SMART_PREDISCHARGE_ENABLED,
+    DEFAULT_NEGATIVE_INJECTION_THRESHOLD,
+    DEFAULT_PREDISCHARGE_RESERVE_SOC,
+    DEFAULT_PREDISCHARGE_MAX_EXPORT_POWER_W,
+    DEFAULT_CURTAILMENT_HEADROOM_MARGIN_PCT,
     CONF_AVERAGE_PRICE_SENSOR,
     CONF_DP_PRICE_DISCHARGE_CONTROL,
     CONF_RT_PRICE_DISCHARGE_CONTROL,
@@ -608,6 +618,21 @@ class ChargeDischargeController:
         self.round_trip_efficiency = config_entry.data.get(
             CONF_ROUND_TRIP_EFFICIENCY, DEFAULT_ROUND_TRIP_EFFICIENCY
         )
+        self.smart_predischarge_enabled = config_entry.data.get(
+            CONF_SMART_PREDISCHARGE_ENABLED, DEFAULT_SMART_PREDISCHARGE_ENABLED
+        )
+        self.negative_injection_threshold = config_entry.data.get(
+            CONF_NEGATIVE_INJECTION_THRESHOLD, DEFAULT_NEGATIVE_INJECTION_THRESHOLD
+        )
+        self.predischarge_reserve_soc = config_entry.data.get(
+            CONF_PREDISCHARGE_RESERVE_SOC, DEFAULT_PREDISCHARGE_RESERVE_SOC
+        )
+        self.predischarge_max_export_power_w = config_entry.data.get(
+            CONF_PREDISCHARGE_MAX_EXPORT_POWER_W, DEFAULT_PREDISCHARGE_MAX_EXPORT_POWER_W
+        )
+        self.curtailment_headroom_margin_pct = config_entry.data.get(
+            CONF_CURTAILMENT_HEADROOM_MARGIN_PCT, DEFAULT_CURTAILMENT_HEADROOM_MARGIN_PCT
+        )
         self.dp_price_discharge_control: bool = config_entry.data.get(CONF_DP_PRICE_DISCHARGE_CONTROL, False)
         self._dp_daily_avg_price: Optional[float] = None  # Computed from price slots in _evaluate_dynamic_pricing
         self._dp_arbitrage_ceiling: Optional[float] = None  # Set per evaluation when the margin gate is on
@@ -644,6 +669,14 @@ class ChargeDischargeController:
         self._solar_forecast_issue_cleared = False
         self._dp_evening_reevaluated_date = None  # Prevent multiple evening re-evaluations per day
         self._dp_last_eval_soc = None  # avg SOC at last DP (re)eval; SOC-drop reeval reference (#411)
+        # Smart pre-discharge is runtime-only.  Plans are rebuilt after restart;
+        # no plan or override is persisted in Home Assistant storage.
+        self._curtailment_plan = None
+        self._curtailment_runtime_status = "disabled"
+        self._curtailment_runtime_reason = "disabled"
+        self._curtailment_active = False
+        self._curtailment_active_export_target_w = 0.0
+        self._curtailment_last_evaluation = None
         self._pricing_mgr = PricingManager(hass, self)
 
         # Consumption history for dynamic base consumption (7-day rolling average)
@@ -1093,6 +1126,14 @@ class ChargeDischargeController:
 
     def update_pd_parameters(self):
         """Re-read PD controller parameters from config_entry.data (hot-reload)."""
+        old_pricing_mode = self.predictive_charging_mode
+        old_smart_predischarge = self.smart_predischarge_enabled
+        old_curtailment_config = (
+            self.negative_injection_threshold,
+            self.predischarge_reserve_soc,
+            self.predischarge_max_export_power_w,
+            self.curtailment_headroom_margin_pct,
+        )
         # Update weekly full charge settings; reset completion state if day changed
         new_weekly_day = self.config_entry.data.get(CONF_WEEKLY_FULL_CHARGE_DAY, "sun")
         new_weekly_enabled = self.config_entry.data.get(CONF_ENABLE_WEEKLY_FULL_CHARGE, False)
@@ -1177,12 +1218,44 @@ class ChargeDischargeController:
         self.round_trip_efficiency = self.config_entry.data.get(
             CONF_ROUND_TRIP_EFFICIENCY, DEFAULT_ROUND_TRIP_EFFICIENCY
         )
+        self.smart_predischarge_enabled = self.config_entry.data.get(
+            CONF_SMART_PREDISCHARGE_ENABLED, DEFAULT_SMART_PREDISCHARGE_ENABLED
+        )
+        self.negative_injection_threshold = self.config_entry.data.get(
+            CONF_NEGATIVE_INJECTION_THRESHOLD, DEFAULT_NEGATIVE_INJECTION_THRESHOLD
+        )
+        self.predischarge_reserve_soc = self.config_entry.data.get(
+            CONF_PREDISCHARGE_RESERVE_SOC, DEFAULT_PREDISCHARGE_RESERVE_SOC
+        )
+        self.predischarge_max_export_power_w = self.config_entry.data.get(
+            CONF_PREDISCHARGE_MAX_EXPORT_POWER_W, DEFAULT_PREDISCHARGE_MAX_EXPORT_POWER_W
+        )
+        self.curtailment_headroom_margin_pct = self.config_entry.data.get(
+            CONF_CURTAILMENT_HEADROOM_MARGIN_PCT, DEFAULT_CURTAILMENT_HEADROOM_MARGIN_PCT
+        )
+        new_curtailment_config = (
+            self.negative_injection_threshold,
+            self.predischarge_reserve_soc,
+            self.predischarge_max_export_power_w,
+            self.curtailment_headroom_margin_pct,
+        )
         self.capacity_protection_enabled = self.config_entry.data.get(CONF_CAPACITY_PROTECTION_ENABLED, False)
         self.capacity_protection_excluded_devices = self.config_entry.data.get(
             CONF_CAPACITY_PROTECTION_EXCLUDED_DEVICES, False
         )
         self.capacity_protection_soc_threshold = self.config_entry.data.get(CONF_CAPACITY_PROTECTION_SOC_THRESHOLD, DEFAULT_CAPACITY_PROTECTION_SOC)
         self.capacity_protection_limit = self.config_entry.data.get(CONF_CAPACITY_PROTECTION_LIMIT, DEFAULT_CAPACITY_PROTECTION_LIMIT)
+
+        if (
+            old_pricing_mode != self.predictive_charging_mode
+            or old_smart_predischarge != self.smart_predischarge_enabled
+            or old_curtailment_config != new_curtailment_config
+            or self.predictive_charging_mode != PREDICTIVE_MODE_DYNAMIC_PRICING
+            or not self.smart_predischarge_enabled
+        ):
+            self._pricing_mgr.clear_curtailment_runtime(
+                "mode_or_configuration_changed"
+            )
 
         # Hourly balance: ON→OFF cleans up offset; flag change is enough for async_process to react
         new_hb_enabled = self.config_entry.data.get(CONF_ENABLE_HOURLY_BALANCE, False)
@@ -1419,7 +1492,21 @@ class ChargeDischargeController:
         """Return True if discharge is blocked globally or for the given battery."""
         if self._global_discharge_blockers:
             return True
-        return bool(coordinator is not None and self._battery_discharge_blockers.get(coordinator))
+        if coordinator is None:
+            return False
+        blockers = self._battery_discharge_blockers.get(coordinator, {})
+        if self._capacity_protection_overrides_curtailment():
+            return bool(
+                set(blockers) - {"curtailment_negative_window"}
+            )
+        return bool(blockers)
+
+    def _capacity_protection_overrides_curtailment(self) -> bool:
+        """Whether the priority-10 capacity-safety path may use the battery."""
+        return bool(
+            getattr(self, "_capacity_protection_active", False)
+            or "capacity_protection" in getattr(self, "_setpoint_overrides", {})
+        )
 
     def get_charge_blockers(self, coordinator=None) -> dict:
         """Return charge blockers for the requested scope."""
@@ -1435,6 +1522,10 @@ class ChargeDischargeController:
             return self._serialize_blockers(self._global_discharge_blockers)
         merged = dict(self._global_discharge_blockers)
         merged.update(self._battery_discharge_blockers.get(coordinator, {}))
+        if self._capacity_protection_overrides_curtailment():
+            # Capacity protection owns priority 10 and must remain able to
+            # shave a peak even while the solar window guard is active.
+            merged.pop("curtailment_negative_window", None)
         return self._serialize_blockers(merged)
 
     def get_battery_charge_blockers(self) -> dict:
@@ -1883,6 +1974,11 @@ class ChargeDischargeController:
 
         self._refresh_time_slot_blocks()
         self._apply_price_discharge_block()
+        # Smart pre-discharge is evaluated only in dynamic-pricing mode and
+        # registers its negative-window/floor guards centrally before PD runs.
+        pricing_mgr = getattr(self, "_pricing_mgr", None)
+        if pricing_mgr is not None:
+            pricing_mgr.refresh_curtailment_runtime()
         self._refresh_ev_blocks()
         self._refresh_dynamic_power_control_block()
         self._refresh_user_battery_blocks()
@@ -4837,6 +4933,7 @@ class ChargeDischargeController:
         # === MANUAL MODE CHECK (highest priority) ===
         # If manual mode is enabled, skip all automatic control logic
         if self.manual_mode_enabled:
+            self._pricing_mgr.clear_curtailment_runtime("manual_mode")
             _LOGGER.debug("Manual Mode active - skipping automatic control")
             # Register-based drivers (Marstek) obey the user's force_mode /
             # set_*_power register writes directly, so we just freeze the
@@ -6300,6 +6397,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if data := hass.data[DOMAIN].get(entry.entry_id):
         coordinators = data.get("coordinators", [])
+        controller = data.get("controller")
+        if controller is not None:
+            # Remove the opt-in runtime override/blockers before the control
+            # timer and entities disappear.  The plan itself is never persisted.
+            controller._pricing_mgr.clear_curtailment_runtime("unload")
 
         # 1. Cancel periodic timers FIRST to stop control loop and coordinator refresh
         # These run every 2.0s / 1.5s and would write registers on a closing connection

--- a/custom_components/omnibattery/binary_sensor.py
+++ b/custom_components/omnibattery/binary_sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -11,7 +12,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN, CONF_CAPACITY_PROTECTION_ENABLED
+from .const import (
+    DOMAIN,
+    CONF_CAPACITY_PROTECTION_ENABLED,
+    PREDICTIVE_MODE_DYNAMIC_PRICING,
+)
 from .infra.coordinator import MarstekVenusDataUpdateCoordinator
 from .infra.entity_naming import english_entity_id, system_entity_id, SYSTEM_UNIQUE_ID_PREFIX
 
@@ -40,6 +45,8 @@ async def async_setup_entry(
     # Add predictive charging status sensor (system-level)
     if controller and controller.predictive_charging_enabled:
         entities.append(PredictiveChargingStatusSensor(hass, entry, controller))
+        if controller.predictive_charging_mode == PREDICTIVE_MODE_DYNAMIC_PRICING:
+            entities.append(CurtailmentStatusSensor(hass, entry, controller))
 
     # Add capacity protection status sensor (system-level, when configured, regardless of enabled state)
     if controller and CONF_CAPACITY_PROTECTION_ENABLED in entry.data:
@@ -218,6 +225,98 @@ class CapacityProtectionStatusSensor(BinarySensorEntity):
     @property
     def device_info(self):
         """Return device information for the system."""
+        return {
+            "identifiers": {(DOMAIN, "marstek_venus_system")},
+            "name": "Omnibattery System",
+            "manufacturer": "Omnibattery",
+            "model": "Multi-Battery System",
+        }
+
+
+class CurtailmentStatusSensor(BinarySensorEntity):
+    """Diagnostic state for the dynamic-pricing smart pre-discharge planner."""
+
+    _unrecorded_attributes = frozenset({
+        "risk_slots",
+        "selected_discharge_slots",
+        "target_soc_by_battery",
+    })
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, controller) -> None:
+        self.hass = hass
+        self.entry = entry
+        self.controller = controller
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "curtailment_status"
+        self._attr_unique_id = f"{SYSTEM_UNIQUE_ID_PREFIX}curtailment_status"
+        self.entity_id = system_entity_id("binary_sensor", "curtailment_status")
+        self._attr_device_class = "running"
+        self._attr_icon = "mdi:solar-power-variant"
+        self._attr_should_poll = True
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def is_on(self) -> bool:
+        return getattr(self.controller, "_curtailment_runtime_status", "disabled") in {
+            "predischarging",
+            "protected_window",
+        }
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        plan = getattr(self.controller, "_curtailment_plan", None)
+        attrs = {
+            "enabled": bool(getattr(self.controller, "smart_predischarge_enabled", False)),
+            "status": getattr(self.controller, "_curtailment_runtime_status", "disabled"),
+            "reason": getattr(self.controller, "_curtailment_runtime_reason", "disabled"),
+            "active_export_target_w": getattr(
+                self.controller, "_curtailment_active_export_target_w", 0.0
+            ),
+            "negative_injection_threshold": getattr(
+                self.controller, "negative_injection_threshold", 0.0
+            ),
+        }
+        if plan is None:
+            return attrs
+        now = datetime.now()
+        next_window = next(
+            (slot.start.isoformat() for slot in plan.risk_slots if slot.end > now),
+            None,
+        )
+        attrs.update({
+            "next_window": next_window,
+            "risk_slots": [
+                {"start": slot.start.isoformat(), "end": slot.end.isoformat(), "price": slot.price}
+                for slot in plan.risk_slots
+            ],
+            "required_headroom_kwh": round(plan.required_headroom_kwh, 3),
+            "current_headroom_kwh": round(plan.current_headroom_kwh, 3),
+            "planned_discharge_kwh": round(plan.planned_discharge_kwh, 3),
+            "shortfall_kwh": round(plan.shortfall_kwh, 3),
+            "target_soc_by_battery": {
+                name: round(value, 1)
+                for name, value in plan.target_soc_by_battery.items()
+            },
+            "selected_discharge_slots": [
+                {
+                    "start": slot.start.isoformat(),
+                    "end": slot.end.isoformat(),
+                    "price": slot.price,
+                    "planned_energy_kwh": round(slot.planned_energy_kwh, 3),
+                    "power_w": round(slot.power_w),
+                }
+                for slot in plan.selected_discharge_slots
+            ],
+            "plan_status": plan.status,
+            "plan_reason": plan.reason,
+            "evaluation_time": (
+                plan.evaluation_time.isoformat() if plan.evaluation_time else None
+            ),
+        })
+        return attrs
+
+    @property
+    def device_info(self):
         return {
             "identifiers": {(DOMAIN, "marstek_venus_system")},
             "name": "Omnibattery System",

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -72,6 +72,16 @@ from .const import (
     CONF_PRICE_INTEGRATION_TYPE,
     CONF_MAX_PRICE_THRESHOLD,
     CONF_DISCHARGE_PRICE_THRESHOLD,
+    CONF_SMART_PREDISCHARGE_ENABLED,
+    CONF_NEGATIVE_INJECTION_THRESHOLD,
+    CONF_PREDISCHARGE_RESERVE_SOC,
+    CONF_PREDISCHARGE_MAX_EXPORT_POWER_W,
+    CONF_CURTAILMENT_HEADROOM_MARGIN_PCT,
+    DEFAULT_SMART_PREDISCHARGE_ENABLED,
+    DEFAULT_NEGATIVE_INJECTION_THRESHOLD,
+    DEFAULT_PREDISCHARGE_RESERVE_SOC,
+    DEFAULT_PREDISCHARGE_MAX_EXPORT_POWER_W,
+    DEFAULT_CURTAILMENT_HEADROOM_MARGIN_PCT,
     CONF_AVERAGE_PRICE_SENSOR,
     CONF_DP_PRICE_DISCHARGE_CONTROL,
     CONF_RT_PRICE_DISCHARGE_CONTROL,
@@ -124,6 +134,13 @@ _SESSY_MAX_DISCHARGE_POWER_W = 1700
 _SESSY_DEFAULT_MIN_SOC = 5
 _HOYMILES_MAX_POWER_W = 2000
 _HOYMILES_DEFAULT_POWER_W = 1000
+
+
+def _parse_optional_float(value: Any) -> float | None:
+    """Parse a localized optional number while preserving an explicit zero."""
+    if value is None or value == "":
+        return None
+    return float(str(value).replace(",", "."))
 
 
 def _soc_selector_limits(brand: str) -> tuple[int, int, int, int, int, int]:
@@ -1575,10 +1592,8 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                                 errors["solar_forecast_sensor"] = "invalid_unit"
 
                 if not errors:
-                    max_price_raw = user_input.get(CONF_MAX_PRICE_THRESHOLD)
-                    max_price = float(str(max_price_raw).replace(",", ".")) if max_price_raw else None
-                    discharge_price_raw = user_input.get(CONF_DISCHARGE_PRICE_THRESHOLD)
-                    discharge_price = float(str(discharge_price_raw).replace(",", ".")) if discharge_price_raw else None
+                    max_price = _parse_optional_float(user_input.get(CONF_MAX_PRICE_THRESHOLD))
+                    discharge_price = _parse_optional_float(user_input.get(CONF_DISCHARGE_PRICE_THRESHOLD))
 
                     if max_price is not None and discharge_price is not None and discharge_price < max_price:
                         errors[CONF_DISCHARGE_PRICE_THRESHOLD] = "discharge_below_charge"
@@ -1594,6 +1609,21 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                         self.config_data["charging_time_slot"] = None
                         self.config_data[CONF_PREDICTIVE_SAFETY_MARGIN_KWH] = user_input.get(CONF_PREDICTIVE_SAFETY_MARGIN_KWH, DEFAULT_PREDICTIVE_SAFETY_MARGIN_KWH)
                         self.config_data[CONF_PREDICTIVE_GRID_CHARGE_MARGIN_PCT] = user_input.get(CONF_PREDICTIVE_GRID_CHARGE_MARGIN_PCT, DEFAULT_PREDICTIVE_GRID_CHARGE_MARGIN_PCT)
+                        self.config_data[CONF_SMART_PREDISCHARGE_ENABLED] = user_input.get(
+                            CONF_SMART_PREDISCHARGE_ENABLED, DEFAULT_SMART_PREDISCHARGE_ENABLED
+                        )
+                        self.config_data[CONF_NEGATIVE_INJECTION_THRESHOLD] = user_input.get(
+                            CONF_NEGATIVE_INJECTION_THRESHOLD, DEFAULT_NEGATIVE_INJECTION_THRESHOLD
+                        )
+                        self.config_data[CONF_PREDISCHARGE_RESERVE_SOC] = user_input.get(
+                            CONF_PREDISCHARGE_RESERVE_SOC, DEFAULT_PREDISCHARGE_RESERVE_SOC
+                        )
+                        self.config_data[CONF_PREDISCHARGE_MAX_EXPORT_POWER_W] = user_input.get(
+                            CONF_PREDISCHARGE_MAX_EXPORT_POWER_W, DEFAULT_PREDISCHARGE_MAX_EXPORT_POWER_W
+                        )
+                        self.config_data[CONF_CURTAILMENT_HEADROOM_MARGIN_PCT] = user_input.get(
+                            CONF_CURTAILMENT_HEADROOM_MARGIN_PCT, DEFAULT_CURTAILMENT_HEADROOM_MARGIN_PCT
+                        )
 
                         return await self._finish_setup()
             except Exception as e:
@@ -1633,6 +1663,19 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             NumberSelectorConfig(min=0, max=20, step=0.1, unit_of_measurement="kWh", mode=NumberSelectorMode.BOX)
         )
         schema_dict[vol.Optional(CONF_PREDICTIVE_GRID_CHARGE_MARGIN_PCT, default=DEFAULT_PREDICTIVE_GRID_CHARGE_MARGIN_PCT)] = NumberSelector(
+            NumberSelectorConfig(min=0, max=100, step=5, unit_of_measurement="%", mode=NumberSelectorMode.BOX)
+        )
+        schema_dict[vol.Optional(CONF_SMART_PREDISCHARGE_ENABLED, default=DEFAULT_SMART_PREDISCHARGE_ENABLED)] = bool
+        schema_dict[vol.Optional(CONF_NEGATIVE_INJECTION_THRESHOLD, default=DEFAULT_NEGATIVE_INJECTION_THRESHOLD)] = NumberSelector(
+            NumberSelectorConfig(min=-2, max=2, step=0.001, unit_of_measurement="€/kWh", mode=NumberSelectorMode.BOX)
+        )
+        schema_dict[vol.Optional(CONF_PREDISCHARGE_RESERVE_SOC, default=DEFAULT_PREDISCHARGE_RESERVE_SOC)] = NumberSelector(
+            NumberSelectorConfig(min=0, max=100, step=1, unit_of_measurement="%", mode=NumberSelectorMode.BOX)
+        )
+        schema_dict[vol.Optional(CONF_PREDISCHARGE_MAX_EXPORT_POWER_W, default=DEFAULT_PREDISCHARGE_MAX_EXPORT_POWER_W)] = NumberSelector(
+            NumberSelectorConfig(min=0, max=10000, step=50, unit_of_measurement="W", mode=NumberSelectorMode.BOX)
+        )
+        schema_dict[vol.Optional(CONF_CURTAILMENT_HEADROOM_MARGIN_PCT, default=DEFAULT_CURTAILMENT_HEADROOM_MARGIN_PCT)] = NumberSelector(
             NumberSelectorConfig(min=0, max=100, step=5, unit_of_measurement="%", mode=NumberSelectorMode.BOX)
         )
 
@@ -3428,10 +3471,8 @@ class OptionsFlowHandler(OptionsFlow):
                                 errors["solar_forecast_sensor"] = "invalid_unit"
 
                 if not errors:
-                    max_price_raw = user_input.get(CONF_MAX_PRICE_THRESHOLD)
-                    max_price = float(str(max_price_raw).replace(",", ".")) if max_price_raw else None
-                    discharge_price_raw = user_input.get(CONF_DISCHARGE_PRICE_THRESHOLD)
-                    discharge_price = float(str(discharge_price_raw).replace(",", ".")) if discharge_price_raw else None
+                    max_price = _parse_optional_float(user_input.get(CONF_MAX_PRICE_THRESHOLD))
+                    discharge_price = _parse_optional_float(user_input.get(CONF_DISCHARGE_PRICE_THRESHOLD))
 
                     if max_price is not None and discharge_price is not None and discharge_price < max_price:
                         errors[CONF_DISCHARGE_PRICE_THRESHOLD] = "discharge_below_charge"
@@ -3447,6 +3488,26 @@ class OptionsFlowHandler(OptionsFlow):
                         self.config_data["charging_time_slot"] = None
                         self.config_data[CONF_PREDICTIVE_SAFETY_MARGIN_KWH] = user_input.get(CONF_PREDICTIVE_SAFETY_MARGIN_KWH, DEFAULT_PREDICTIVE_SAFETY_MARGIN_KWH)
                         self.config_data[CONF_PREDICTIVE_GRID_CHARGE_MARGIN_PCT] = user_input.get(CONF_PREDICTIVE_GRID_CHARGE_MARGIN_PCT, DEFAULT_PREDICTIVE_GRID_CHARGE_MARGIN_PCT)
+                        self.config_data[CONF_SMART_PREDISCHARGE_ENABLED] = user_input.get(
+                            CONF_SMART_PREDISCHARGE_ENABLED,
+                            existing_config.get(CONF_SMART_PREDISCHARGE_ENABLED, DEFAULT_SMART_PREDISCHARGE_ENABLED),
+                        )
+                        self.config_data[CONF_NEGATIVE_INJECTION_THRESHOLD] = user_input.get(
+                            CONF_NEGATIVE_INJECTION_THRESHOLD,
+                            existing_config.get(CONF_NEGATIVE_INJECTION_THRESHOLD, DEFAULT_NEGATIVE_INJECTION_THRESHOLD),
+                        )
+                        self.config_data[CONF_PREDISCHARGE_RESERVE_SOC] = user_input.get(
+                            CONF_PREDISCHARGE_RESERVE_SOC,
+                            existing_config.get(CONF_PREDISCHARGE_RESERVE_SOC, DEFAULT_PREDISCHARGE_RESERVE_SOC),
+                        )
+                        self.config_data[CONF_PREDISCHARGE_MAX_EXPORT_POWER_W] = user_input.get(
+                            CONF_PREDISCHARGE_MAX_EXPORT_POWER_W,
+                            existing_config.get(CONF_PREDISCHARGE_MAX_EXPORT_POWER_W, DEFAULT_PREDISCHARGE_MAX_EXPORT_POWER_W),
+                        )
+                        self.config_data[CONF_CURTAILMENT_HEADROOM_MARGIN_PCT] = user_input.get(
+                            CONF_CURTAILMENT_HEADROOM_MARGIN_PCT,
+                            existing_config.get(CONF_CURTAILMENT_HEADROOM_MARGIN_PCT, DEFAULT_CURTAILMENT_HEADROOM_MARGIN_PCT),
+                        )
                         return await self._save_and_finish()
             except Exception as e:
                 _LOGGER.error("Error validating dynamic pricing config: %s", e)
@@ -3460,6 +3521,21 @@ class OptionsFlowHandler(OptionsFlow):
         default_dp_discharge_control = existing_config.get(CONF_DP_PRICE_DISCHARGE_CONTROL, False)
         default_margin = existing_config.get(CONF_PREDICTIVE_SAFETY_MARGIN_KWH, DEFAULT_PREDICTIVE_SAFETY_MARGIN_KWH)
         default_grid_margin = existing_config.get(CONF_PREDICTIVE_GRID_CHARGE_MARGIN_PCT, DEFAULT_PREDICTIVE_GRID_CHARGE_MARGIN_PCT)
+        default_smart_predischarge = existing_config.get(
+            CONF_SMART_PREDISCHARGE_ENABLED, DEFAULT_SMART_PREDISCHARGE_ENABLED
+        )
+        default_negative_threshold = existing_config.get(
+            CONF_NEGATIVE_INJECTION_THRESHOLD, DEFAULT_NEGATIVE_INJECTION_THRESHOLD
+        )
+        default_reserve_soc = existing_config.get(
+            CONF_PREDISCHARGE_RESERVE_SOC, DEFAULT_PREDISCHARGE_RESERVE_SOC
+        )
+        default_export_power = existing_config.get(
+            CONF_PREDISCHARGE_MAX_EXPORT_POWER_W, DEFAULT_PREDISCHARGE_MAX_EXPORT_POWER_W
+        )
+        default_headroom_margin = existing_config.get(
+            CONF_CURTAILMENT_HEADROOM_MARGIN_PCT, DEFAULT_CURTAILMENT_HEADROOM_MARGIN_PCT
+        )
 
         schema_dict: dict = {
             vol.Required(CONF_PRICE_INTEGRATION_TYPE, default=default_integration):
@@ -3501,6 +3577,19 @@ class OptionsFlowHandler(OptionsFlow):
             NumberSelectorConfig(min=0, max=20, step=0.1, unit_of_measurement="kWh", mode=NumberSelectorMode.BOX)
         )
         schema_dict[vol.Optional(CONF_PREDICTIVE_GRID_CHARGE_MARGIN_PCT, default=default_grid_margin)] = NumberSelector(
+            NumberSelectorConfig(min=0, max=100, step=5, unit_of_measurement="%", mode=NumberSelectorMode.BOX)
+        )
+        schema_dict[vol.Optional(CONF_SMART_PREDISCHARGE_ENABLED, default=default_smart_predischarge)] = bool
+        schema_dict[vol.Optional(CONF_NEGATIVE_INJECTION_THRESHOLD, default=default_negative_threshold)] = NumberSelector(
+            NumberSelectorConfig(min=-2, max=2, step=0.001, unit_of_measurement="€/kWh", mode=NumberSelectorMode.BOX)
+        )
+        schema_dict[vol.Optional(CONF_PREDISCHARGE_RESERVE_SOC, default=default_reserve_soc)] = NumberSelector(
+            NumberSelectorConfig(min=0, max=100, step=1, unit_of_measurement="%", mode=NumberSelectorMode.BOX)
+        )
+        schema_dict[vol.Optional(CONF_PREDISCHARGE_MAX_EXPORT_POWER_W, default=default_export_power)] = NumberSelector(
+            NumberSelectorConfig(min=0, max=10000, step=50, unit_of_measurement="W", mode=NumberSelectorMode.BOX)
+        )
+        schema_dict[vol.Optional(CONF_CURTAILMENT_HEADROOM_MARGIN_PCT, default=default_headroom_margin)] = NumberSelector(
             NumberSelectorConfig(min=0, max=100, step=5, unit_of_measurement="%", mode=NumberSelectorMode.BOX)
         )
 

--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -599,6 +599,20 @@ CONF_DISCHARGE_PRICE_THRESHOLD = "discharge_price_threshold"
 CONF_MIN_ARBITRAGE_MARGIN = "min_arbitrage_margin"
 CONF_ROUND_TRIP_EFFICIENCY = "round_trip_efficiency"
 
+# Smart pre-discharge / anti-curtailment.  This is deliberately separate from
+# the normal predictive-charging settings: it is only read by dynamic pricing
+# and remains disabled for existing entries unless explicitly enabled.
+CONF_SMART_PREDISCHARGE_ENABLED = "smart_predischarge_enabled"
+CONF_NEGATIVE_INJECTION_THRESHOLD = "negative_injection_threshold"
+CONF_PREDISCHARGE_RESERVE_SOC = "predischarge_reserve_soc"
+CONF_PREDISCHARGE_MAX_EXPORT_POWER_W = "predischarge_max_export_power_w"
+CONF_CURTAILMENT_HEADROOM_MARGIN_PCT = "curtailment_headroom_margin_pct"
+DEFAULT_SMART_PREDISCHARGE_ENABLED = False
+DEFAULT_NEGATIVE_INJECTION_THRESHOLD = 0.0
+DEFAULT_PREDISCHARGE_RESERVE_SOC = 0.0
+DEFAULT_PREDISCHARGE_MAX_EXPORT_POWER_W = 0.0
+DEFAULT_CURTAILMENT_HEADROOM_MARGIN_PCT = 0.0
+
 PREDICTIVE_MODE_TIME_SLOT = "time_slot"
 PREDICTIVE_MODE_DYNAMIC_PRICING = "dynamic_pricing"
 PREDICTIVE_MODE_REALTIME_PRICE = "realtime_price"

--- a/custom_components/omnibattery/frontend/marstek-panel.js
+++ b/custom_components/omnibattery/frontend/marstek-panel.js
@@ -60,7 +60,7 @@ const I18N = {
     diagTitle: "Integration status",
     diagIntegration: "Integration", diagPdState: "PD state", diagNetBalance: "Net balance", diagAlarm: "Alarm",
     diagActiveBatteries: "Active batteries", diagNonResponsive: "No response",
-    diagDischargeWindow: "Discharge window", diagPredictive: "Predictive charging",
+    diagDischargeWindow: "Discharge window", diagPredictive: "Predictive charging", diagCurtailment: "Smart pre-discharge",
     diagPeak: "Peak shaving", diagWeeklyCharge: "Weekly charge", diagChargeDelay: "Charge delay",
     nResponsive: "{n} no response", none: "None",
     noBatteriesTitle: "No batteries",
@@ -90,7 +90,7 @@ const I18N = {
     secTempLimit: "Temperature charge limit", itemTempLimitC: "Temperature limit", itemTempLimitBand: "Ramp band", itemTempLimitFloor: "Minimum charge power", itemTempApplyDischarge: "Also throttle discharge",
     itemMaxContracted: "Max contracted power", itemSolarSafety: "Solar safety margin", itemGridChargeMargin: "Grid charge margin", itemMinSocFloorEnable: "SOC floor", itemMinSocFloor: "Guaranteed minimum SOC",
     itemSocThreshold: "SOC threshold", itemPeakLimit: "Peak limit", itemExcludedPeakShaving: "Peak shaving for excluded devices",
-    itemArbitrageMargin: "Min. arbitrage margin", itemRoundTripEfficiency: "Round-trip efficiency", itemMaxPrice: "Max price (charge)", itemDischargePrice: "Discharge price floor", itemPriceDischarge: "Discharge only above price", itemReevaluatePrices: "Re-evaluate prices now",
+    itemArbitrageMargin: "Min. arbitrage margin", itemRoundTripEfficiency: "Round-trip efficiency", itemMaxPrice: "Max price (charge)", itemDischargePrice: "Discharge price floor", itemPriceDischarge: "Discharge only above price", itemReevaluatePrices: "Re-evaluate prices now", itemSmartPredischarge: "Smart pre-discharge", itemNegativeThreshold: "Negative injection threshold", itemPredischargeReserve: "Pre-discharge reserve SOC", itemPredischargeExport: "Pre-discharge export cap", itemCurtailmentMargin: "Curtailment headroom margin",
     itemDelaySafety: "Safety margin", itemDelaySoc: "Delay target SOC", itemDelaySocEnable: "Delay target SOC enabled", itemDelayDeadband: "Balance deadband",
     secHourly: "Hourly balance", hourlyEsOnly: "Only useful in Spain (RD 244/2019) · detected country: {c}", secWeeklyFull: "Weekly full charge", itemWeeklyDay: "Full charge day", itemWeeklyDelay: "Wait for solar charge delay", itemHourlyTarget: "Target net balance", itemHourlyMaxOffset: "Max power offset", itemHourlyDeadband: "Deadband", itemHourlyHysteresis: "Hysteresis",
     secSlots: "Configured slots", itemSlot: "Slot",
@@ -130,7 +130,7 @@ const I18N = {
     diagTitle: "Estado de la integración",
     diagIntegration: "Integración", diagPdState: "Estado PD", diagNetBalance: "Balance neto", diagAlarm: "Alarma",
     diagActiveBatteries: "Baterías activas", diagNonResponsive: "Sin respuesta",
-    diagDischargeWindow: "Ventana de descarga", diagPredictive: "Carga predictiva",
+    diagDischargeWindow: "Ventana de descarga", diagPredictive: "Carga predictiva", diagCurtailment: "Predescarga inteligente",
     diagPeak: "Reducción de picos", diagWeeklyCharge: "Carga semanal", diagChargeDelay: "Retardo de carga",
     nResponsive: "{n} sin respuesta", none: "Ninguna",
     noBatteriesTitle: "Sin baterías",
@@ -160,7 +160,7 @@ const I18N = {
     secTempLimit: "Límite de carga por temperatura", itemTempLimitC: "Límite de temperatura", itemTempLimitBand: "Banda de reducción", itemTempLimitFloor: "Potencia de carga mínima", itemTempApplyDischarge: "Reducir también la descarga",
     itemMaxContracted: "Potencia contratada máx.", itemSolarSafety: "Margen de seguridad solar", itemGridChargeMargin: "Margen de carga de red", itemMinSocFloorEnable: "Suelo de SOC", itemMinSocFloor: "SOC mínimo garantizado",
     itemSocThreshold: "Umbral de SOC", itemPeakLimit: "Límite de pico", itemExcludedPeakShaving: "Reducción de picos para dispositivos excluidos",
-    itemArbitrageMargin: "Margen mínimo de arbitraje", itemRoundTripEfficiency: "Eficiencia de ciclo completo", itemMaxPrice: "Precio máximo (carga)", itemDischargePrice: "Precio mínimo de descarga", itemPriceDischarge: "Descargar solo si precio alto", itemReevaluatePrices: "Reevaluar precios ahora",
+    itemArbitrageMargin: "Margen mínimo de arbitraje", itemRoundTripEfficiency: "Eficiencia de ciclo completo", itemMaxPrice: "Precio máximo (carga)", itemDischargePrice: "Precio mínimo de descarga", itemPriceDischarge: "Descargar solo si precio alto", itemReevaluatePrices: "Reevaluar precios ahora", itemSmartPredischarge: "Predescarga inteligente", itemNegativeThreshold: "Umbral de inyección negativa", itemPredischargeReserve: "SOC de reserva de predescarga", itemPredischargeExport: "Límite de exportación de predescarga", itemCurtailmentMargin: "Margen de headroom anti-vertido",
     itemDelaySafety: "Margen de seguridad", itemDelaySoc: "SOC objetivo de retardo", itemDelaySocEnable: "SOC objetivo de retardo activo", itemDelayDeadband: "Banda muerta de balance",
     secHourly: "Balance horario", hourlyEsOnly: "Solo útil en España (RD 244/2019) · país detectado: {c}", secWeeklyFull: "Carga semanal completa", itemWeeklyDay: "Día de carga completa", itemWeeklyDelay: "Esperar al retraso por solar", itemHourlyTarget: "Objetivo de balance neto", itemHourlyMaxOffset: "Offset máx. de potencia", itemHourlyDeadband: "Banda muerta", itemHourlyHysteresis: "Histéresis",
     secSlots: "Franjas configuradas", itemSlot: "Franja",
@@ -200,7 +200,7 @@ const I18N = {
     diagTitle: "Estat de la integració",
     diagIntegration: "Integració", diagPdState: "Estat PD", diagNetBalance: "Balanç net", diagAlarm: "Alarma",
     diagActiveBatteries: "Bateries actives", diagNonResponsive: "Sense resposta",
-    diagDischargeWindow: "Finestra de descàrrega", diagPredictive: "Càrrega predictiva",
+    diagDischargeWindow: "Finestra de descàrrega", diagPredictive: "Càrrega predictiva", diagCurtailment: "Predescàrrega intel·ligent",
     diagPeak: "Reducció de pics", diagWeeklyCharge: "Càrrega setmanal", diagChargeDelay: "Retard de càrrega",
     nResponsive: "{n} sense resposta", none: "Cap",
     noBatteriesTitle: "Sense bateries",
@@ -227,7 +227,7 @@ const I18N = {
     secTempLimit: "Límit de càrrega per temperatura", itemTempLimitC: "Límit de temperatura", itemTempLimitBand: "Banda de reducció", itemTempLimitFloor: "Potència de càrrega mínima", itemTempApplyDischarge: "Redueix també la descàrrega",
     itemMaxContracted: "Potència contractada màx.", itemSolarSafety: "Marge de seguretat solar", itemGridChargeMargin: "Marge de càrrega de xarxa", itemMinSocFloorEnable: "SOC Mínim", itemMinSocFloor: "SOC mínim garantit",
     itemSocThreshold: "Llindar de SOC", itemPeakLimit: "Límit de pic", itemExcludedPeakShaving: "Reducció de pics per a dispositius exclosos",
-    itemArbitrageMargin: "Marge mínim d'arbitratge", itemRoundTripEfficiency: "Eficiència de cicle complet", itemMaxPrice: "Preu màxim (càrrega)", itemDischargePrice: "Preu mínim de descàrrega", itemPriceDischarge: "Descarregar només si preu alt", itemReevaluatePrices: "Reavaluar preus ara",
+    itemArbitrageMargin: "Marge mínim d'arbitratge", itemRoundTripEfficiency: "Eficiència de cicle complet", itemMaxPrice: "Preu màxim (càrrega)", itemDischargePrice: "Preu mínim de descàrrega", itemPriceDischarge: "Descarregar només si preu alt", itemReevaluatePrices: "Reavaluar preus ara", itemSmartPredischarge: "Predescàrrega intel·ligent", itemNegativeThreshold: "Llindar d'injecció negativa", itemPredischargeReserve: "SOC de reserva de predescàrrega", itemPredischargeExport: "Límit d'exportació de predescàrrega", itemCurtailmentMargin: "Marge d'espai anti-abocament",
     itemDelaySafety: "Marge de seguretat", itemDelaySoc: "SOC objectiu de retard", itemDelaySocEnable: "SOC objectiu de retard actiu", itemDelayDeadband: "Banda morta de balanç",
     secHourly: "Balanç horari", hourlyEsOnly: "Només útil a Espanya (RD 244/2019) · país detectat: {c}", secWeeklyFull: "Càrrega setmanal completa", itemWeeklyDay: "Dia de càrrega completa", itemWeeklyDelay: "Espera el retard per solar", itemHourlyTarget: "Objectiu de balanç net", itemHourlyMaxOffset: "Offset màx. de potència", itemHourlyDeadband: "Banda morta", itemHourlyHysteresis: "Histèresi",
     secSlots: "Franges configurades", itemSlot: "Franja",
@@ -267,7 +267,7 @@ const I18N = {
     diagTitle: "Integrationsstatus",
     diagIntegration: "Integration", diagPdState: "PD-Status", diagNetBalance: "Netto-Balance", diagAlarm: "Alarm",
     diagActiveBatteries: "Aktive Batterien", diagNonResponsive: "Keine Antwort",
-    diagDischargeWindow: "Entladefenster", diagPredictive: "Prädiktives Laden",
+    diagDischargeWindow: "Entladefenster", diagPredictive: "Prädiktives Laden", diagCurtailment: "Intelligente Vorentladung",
     diagPeak: "Spitzenlastkappung", diagWeeklyCharge: "Wöchentliche Ladung", diagChargeDelay: "Ladeverzögerung",
     nResponsive: "{n} ohne Antwort", none: "Keine",
     noBatteriesTitle: "Keine Batterien",
@@ -294,7 +294,7 @@ const I18N = {
     secTempLimit: "Temperaturbasierte Ladebegrenzung", itemTempLimitC: "Temperaturgrenze", itemTempLimitBand: "Drosselbereich", itemTempLimitFloor: "Minimale Ladeleistung", itemTempApplyDischarge: "Auch Entladung drosseln",
     itemMaxContracted: "Max. Vertragsleistung", itemSolarSafety: "Sicherheitspuffer Solar", itemGridChargeMargin: "Netzladungs-Marge", itemMinSocFloorEnable: "SOC-Untergrenze", itemMinSocFloor: "Garantierter Mindest-SOC",
     itemSocThreshold: "SOC-Schwelle", itemPeakLimit: "Spitzenlimit", itemExcludedPeakShaving: "Spitzenlastkappung für ausgeschlossene Geräte",
-    itemArbitrageMargin: "Min. Arbitragemarge", itemRoundTripEfficiency: "Round-Trip-Wirkungsgrad", itemMaxPrice: "Max. Preis (Laden)", itemDischargePrice: "Entlade-Preisuntergrenze", itemPriceDischarge: "Nur über Preis entladen", itemReevaluatePrices: "Preise jetzt neu bewerten",
+    itemArbitrageMargin: "Min. Arbitragemarge", itemRoundTripEfficiency: "Round-Trip-Wirkungsgrad", itemMaxPrice: "Max. Preis (Laden)", itemDischargePrice: "Entlade-Preisuntergrenze", itemPriceDischarge: "Nur über Preis entladen", itemReevaluatePrices: "Preise jetzt neu bewerten", itemSmartPredischarge: "Intelligente Vorentladung", itemNegativeThreshold: "Schwelle für negative Einspeisung", itemPredischargeReserve: "Vorentlade-Reserve-SOC", itemPredischargeExport: "Vorentlade-Exportlimit", itemCurtailmentMargin: "Reserve-Marge gegen Abregelung",
     itemDelaySafety: "Sicherheitspuffer", itemDelaySoc: "Verzögerungs-Ziel-SOC", itemDelaySocEnable: "Verzögerungs-Ziel-SOC aktiv", itemDelayDeadband: "Bilanz-Totband",
     secHourly: "Stündliche Balance", hourlyEsOnly: "Nur in Spanien sinnvoll (RD 244/2019) · erkanntes Land: {c}", secWeeklyFull: "Wöchentliche Vollladung", itemWeeklyDay: "Tag der Vollladung", itemWeeklyDelay: "Auf Solar-Ladeverzögerung warten", itemHourlyTarget: "Ziel-Nettobalance", itemHourlyMaxOffset: "Max. Leistungs-Offset", itemHourlyDeadband: "Totband", itemHourlyHysteresis: "Hysterese",
     secSlots: "Konfigurierte Zeitfenster", itemSlot: "Zeitfenster",
@@ -334,7 +334,7 @@ const I18N = {
     diagTitle: "État de l'intégration",
     diagIntegration: "Intégration", diagPdState: "État PD", diagNetBalance: "Bilan net", diagAlarm: "Alarme",
     diagActiveBatteries: "Batteries actives", diagNonResponsive: "Sans réponse",
-    diagDischargeWindow: "Fenêtre de décharge", diagPredictive: "Charge prédictive",
+    diagDischargeWindow: "Fenêtre de décharge", diagPredictive: "Charge prédictive", diagCurtailment: "Pré-décharge intelligente",
     diagPeak: "Écrêtement de pointe", diagWeeklyCharge: "Charge hebdomadaire", diagChargeDelay: "Délai de charge",
     nResponsive: "{n} sans réponse", none: "Aucune",
     noBatteriesTitle: "Aucune batterie",
@@ -361,7 +361,7 @@ const I18N = {
     secTempLimit: "Limite de charge par température", itemTempLimitC: "Limite de température", itemTempLimitBand: "Plage de réduction", itemTempLimitFloor: "Puissance de charge minimale", itemTempApplyDischarge: "Réduire aussi la décharge",
     itemMaxContracted: "Puissance contractuelle max.", itemSolarSafety: "Marge de sécurité solaire", itemGridChargeMargin: "Marge de charge réseau", itemMinSocFloorEnable: "Plancher SOC", itemMinSocFloor: "SOC minimum garanti",
     itemSocThreshold: "Seuil SOC", itemPeakLimit: "Limite de pointe", itemExcludedPeakShaving: "Écrêtement des pointes pour appareils exclus",
-    itemArbitrageMargin: "Marge d'arbitrage min.", itemRoundTripEfficiency: "Rendement aller-retour", itemMaxPrice: "Prix max. (charge)", itemDischargePrice: "Prix plancher de décharge", itemPriceDischarge: "Décharger si prix élevé", itemReevaluatePrices: "Réévaluer les prix",
+    itemArbitrageMargin: "Marge d'arbitrage min.", itemRoundTripEfficiency: "Rendement aller-retour", itemMaxPrice: "Prix max. (charge)", itemDischargePrice: "Prix plancher de décharge", itemPriceDischarge: "Décharger si prix élevé", itemReevaluatePrices: "Réévaluer les prix", itemSmartPredischarge: "Pré-décharge intelligente", itemNegativeThreshold: "Seuil d'injection négative", itemPredischargeReserve: "SOC de réserve de pré-décharge", itemPredischargeExport: "Limite d'export de pré-décharge", itemCurtailmentMargin: "Marge de réserve anti-écrêtement",
     itemDelaySafety: "Marge de sécurité", itemDelaySoc: "SOC cible du délai", itemDelaySocEnable: "SOC cible du délai actif", itemDelayDeadband: "Bande morte de bilan",
     secHourly: "Bilan horaire", hourlyEsOnly: "Utile uniquement en Espagne (RD 244/2019) · pays détecté : {c}", secWeeklyFull: "Charge complète hebdomadaire", itemWeeklyDay: "Jour de charge complète", itemWeeklyDelay: "Attendre le délai de charge solaire", itemHourlyTarget: "Cible bilan net", itemHourlyMaxOffset: "Décalage max. puissance", itemHourlyDeadband: "Bande morte", itemHourlyHysteresis: "Hystérésis",
     secSlots: "Créneaux configurés", itemSlot: "Créneau",
@@ -401,7 +401,7 @@ const I18N = {
     diagTitle: "Integratiestatus",
     diagIntegration: "Integratie", diagPdState: "PD-status", diagNetBalance: "Nettosaldo", diagAlarm: "Alarm",
     diagActiveBatteries: "Actieve batterijen", diagNonResponsive: "Geen reactie",
-    diagDischargeWindow: "Ontlaadvenster", diagPredictive: "Voorspellend laden",
+    diagDischargeWindow: "Ontlaadvenster", diagPredictive: "Voorspellend laden", diagCurtailment: "Slim voorontladen",
     diagPeak: "Piekbegrenzing", diagWeeklyCharge: "Wekelijkse lading", diagChargeDelay: "Laadvertraging",
     nResponsive: "{n} geen reactie", none: "Geen",
     noBatteriesTitle: "Geen batterijen",
@@ -428,7 +428,7 @@ const I18N = {
     secTempLimit: "Temperatuurbegrenzing laden", itemTempLimitC: "Temperatuurlimiet", itemTempLimitBand: "Afbouwband", itemTempLimitFloor: "Minimaal laadvermogen", itemTempApplyDischarge: "Ook ontladen terugregelen",
     itemMaxContracted: "Max. gecontracteerd vermogen", itemSolarSafety: "Veiligheidsmarge zon", itemGridChargeMargin: "Netladingsmarge", itemMinSocFloorEnable: "SOC-vloer", itemMinSocFloor: "Gegarandeerde min. SOC",
     itemSocThreshold: "SOC-drempel", itemPeakLimit: "Pieklimiet", itemExcludedPeakShaving: "Piekbegrenzing voor uitgesloten apparaten",
-    itemArbitrageMargin: "Min. arbitragemarge", itemRoundTripEfficiency: "Retourrendement", itemMaxPrice: "Max. prijs (laden)", itemDischargePrice: "Ontlaad-prijsondergrens", itemPriceDischarge: "Alleen ontladen bij hoge prijs", itemReevaluatePrices: "Prijzen nu herberekenen",
+    itemArbitrageMargin: "Min. arbitragemarge", itemRoundTripEfficiency: "Retourrendement", itemMaxPrice: "Max. prijs (laden)", itemDischargePrice: "Ontlaad-prijsondergrens", itemPriceDischarge: "Alleen ontladen bij hoge prijs", itemReevaluatePrices: "Prijzen nu herberekenen", itemSmartPredischarge: "Slim voorontladen", itemNegativeThreshold: "Drempel negatieve injectie", itemPredischargeReserve: "Reserve-SOC voorontladen", itemPredischargeExport: "Exportlimiet voorontladen", itemCurtailmentMargin: "Headroommarge tegen afregeling",
     itemDelaySafety: "Veiligheidsmarge", itemDelaySoc: "Doel-SOC vertraging", itemDelaySocEnable: "Doel-SOC vertraging actief", itemDelayDeadband: "Balans dode band",
     secHourly: "Uurbalans", hourlyEsOnly: "Alleen nuttig in Spanje (RD 244/2019) · gedetecteerd land: {c}", secWeeklyFull: "Wekelijkse volledige lading", itemWeeklyDay: "Dag volledige lading", itemWeeklyDelay: "Wachten op zonne-laadvertraging", itemHourlyTarget: "Doel nettosaldo", itemHourlyMaxOffset: "Max. vermogensoffset", itemHourlyDeadband: "Dodeband", itemHourlyHysteresis: "Hysterese",
     secSlots: "Geconfigureerde tijdvakken", itemSlot: "Tijdvak",
@@ -514,6 +514,7 @@ const K = {
   peakSwitch: "capacity_protection",
   // diagnostic-category entities of the "Marstek Venus System" device
   predictiveActive: "predictive_charging_active",
+  curtailmentActive: "curtailment_status",
   capacityActive: "capacity_protection_active",
   weeklyFullCharge: "weekly_full_charge",
   chargeDelay: "charge_delay_status",
@@ -533,6 +534,7 @@ const DIAG_ROWS = [
   { key: K.nonResponsive, lk: "diagNonResponsive" },
   { key: K.dischargeWindow, lk: "diagDischargeWindow" },
   { key: K.predictiveActive, lk: "diagPredictive" },
+  { key: K.curtailmentActive, lk: "diagCurtailment" },
   { key: K.chargeDelay, lk: "diagChargeDelay" },
   { key: K.weeklyFullCharge, lk: "diagWeeklyCharge" },
   { key: K.capacityActive, lk: "diagPeak" },
@@ -724,6 +726,12 @@ const SYS_SECTIONS = [
       { key: "discharge_price_threshold", lk: "itemDischargePrice", icon: "mdi:cash-minus" },
       { key: "min_arbitrage_margin", lk: "itemArbitrageMargin", icon: "mdi:scale-balance" },
       { key: "round_trip_efficiency", lk: "itemRoundTripEfficiency", icon: "mdi:battery-sync" },
+      { key: "smart_predischarge", domain: "switch", lk: "itemSmartPredischarge", icon: "mdi:battery-arrow-down-outline", gate: true },
+      { key: "negative_injection_threshold", lk: "itemNegativeThreshold", icon: "mdi:cash-minus" },
+      { key: "predischarge_reserve_soc", lk: "itemPredischargeReserve", icon: "mdi:battery-lock" },
+      { key: "predischarge_max_export_power_w", lk: "itemPredischargeExport", icon: "mdi:transmission-tower-export" },
+      { key: "curtailment_headroom_margin_pct", lk: "itemCurtailmentMargin", icon: "mdi:battery-plus" },
+      { key: "curtailment_status", domain: "binary_sensor", lk: "diagCurtailment", icon: "mdi:solar-power-variant" },
       // Dynamic-pricing only (system button exists solely in that mode), so on
       // time-slot / real-time installs this row simply doesn't render.
       { key: "reevaluate_dynamic_pricing", domain: "button", lk: "itemReevaluatePrices", icon: "mdi:calendar-refresh" },
@@ -829,6 +837,12 @@ const SYS_HELP = {
     secNoPd: "When ON, the PD controller is bypassed and each battery tracks the grid setpoint 1:1 (raw, kp=1, no integral/derivative/smoothing/rate-limit). It still reuses the deadband, min charge/discharge power, relay cooldown and target-grid-power knobs above. Use only if PD tuning can't tame your meter; PD is the safer default.",
     no_pd_command_delay: "Collapse-debounce window for No-PD mode. Grid-sensor updates arriving within this window collapse into a single command issued on the latest value, so a fast meter can't flood the bus. 0 = act on every event (paced only by PD min cycle interval). Range: 0–3 s, step 0.1, default: 0 s.",
     diagPredictive: "Charges batteries from the grid during off-peak hours when today's solar forecast is insufficient.",
+    smart_predischarge: "Opt-in dynamic-pricing anti-curtailment. It creates headroom before forecast PV reaches a negative-price window, while preserving SOC floors, user ownership and battery safety limits.",
+    negative_injection_threshold: "Price at or below which a future slot is protected when forecast PV exceeds estimated household consumption. The comparison is inclusive (<=).",
+    predischarge_reserve_soc: "Additional SOC floor for pre-discharge. 0 uses each battery's existing minimum and guaranteed SOC floors.",
+    predischarge_max_export_power_w: "Maximum deliberate grid export during pre-discharge. 0 W means self-consumption only; the planner never controls the PV inverter.",
+    curtailment_headroom_margin_pct: "Extra headroom reserved above the forecast solar surplus. 0% follows the forecast exactly.",
+    curtailment_status: "Live plan diagnostics: risk windows, current/required headroom, selected expensive slots, targets and any shortfall or fail-safe reason.",
     diagChargeDelay: "Delays battery charging until the solar energy balance indicates it's needed, exporting excess solar to grid in the meantime.",
     secHourly: "Tracks grid import/export per hour and automatically adjusts the battery setpoint to achieve a target net energy balance.\n\n⚠️ Only useful in Spain, under the hourly surplus-compensation scheme (RD 244/2019), where grid surplus is settled hour by hour. In feed-in-tariff or annual-net-metering markets it provides no benefit and may cause lost export revenue and unnecessary battery cycling.",
     diagPeak: "When enabled, if battery SOC drops below a threshold, the system conserves energy by only discharging to offset consumption above a peak limit.",
@@ -2720,6 +2734,7 @@ class MarstekVenusPanel extends HTMLElement {
           tone: raw === "stable" ? "good" : (raw === "oscillating" || raw === "sluggish") ? "warn" : "neutral",
         };
       case K.predictiveActive:
+      case K.curtailmentActive:
       case K.capacityActive:
         return { text: disp, tone: raw === "on" ? "good" : "neutral" };
       case K.dischargeWindow: {
@@ -4621,7 +4636,7 @@ class MarstekVenusPanel extends HTMLElement {
       );
       frag.appendChild(sel);
       store[sk] = { type: "select", el: sel };
-    } else if (domain === "sensor") {
+    } else if (domain === "sensor" || domain === "binary_sensor") {
       // read-only verdict (e.g. PD control quality) — localized state, no input.
       // Clicking the value opens HA more-info (state history graph).
       const valEl = document.createElement("span");

--- a/custom_components/omnibattery/number.py
+++ b/custom_components/omnibattery/number.py
@@ -32,6 +32,10 @@ from .const import (
     CONF_PRICE_INTEGRATION_TYPE,
     PREDICTIVE_MODE_DYNAMIC_PRICING,
     PRICE_INTEGRATION_CKW,
+    CONF_NEGATIVE_INJECTION_THRESHOLD,
+    CONF_PREDISCHARGE_RESERVE_SOC,
+    CONF_PREDISCHARGE_MAX_EXPORT_POWER_W,
+    CONF_CURTAILMENT_HEADROOM_MARGIN_PCT,
     MIN_CHARGE_HYSTERESIS_PERCENT,
     MAX_CHARGE_HYSTERESIS_PERCENT,
     DOMAIN,
@@ -114,6 +118,10 @@ async def async_setup_entry(
         entities.append(MarstekPriceThresholdNumber(hass, entry, "discharge"))
         entities.append(MarstekArbitrageNumber(hass, entry, "margin"))
         entities.append(MarstekArbitrageNumber(hass, entry, "efficiency"))
+        entities.append(SmartPredischargeNumber(hass, entry, "threshold"))
+        entities.append(SmartPredischargeNumber(hass, entry, "reserve"))
+        entities.append(SmartPredischargeNumber(hass, entry, "export"))
+        entities.append(SmartPredischargeNumber(hass, entry, "margin"))
 
     # Temperature charge limit sliders (system-level, when the feature is configured)
     if CONF_ENABLE_TEMP_CHARGE_LIMIT in entry.data:
@@ -439,6 +447,106 @@ class MarstekPriceThresholdNumber(NumberEntity):
     @property
     def device_info(self):
         """Return device information for the system."""
+        return {
+            "identifiers": {(DOMAIN, "marstek_venus_system")},
+            "name": "Omnibattery System",
+            "manufacturer": "Omnibattery",
+            "model": "Multi-Battery System",
+        }
+
+
+class SmartPredischargeNumber(NumberEntity):
+    """Hot-editable anti-curtailment parameter, dynamic-pricing only."""
+
+    _attr_has_entity_name = True
+    _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_should_poll = False
+
+    _DEFINITIONS = {
+        "threshold": (
+            CONF_NEGATIVE_INJECTION_THRESHOLD,
+            -2.0,
+            2.0,
+            0.001,
+            "mdi:cash-minus",
+        ),
+        "reserve": (
+            CONF_PREDISCHARGE_RESERVE_SOC,
+            0.0,
+            100.0,
+            1.0,
+            "mdi:battery-lock",
+        ),
+        "export": (
+            CONF_PREDISCHARGE_MAX_EXPORT_POWER_W,
+            0.0,
+            10000.0,
+            50.0,
+            "mdi:transmission-tower-export",
+        ),
+        "margin": (
+            CONF_CURTAILMENT_HEADROOM_MARGIN_PCT,
+            0.0,
+            100.0,
+            5.0,
+            "mdi:battery-plus",
+        ),
+    }
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, kind: str) -> None:
+        self.hass = hass
+        self.entry = entry
+        self._kind = kind
+        key, minimum, maximum, step, icon = self._DEFINITIONS[kind]
+        self._conf_key = key
+        self._attr_translation_key = key
+        self._attr_unique_id = f"{SYSTEM_UNIQUE_ID_PREFIX}{key}"
+        self.entity_id = system_entity_id("number", key)
+        self._attr_icon = icon
+        self._attr_native_min_value = minimum
+        self._attr_native_max_value = maximum
+        self._attr_native_step = step
+        if kind == "threshold":
+            is_chf = entry.data.get(CONF_PRICE_INTEGRATION_TYPE) == PRICE_INTEGRATION_CKW
+            self._attr_native_unit_of_measurement = "CHF/kWh" if is_chf else "€/kWh"
+        elif kind in {"reserve", "margin"}:
+            self._attr_native_unit_of_measurement = "%"
+        else:
+            self._attr_native_unit_of_measurement = "W"
+
+    async def async_added_to_hass(self) -> None:
+        self.async_on_remove(self.entry.add_update_listener(self._handle_entry_update))
+
+    async def _handle_entry_update(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> float:
+        value = self.entry.data.get(self._conf_key, 0.0)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    async def async_set_native_value(self, value: float) -> None:
+        new_data = dict(self.entry.data)
+        new_data[self._conf_key] = float(value)
+        self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+        controller = self.hass.data[DOMAIN][self.entry.entry_id].get("controller")
+        if controller is not None:
+            controller.update_pd_parameters()
+            # Never keep applying a plan calculated with the previous threshold,
+            # forecast margin or export cap.  The existing reevaluate button (or
+            # the next scheduled evaluation) rebuilds it.
+            controller._pricing_mgr.clear_curtailment_runtime(
+                "configuration_changed"
+            )
+        _LOGGER.info("Smart pre-discharge %s updated to %s", self._conf_key, value)
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
         return {
             "identifiers": {(DOMAIN, "marstek_venus_system")},
             "name": "Omnibattery System",

--- a/custom_components/omnibattery/pricing/__init__.py
+++ b/custom_components/omnibattery/pricing/__init__.py
@@ -25,8 +25,18 @@ class DynamicPricingSchedule:
     charging_needed: bool = True
 
 
+from .curtailment import BatterySnapshot, CurtailmentPlan, PreDischargeSlot
+
+
 # Imported after PriceSlot is defined so ``calculations`` can resolve it from
 # the partially-initialised package without a circular import.
 from . import calculations  # noqa: E402,F401
 
-__all__ = ["PriceSlot", "DynamicPricingSchedule", "calculations"]
+__all__ = [
+    "PriceSlot",
+    "DynamicPricingSchedule",
+    "BatterySnapshot",
+    "CurtailmentPlan",
+    "PreDischargeSlot",
+    "calculations",
+]

--- a/custom_components/omnibattery/pricing/curtailment.py
+++ b/custom_components/omnibattery/pricing/curtailment.py
@@ -1,0 +1,499 @@
+"""Pure planning helpers for smart pre-discharge.
+
+The planner has no Home Assistant dependency.  It receives normalized
+``PriceSlot`` objects and snapshots of the batteries, then returns a plan that
+the pricing engine can safely apply through the normal PD path.  In particular,
+it never controls a PV inverter and it treats all battery floors as hard
+constraints.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Callable, Iterable, Mapping, Sequence
+
+from ..const import CHARGE_EFFICIENCY
+from . import PriceSlot
+
+
+EPSILON = 1e-6
+
+
+@dataclass(frozen=True)
+class BatterySnapshot:
+    """The battery state needed by the pure planner."""
+
+    name: str
+    soc_pct: float
+    capacity_kwh: float
+    max_soc_pct: float
+    floor_soc_pct: float
+    max_discharge_power_w: float
+    eligible: bool = True
+    can_discharge: bool = True
+
+
+@dataclass(frozen=True)
+class PreDischargeSlot:
+    """One grouped, future slot in which PD may pre-discharge."""
+
+    start: datetime
+    end: datetime
+    price: float
+    planned_energy_kwh: float = 0.0
+    power_w: float = 0.0
+    export_target_w: float = 0.0
+
+    @property
+    def duration_hours(self) -> float:
+        return max(0.0, (self.end - self.start).total_seconds() / 3600.0)
+
+
+@dataclass
+class CurtailmentPlan:
+    """A recalculated anti-curtailment plan and its diagnostic accounting."""
+
+    status: str = "disabled"
+    reason: str = "disabled"
+    evaluation_time: datetime | None = None
+    risk_slots: list[PriceSlot] = field(default_factory=list)
+    selected_discharge_slots: list[PreDischargeSlot] = field(default_factory=list)
+    required_headroom_kwh: float = 0.0
+    current_headroom_kwh: float = 0.0
+    planned_discharge_kwh: float = 0.0
+    shortfall_kwh: float = 0.0
+    target_soc_by_battery: dict[str, float] = field(default_factory=dict)
+    active_export_target_w: float = 0.0
+    solar_surplus_kwh: float = 0.0
+
+    # Short aliases make the object convenient for integrations and tests while
+    # keeping the explicit diagnostic name used by the entity attributes.
+    @property
+    def discharge_slots(self) -> list[PreDischargeSlot]:
+        return self.selected_discharge_slots
+
+    @property
+    def required_headroom(self) -> float:
+        return self.required_headroom_kwh
+
+    @property
+    def current_headroom(self) -> float:
+        return self.current_headroom_kwh
+
+    @property
+    def is_fail_safe(self) -> bool:
+        return self.status == "fail_safe"
+
+
+def _duration_hours(slot: PriceSlot) -> float:
+    return max(0.0, (slot.end - slot.start).total_seconds() / 3600.0)
+
+
+def _overlaps(left: PriceSlot | PreDischargeSlot, right: PriceSlot | PreDischargeSlot) -> bool:
+    return left.start < right.end and right.start < left.end
+
+
+def _finite(value: object) -> bool:
+    try:
+        return math.isfinite(float(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def _cumulative_share(
+    fraction_fn: Callable[[float], float] | None,
+    start: datetime,
+    end: datetime,
+) -> float:
+    """Return a bounded generation share for one slot.
+
+    ``fraction_fn`` is the existing solar model's cumulative fraction.  The
+    fallback is intentionally uniform; it is used only when a caller has no
+    solar model and keeps the pure helper useful in fail-safe tests.
+    """
+    if fraction_fn is None:
+        return 0.0
+    try:
+        start_hour = start.hour + start.minute / 60.0 + start.second / 3600.0
+        end_hour = end.hour + end.minute / 60.0 + end.second / 3600.0
+        # A final slot may end exactly at local midnight.  Preserve that as
+        # hour 24 for the same daily model instead of wrapping it to 00:00
+        # and falsely reporting zero production in the last slot.
+        day_delta = (end.date() - start.date()).days
+        if day_delta > 0:
+            end_hour += 24.0 * day_delta
+        start_fraction = float(fraction_fn(start_hour))
+        end_fraction = float(fraction_fn(end_hour))
+    except (TypeError, ValueError, AttributeError):
+        return 0.0
+    if not math.isfinite(start_fraction) or not math.isfinite(end_fraction):
+        return 0.0
+    return max(0.0, min(1.0, end_fraction) - max(0.0, min(1.0, start_fraction)))
+
+
+def distribute_solar_forecast(
+    slots: Sequence[PriceSlot],
+    forecast_kwh: float,
+    fraction_fn: Callable[[float], float] | None = None,
+) -> dict[PriceSlot, float]:
+    """Distribute a daily solar forecast over normalized price slots.
+
+    The production model supplies a cumulative fraction.  If it cannot be
+    supplied, the function uses a duration-weighted uniform fallback rather
+    than inventing a peak.  Only non-negative finite forecast values are used.
+    """
+    if not _finite(forecast_kwh) or float(forecast_kwh) <= 0 or not slots:
+        return {slot: 0.0 for slot in slots}
+
+    forecast = float(forecast_kwh)
+    if fraction_fn is not None:
+        shares = {slot: _cumulative_share(fraction_fn, slot.start, slot.end) for slot in slots}
+        total_share = sum(shares.values())
+        if total_share > EPSILON:
+            # The model is cumulative over the whole solar day.  Do not
+            # renormalize only the future slots: after sunset that would turn
+            # a zero-generation period into a false PV surplus.
+            return {slot: forecast * share for slot, share in shares.items()}
+        return {slot: 0.0 for slot in slots}
+
+    total_hours = sum(_duration_hours(slot) for slot in slots)
+    if total_hours <= EPSILON:
+        return {slot: 0.0 for slot in slots}
+    return {
+        slot: forecast * _duration_hours(slot) / total_hours
+        for slot in slots
+    }
+
+
+def estimate_consumption_by_slot(
+    slots: Sequence[PriceSlot],
+    daily_consumption_kwh: float,
+    fraction_fn: Callable[[float], float] | None = None,
+) -> dict[PriceSlot, float]:
+    """Estimate consumption per slot, with a uniform daily-history fallback."""
+    if not _finite(daily_consumption_kwh) or float(daily_consumption_kwh) <= 0:
+        return {slot: 0.0 for slot in slots}
+
+    consumption = float(daily_consumption_kwh)
+    if fraction_fn is not None:
+        shares = {slot: _cumulative_share(fraction_fn, slot.start, slot.end) for slot in slots}
+        total_share = sum(shares.values())
+        if total_share > EPSILON:
+            return {slot: consumption * share / total_share for slot, share in shares.items()}
+
+    total_hours = sum(_duration_hours(slot) for slot in slots)
+    if total_hours <= EPSILON:
+        return {slot: 0.0 for slot in slots}
+    return {
+        slot: consumption * _duration_hours(slot) / 24.0
+        for slot in slots
+    }
+
+
+def _make_blocks(slots: Sequence[PriceSlot]) -> list[list[PriceSlot]]:
+    """Group adjacent same-duration slots into roughly one-hour blocks."""
+    ordered = sorted(slots, key=lambda slot: slot.start)
+    blocks: list[list[PriceSlot]] = []
+    run: list[PriceSlot] = []
+    run_duration: float | None = None
+
+    def flush() -> None:
+        nonlocal run
+        if not run:
+            return
+        duration = run_duration or _duration_hours(run[0])
+        block_size = max(1, int(round(1.0 / duration))) if duration > EPSILON else 1
+        for index in range(0, len(run), block_size):
+            blocks.append(run[index:index + block_size])
+        run = []
+
+    for slot in ordered:
+        duration = _duration_hours(slot)
+        contiguous = bool(run) and abs((slot.start - run[-1].end).total_seconds()) < 1
+        same_duration = run_duration is not None and abs(duration - run_duration) < 1e-6
+        if run and (not contiguous or not same_duration):
+            flush()
+            run_duration = None
+        if not run:
+            run_duration = duration
+        run.append(slot)
+    flush()
+    return blocks
+
+
+def select_most_valuable_discharge_slots(
+    candidates: Sequence[PriceSlot],
+    energy_needed_kwh: float,
+    max_discharge_power_w: float,
+    *,
+    max_export_power_w: float = 0.0,
+    available_energy_by_slot: Mapping[PriceSlot, float] | None = None,
+) -> list[PreDischargeSlot]:
+    """Choose expensive contiguous blocks before risk windows.
+
+    For 15-minute feeds the block size is four slots; for hourly feeds it is
+    one.  Blocks are ranked by price, with later blocks winning ties so the
+    discharge remains close to the protected solar window.
+    """
+    if energy_needed_kwh <= EPSILON or max_discharge_power_w <= EPSILON:
+        return []
+
+    blocks = _make_blocks(candidates)
+    ranked: list[tuple[float, datetime, list[PriceSlot]]] = []
+    for block in blocks:
+        if not block:
+            continue
+        duration = sum(_duration_hours(slot) for slot in block)
+        if duration <= EPSILON:
+            continue
+        average_price = sum(slot.price * _duration_hours(slot) for slot in block) / duration
+        ranked.append((average_price, block[-1].end, block))
+    ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+
+    selected: list[PreDischargeSlot] = []
+    remaining = float(energy_needed_kwh)
+    for _average_price, _end, block in ranked:
+        if remaining <= EPSILON:
+            break
+        power_w = max(0.0, float(max_discharge_power_w))
+        slot_capacities = {
+            slot: min(
+                power_w * _duration_hours(slot) / 1000.0,
+                max(0.0, float(available_energy_by_slot.get(slot, 0.0))),
+            )
+            if available_energy_by_slot is not None
+            else power_w * _duration_hours(slot) / 1000.0
+            for slot in block
+        }
+        block_energy = sum(slot_capacities.values())
+        if block_energy <= EPSILON:
+            continue
+        allocated_energy = min(remaining, block_energy)
+        # A block is kept whole to avoid relay chatter; the live controller
+        # later adapts the setpoint to the actual remaining headroom.
+        selected.extend(
+            PreDischargeSlot(
+                start=slot.start,
+                end=slot.end,
+                price=float(slot.price),
+                planned_energy_kwh=allocated_energy * slot_capacities[slot] / block_energy,
+                power_w=(
+                    allocated_energy * slot_capacities[slot] / block_energy
+                    / _duration_hours(slot) * 1000.0
+                    if _duration_hours(slot) > EPSILON
+                    else 0.0
+                ),
+                export_target_w=max(0.0, float(max_export_power_w)),
+            )
+            for slot in block
+            if slot_capacities[slot] > EPSILON
+        )
+        remaining -= allocated_energy
+    return sorted(selected, key=lambda slot: slot.start)
+
+
+def _invalid_battery(snapshot: BatterySnapshot) -> bool:
+    return not (
+        snapshot.eligible
+        and _finite(snapshot.soc_pct)
+        and _finite(snapshot.capacity_kwh)
+        and _finite(snapshot.max_soc_pct)
+        and _finite(snapshot.floor_soc_pct)
+        and _finite(snapshot.max_discharge_power_w)
+        and snapshot.capacity_kwh > 0
+        and snapshot.max_soc_pct >= snapshot.floor_soc_pct
+        and snapshot.max_discharge_power_w >= 0
+    )
+
+
+def plan_curtailment(
+    price_slots: Sequence[PriceSlot],
+    solar_forecast_kwh: float | None = None,
+    daily_consumption_kwh: float | None = None,
+    batteries: Sequence[BatterySnapshot] = (),
+    *,
+    negative_injection_threshold: float = 0.0,
+    predischarge_reserve_soc: float = 0.0,
+    headroom_margin_pct: float = 0.0,
+    charge_power_w: float | None = None,
+    max_export_power_w: float = 0.0,
+    solar_fraction_fn: Callable[[float], float] | None = None,
+    consumption_fraction_fn: Callable[[float], float] | None = None,
+    solar_by_slot: Mapping[PriceSlot, float] | None = None,
+    consumption_by_slot: Mapping[PriceSlot, float] | None = None,
+    reserved_slots: Iterable[PriceSlot] = (),
+    now: datetime | None = None,
+) -> CurtailmentPlan:
+    """Build an anti-curtailment plan from normalized prices and live capacity."""
+    evaluated_at = now or datetime.now()
+    plan = CurtailmentPlan(evaluation_time=evaluated_at)
+
+    if not price_slots:
+        plan.status, plan.reason = "fail_safe", "missing_prices"
+        return plan
+    if solar_forecast_kwh is None or not _finite(solar_forecast_kwh):
+        plan.status, plan.reason = "fail_safe", "missing_solar_forecast"
+        return plan
+    if daily_consumption_kwh is None or not _finite(daily_consumption_kwh):
+        plan.status, plan.reason = "fail_safe", "missing_consumption"
+        return plan
+
+    try:
+        valid_slots = [
+            slot
+            for slot in price_slots
+            if slot.end > slot.start and _finite(slot.price)
+        ]
+        ordered_slots = sorted(
+            (slot for slot in valid_slots if slot.end > evaluated_at),
+            key=lambda slot: slot.start,
+        )
+    except (AttributeError, TypeError, ValueError):
+        valid_slots = []
+        ordered_slots = []
+    if not ordered_slots:
+        reason = "no_future_slots" if valid_slots else "invalid_or_missing_price_slots"
+        plan.status, plan.reason = "fail_safe", reason
+        return plan
+
+    valid_batteries = [snapshot for snapshot in batteries if not _invalid_battery(snapshot)]
+    if not valid_batteries:
+        plan.status, plan.reason = "fail_safe", "missing_battery_capacity_or_soc"
+        return plan
+    if charge_power_w is None or not _finite(charge_power_w) or float(charge_power_w) <= 0:
+        plan.status, plan.reason = "fail_safe", "missing_charge_capacity"
+        return plan
+
+    solar = dict(solar_by_slot or distribute_solar_forecast(
+        ordered_slots, float(solar_forecast_kwh), solar_fraction_fn
+    ))
+    consumption = dict(consumption_by_slot or estimate_consumption_by_slot(
+        ordered_slots, float(daily_consumption_kwh), consumption_fraction_fn
+    ))
+    if not _finite(negative_injection_threshold):
+        plan.status, plan.reason = "fail_safe", "invalid_negative_injection_threshold"
+        return plan
+    threshold = float(negative_injection_threshold)
+    risk_slots: list[PriceSlot] = []
+    required_kwh = 0.0
+    surplus_kwh = 0.0
+    export_cap_w = max(0.0, float(max_export_power_w or 0.0))
+    for slot in ordered_slots:
+        slot_solar = max(0.0, float(solar.get(slot, 0.0) or 0.0))
+        slot_consumption = max(0.0, float(consumption.get(slot, 0.0) or 0.0))
+        surplus = max(0.0, slot_solar - slot_consumption)
+        if float(slot.price) <= threshold and surplus > EPSILON:
+            risk_slots.append(slot)
+            surplus_kwh += surplus
+            # The export cap applies while creating headroom before the risk
+            # window; it does not permit export during that protected window.
+            # Convert AC-side PV surplus to the battery-side headroom that it
+            # can consume, accounting for the integration's charge efficiency.
+            required_kwh += min(
+                surplus,
+                float(charge_power_w) * _duration_hours(slot) / 1000.0,
+            ) * CHARGE_EFFICIENCY
+
+    plan.risk_slots = risk_slots
+    plan.solar_surplus_kwh = surplus_kwh
+    if not risk_slots:
+        plan.status, plan.reason = "no_risk", "no_negative_injection_window"
+        return plan
+
+    margin = max(0.0, float(headroom_margin_pct or 0.0)) / 100.0
+    required_kwh *= 1.0 + margin
+    plan.required_headroom_kwh = required_kwh
+
+    current_headroom = sum(
+        max(0.0, (snapshot.max_soc_pct - snapshot.soc_pct) / 100.0 * snapshot.capacity_kwh)
+        for snapshot in valid_batteries
+    )
+    plan.current_headroom_kwh = current_headroom
+
+    if current_headroom + EPSILON >= required_kwh:
+        plan.status, plan.reason = "protected", "headroom_sufficient"
+        plan.target_soc_by_battery = {
+            snapshot.name: float(snapshot.soc_pct) for snapshot in valid_batteries
+        }
+        return plan
+
+    extra_needed = required_kwh - current_headroom
+    reserve = max(0.0, float(predischarge_reserve_soc or 0.0))
+    discharge_batteries = [
+        snapshot
+        for snapshot in valid_batteries
+        if snapshot.can_discharge and snapshot.max_discharge_power_w > EPSILON
+    ]
+    available_by_battery = {
+        snapshot.name: max(
+            0.0,
+            (snapshot.soc_pct - max(snapshot.floor_soc_pct, reserve))
+            / 100.0 * snapshot.capacity_kwh,
+        )
+        for snapshot in discharge_batteries
+    }
+    available_discharge_kwh = sum(available_by_battery.values())
+    max_discharge_power_w = sum(
+        snapshot.max_discharge_power_w for snapshot in discharge_batteries
+    )
+
+    reserved = list(reserved_slots)
+    earliest_risk_start = min(slot.start for slot in risk_slots)
+    candidates = [
+        slot for slot in ordered_slots
+        if float(slot.price) > threshold
+        and not any(_overlaps(slot, risk) for risk in risk_slots)
+        and not any(_overlaps(slot, reserved_slot) for reserved_slot in reserved)
+        # The runtime protects against the aggregate daily surplus, so all of
+        # that headroom must exist before the first risk window.  A later slot
+        # cannot retroactively satisfy an earlier deadline.
+        and slot.end <= earliest_risk_start
+    ]
+    available_energy_by_slot = {
+        slot: max(
+            0.0,
+            float(consumption.get(slot, 0.0) or 0.0)
+            - float(solar.get(slot, 0.0) or 0.0)
+            + export_cap_w * _duration_hours(slot) / 1000.0,
+        )
+        for slot in candidates
+    }
+    selected = select_most_valuable_discharge_slots(
+        candidates,
+        min(extra_needed, available_discharge_kwh),
+        max_discharge_power_w,
+        max_export_power_w=max_export_power_w,
+        available_energy_by_slot=available_energy_by_slot,
+    )
+    planned_kwh = min(
+        min(extra_needed, available_discharge_kwh),
+        sum(slot.planned_energy_kwh for slot in selected),
+    )
+    plan.selected_discharge_slots = selected
+    plan.planned_discharge_kwh = planned_kwh
+    plan.shortfall_kwh = max(0.0, extra_needed - planned_kwh)
+    if plan.shortfall_kwh > EPSILON:
+        plan.status, plan.reason = "shortfall", "insufficient_pre_discharge_power_or_slots"
+    else:
+        plan.status, plan.reason = "planned", "headroom_required"
+
+    # Allocate the planned energy proportionally, clamped to each battery's
+    # configured floor.  Runtime re-reads SOC and applies the same floors.
+    remaining = planned_kwh
+    targets: dict[str, float] = {}
+    for snapshot in discharge_batteries:
+        available = available_by_battery[snapshot.name]
+        allocation = 0.0 if available_discharge_kwh <= EPSILON else planned_kwh * available / available_discharge_kwh
+        allocation = min(available, max(0.0, allocation), remaining)
+        targets[snapshot.name] = max(
+            max(snapshot.floor_soc_pct, reserve),
+            snapshot.soc_pct - allocation / snapshot.capacity_kwh * 100.0,
+        )
+        remaining -= allocation
+    plan.target_soc_by_battery = targets
+    return plan
+
+
+# Descriptive alias used by callers that prefer the noun-first name.
+build_curtailment_plan = plan_curtailment

--- a/custom_components/omnibattery/pricing/engine.py
+++ b/custom_components/omnibattery/pricing/engine.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from datetime import datetime, timedelta
 from time import monotonic
 from typing import TYPE_CHECKING, Any, Optional
@@ -45,6 +46,11 @@ from ..const import (
     FLOOR_HYSTERESIS_PCT,
 )
 from . import PriceSlot, DynamicPricingSchedule, calculations, notifications
+from .curtailment import (
+    BatterySnapshot,
+    CurtailmentPlan,
+    plan_curtailment,
+)
 from .nordpool import (
     NORDPOOL_DOMAIN,
     NORDPOOL_GET_PRICES_SERVICE,
@@ -580,6 +586,437 @@ class PricingManager:
         return any(s.start <= now < s.end for s in self._controller._dynamic_pricing_schedule.selected_slots)
 
     # =========================================================================
+    # SMART PREDISCHARGE / ANTI-CURTAILMENT
+    # =========================================================================
+
+    def _smart_predischarge_enabled(self) -> bool:
+        """Return the feature gate, including the dynamic-pricing scope."""
+        return bool(
+            getattr(self._controller, "smart_predischarge_enabled", False)
+            and getattr(self._controller, "predictive_charging_enabled", False)
+            and getattr(self._controller, "predictive_charging_mode", None)
+            == PREDICTIVE_MODE_DYNAMIC_PRICING
+        )
+
+    def _curtailment_plan_slots(self, slots: list[PriceSlot], now: datetime) -> list[PriceSlot]:
+        """Keep the daily solar plan on the current local day only."""
+        return [slot for slot in slots if slot.end > now and slot.start.date() == now.date()]
+
+    @staticmethod
+    def _future_slot_matches_operation_block(slot: PriceSlot, operation_slot: dict) -> bool:
+        """Return whether a recurring user slot forbids discharge in ``slot``."""
+        if not operation_slot.get("enabled", True) or operation_slot.get("allow_discharge", False):
+            return False
+        days = operation_slot.get("days", [])
+        start_text = operation_slot.get("start_time")
+        end_text = operation_slot.get("end_time")
+        if not start_text or not end_text:
+            return False
+        try:
+            start = datetime.strptime(str(start_text), "%H:%M").time()
+            end = datetime.strptime(str(end_text), "%H:%M").time()
+        except (TypeError, ValueError):
+            return False
+
+        def matches(moment: datetime) -> bool:
+            day = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")[moment.weekday()]
+            if days and day not in days:
+                return False
+            if start <= end:
+                return start <= moment.time() < end
+            return moment.time() >= start or moment.time() < end
+
+        # Checking both ends catches ordinary and cross-midnight recurring slots.
+        return matches(slot.start) or matches(slot.end - timedelta(seconds=1))
+
+    def _curtailment_operation_blocked_slots(self, slots: list[PriceSlot]) -> list[PriceSlot]:
+        configured = self._controller.config_entry.data.get("no_discharge_time_slots", [])
+        if not configured:
+            return []
+        if isinstance(configured, dict):
+            configured = [configured]
+        return [
+            slot
+            for slot in slots
+            if any(self._future_slot_matches_operation_block(slot, item) for item in configured)
+        ]
+
+    def _curtailment_battery_snapshots(self) -> list[BatterySnapshot]:
+        """Read live battery limits without bypassing any user ownership."""
+        snapshots: list[BatterySnapshot] = []
+        reserve = max(0.0, float(getattr(self._controller, "predischarge_reserve_soc", 0.0) or 0.0))
+        guaranteed = (
+            float(getattr(self._controller, "_predictive_min_soc_floor", 0.0) or 0.0)
+            if getattr(self._controller, "_predictive_min_soc_floor_enabled", False)
+            else 0.0
+        )
+        for coordinator in self._controller.coordinators:
+            data = coordinator.data or {}
+            eligible = bool(
+                data
+                and coordinator.is_available
+                and not self._controller._non_responsive.is_excluded(coordinator)
+                and not self._controller._is_active_balance_mode_running(coordinator)
+                and not self._controller._is_backup_function_active(coordinator)
+                and not coordinator.rs485_user_disabled
+                and not self._controller._is_manual_slot_owned(coordinator)
+            )
+            # A user/time-slot blocker must prevent a forced plan.  Price and
+            # this feature's own transient blockers are deliberately ignored:
+            # the former changes with each future slot and the latter is rebuilt.
+            blockers = self._controller.get_discharge_blockers(coordinator)
+            hard_blockers = set(blockers) - {
+                "price_discharge",
+                "curtailment_negative_window",
+                "curtailment_floor",
+            }
+            can_discharge = eligible and not hard_blockers
+            try:
+                soc = float(data.get("battery_soc"))
+                capacity = float(data.get("battery_total_energy"))
+                max_discharge = float(self._controller._battery_power_limit(coordinator, False))
+                max_soc = float(coordinator.max_soc)
+                floor = max(
+                    float(self._controller._effective_discharge_min_soc(coordinator)[0]),
+                    guaranteed,
+                    reserve,
+                )
+            except (AttributeError, TypeError, ValueError):
+                eligible = False
+                can_discharge = False
+                soc = capacity = max_discharge = max_soc = floor = 0.0
+            snapshots.append(
+                BatterySnapshot(
+                    name=coordinator.name,
+                    soc_pct=soc,
+                    capacity_kwh=capacity,
+                    max_soc_pct=max_soc,
+                    floor_soc_pct=floor,
+                    max_discharge_power_w=max_discharge,
+                    eligible=eligible,
+                    can_discharge=can_discharge,
+                )
+            )
+        return snapshots
+
+    def _refresh_curtailment_floor_blocks(
+        self, snapshots: list[BatterySnapshot]
+    ) -> None:
+        """Guard the configured smart reserve while a smart discharge is live."""
+        controller = self._controller
+        for coordinator in controller.coordinators:
+            controller.remove_discharge_block("curtailment_floor", coordinator=coordinator)
+
+        snapshots_by_name = {snapshot.name: snapshot for snapshot in snapshots}
+        for coordinator in controller.coordinators:
+            snapshot = snapshots_by_name.get(coordinator.name)
+            if snapshot is None or not snapshot.eligible or not snapshot.can_discharge:
+                continue
+            if snapshot.soc_pct <= snapshot.floor_soc_pct + 1e-6:
+                controller.set_discharge_block(
+                    "curtailment_floor",
+                    "predischarge_reserve_or_soc_floor",
+                    {
+                        "battery": snapshot.name,
+                        "soc": snapshot.soc_pct,
+                        "floor_soc": snapshot.floor_soc_pct,
+                    },
+                    coordinator=coordinator,
+                )
+
+    def _curtailment_forecast_model(self, now: datetime) -> tuple[float | None, object | None, float | None]:
+        """Return today's forecast, cumulative solar model and daily consumption."""
+        sensor = getattr(self._controller, "solar_forecast_sensor", None)
+        if not sensor:
+            return None, None, None
+        state = self._hass.states.get(sensor)
+        if state is None or state.state in ("unknown", "unavailable"):
+            return None, None, None
+        try:
+            forecast_kwh = float(state.state) * 0.85
+        except (TypeError, ValueError):
+            return None, None, None
+
+        tracker = getattr(self._controller, "_consumption_tracker", None)
+        if tracker is None:
+            return None, None, None
+        try:
+            t_start = getattr(self._controller, "_solar_t_start", None)
+            if t_start is None:
+                t_start = tracker.calculate_sunrise()
+            if t_start is None:
+                return None, None, None
+            if getattr(self._controller, "_solar_t_start", None) is not None:
+                t_end = tracker.estimate_t_end()
+            else:
+                t_end = 2 * tracker.calculate_solar_noon() - t_start
+            if t_end <= t_start:
+                return None, None, None
+            fraction_fn = lambda hour: tracker.get_solar_fraction_done(hour, t_start, t_end)
+            daily_consumption = float(tracker.get_avg_daily_consumption())
+        except (AttributeError, TypeError, ValueError):
+            return None, None, None
+        return forecast_kwh, fraction_fn, daily_consumption
+
+    def _build_curtailment_plan(
+        self,
+        slots: list[PriceSlot],
+        reserved_slots: list[PriceSlot] | None = None,
+        *,
+        now: datetime | None = None,
+    ) -> CurtailmentPlan:
+        """Calculate and publish a new non-persistent smart plan."""
+        evaluated_at = now or datetime.now()
+        if not self._smart_predischarge_enabled():
+            plan = CurtailmentPlan(
+                status="disabled", reason="feature_disabled", evaluation_time=evaluated_at
+            )
+            self._controller._curtailment_plan = plan
+            # Small pricing-engine test doubles and legacy startup paths may not
+            # expose the full controller blocker API.  Runtime cleanup is owned
+            # by the real controller's refresh/update paths.
+            if (
+                hasattr(self._controller, "remove_setpoint_override")
+                and hasattr(self._controller, "coordinators")
+            ):
+                self.clear_curtailment_runtime("disabled", preserve_plan=True)
+            return plan
+
+        daily_slots = self._curtailment_plan_slots(slots, evaluated_at)
+        forecast, solar_model, daily_consumption = self._curtailment_forecast_model(evaluated_at)
+        if forecast is None or solar_model is None or daily_consumption is None:
+            plan = CurtailmentPlan(
+                status="fail_safe",
+                reason="missing_forecast_or_solar_model",
+                evaluation_time=evaluated_at,
+            )
+            self._controller._curtailment_plan = plan
+            self.clear_curtailment_runtime(plan.reason, preserve_plan=True)
+            self._set_curtailment_runtime("fail_safe", plan.reason)
+            return plan
+
+        reserved = list(reserved_slots or [])
+        reserved.extend(self._curtailment_operation_blocked_slots(daily_slots))
+        try:
+            plan = plan_curtailment(
+                daily_slots,
+                forecast,
+                daily_consumption,
+                self._curtailment_battery_snapshots(),
+                negative_injection_threshold=float(
+                    getattr(self._controller, "negative_injection_threshold", 0.0)
+                ),
+                predischarge_reserve_soc=float(
+                    getattr(self._controller, "predischarge_reserve_soc", 0.0)
+                ),
+                headroom_margin_pct=float(
+                    getattr(self._controller, "curtailment_headroom_margin_pct", 0.0)
+                ),
+                charge_power_w=float(getattr(self._controller, "max_charge_capacity", 0.0) or 0.0),
+                max_export_power_w=float(
+                    getattr(self._controller, "predischarge_max_export_power_w", 0.0)
+                ),
+                solar_fraction_fn=solar_model,
+                reserved_slots=reserved,
+                now=evaluated_at,
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("Smart pre-discharge planner failed; using fail-safe: %s", err)
+            plan = CurtailmentPlan(
+                status="fail_safe",
+                reason="planner_error",
+                evaluation_time=evaluated_at,
+            )
+            self._controller._curtailment_plan = plan
+            self.clear_curtailment_runtime(plan.reason, preserve_plan=True)
+            self._set_curtailment_runtime("fail_safe", plan.reason)
+            return plan
+        self._controller._curtailment_plan = plan
+        self._controller._curtailment_last_evaluation = evaluated_at
+        self._set_curtailment_runtime(plan.status, plan.reason)
+        return plan
+
+    def _set_curtailment_runtime(
+        self, status: str, reason: str, active_export_target_w: float | None = None
+    ) -> None:
+        """Publish runtime state and log only transitions."""
+        controller = self._controller
+        target = 0.0 if active_export_target_w is None else float(active_export_target_w)
+        old = (
+            getattr(controller, "_curtailment_runtime_status", "disabled"),
+            getattr(controller, "_curtailment_runtime_reason", "disabled"),
+            round(getattr(controller, "_curtailment_active_export_target_w", 0.0), 1),
+        )
+        controller._curtailment_runtime_status = status
+        controller._curtailment_runtime_reason = reason
+        controller._curtailment_active_export_target_w = target
+        new = (status, reason, round(target, 1))
+        if old != new:
+            _LOGGER.info(
+                "Smart pre-discharge: %s (%s)%s",
+                status,
+                reason,
+                f", export target={target:.0f}W" if status == "predischarging" else "",
+            )
+
+    def clear_curtailment_runtime(self, reason: str = "cleanup", *, preserve_plan: bool = False) -> None:
+        """Remove every smart override/block and optionally keep diagnostics."""
+        controller = self._controller
+        controller.remove_setpoint_override("curtailment_predischarge")
+        controller.remove_discharge_block("curtailment_negative_window")
+        for coordinator in controller.coordinators:
+            controller.remove_discharge_block("curtailment_negative_window", coordinator=coordinator)
+            controller.remove_discharge_block("curtailment_floor", coordinator=coordinator)
+        controller._curtailment_active = False
+        controller._curtailment_active_export_target_w = 0.0
+        if not preserve_plan:
+            controller._curtailment_plan = CurtailmentPlan(
+                status="disabled", reason=reason, evaluation_time=datetime.now()
+            )
+        self._set_curtailment_runtime("disabled" if not preserve_plan else getattr(
+            getattr(controller, "_curtailment_plan", None), "status", "disabled"
+        ), reason)
+
+    def _current_curtailment_risk_slot(self, plan: CurtailmentPlan, now: datetime) -> PriceSlot | None:
+        return next((slot for slot in plan.risk_slots if slot.start <= now < slot.end), None)
+
+    def _current_predischarge_slot(self, plan: CurtailmentPlan, now: datetime):
+        return next((slot for slot in plan.selected_discharge_slots if slot.start <= now < slot.end), None)
+
+    def refresh_curtailment_runtime(self) -> None:
+        """Apply or clear the live action, with fail-safe cleanup on errors."""
+        try:
+            self._refresh_curtailment_runtime()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("Smart pre-discharge runtime failed; cleaning up: %s", err)
+            try:
+                self.clear_curtailment_runtime("runtime_error", preserve_plan=True)
+            except Exception as cleanup_err:  # noqa: BLE001
+                _LOGGER.error("Smart pre-discharge cleanup also failed: %s", cleanup_err)
+            try:
+                self._set_curtailment_runtime("fail_safe", "runtime_error")
+            except Exception:  # noqa: BLE001
+                # Do not let diagnostics compromise the PD loop's safety path.
+                pass
+
+    def _refresh_curtailment_runtime(self) -> None:
+        """Apply or clear the live block/override for the current slot."""
+        if not self._smart_predischarge_enabled():
+            self.clear_curtailment_runtime("feature_disabled")
+            return
+        plan = getattr(self._controller, "_curtailment_plan", None)
+        if plan is None:
+            self.clear_curtailment_runtime("no_plan", preserve_plan=True)
+            self._set_curtailment_runtime("fail_safe", "no_plan")
+            return
+        if plan.status == "fail_safe":
+            self.clear_curtailment_runtime(plan.reason, preserve_plan=True)
+            self._set_curtailment_runtime("fail_safe", plan.reason)
+            return
+        meter_state = self._hass.states.get(getattr(self._controller, "consumption_sensor", None))
+        if self._controller._apply_meter_transform(meter_state) is None:
+            self.clear_curtailment_runtime("invalid_grid_meter", preserve_plan=True)
+            self._set_curtailment_runtime("fail_safe", "invalid_grid_meter")
+            return
+        reported_at = getattr(meter_state, "last_reported", None)
+        if reported_at is not None and hasattr(self._controller, "_sensor_is_within_stale_tolerance"):
+            try:
+                if not self._controller._sensor_is_within_stale_tolerance(reported_at):
+                    self.clear_curtailment_runtime("stale_grid_meter", preserve_plan=True)
+                    self._set_curtailment_runtime("fail_safe", "stale_grid_meter")
+                    return
+            except (TypeError, ValueError):
+                self.clear_curtailment_runtime("invalid_grid_meter_timestamp", preserve_plan=True)
+                self._set_curtailment_runtime("fail_safe", "invalid_grid_meter_timestamp")
+                return
+        current_price = self._get_current_price()
+        if current_price is None or not math.isfinite(float(current_price)):
+            self.clear_curtailment_runtime("invalid_price", preserve_plan=True)
+            self._set_curtailment_runtime("fail_safe", "invalid_price")
+            return
+        if plan.status == "no_risk":
+            self.clear_curtailment_runtime(plan.reason, preserve_plan=True)
+            self._set_curtailment_runtime("no_risk", plan.reason)
+            return
+
+        now = datetime.now()
+        risk_slot = self._current_curtailment_risk_slot(plan, now)
+        # The negative-window blocker is per battery so capacity protection can
+        # take its priority-10 override without a global blocker deadlocking it.
+        for coordinator in self._controller.coordinators:
+            self._controller.remove_discharge_block(
+                "curtailment_negative_window", coordinator=coordinator
+            )
+            self._controller.remove_discharge_block(
+                "curtailment_floor", coordinator=coordinator
+            )
+        self._controller.remove_setpoint_override("curtailment_predischarge")
+        self._controller._curtailment_active = False
+
+        if risk_slot is not None:
+            self._refresh_curtailment_floor_blocks(
+                self._curtailment_battery_snapshots()
+            )
+            details = {
+                "current_price": current_price,
+                "threshold": getattr(self._controller, "negative_injection_threshold", 0.0),
+                "start": risk_slot.start.isoformat(),
+                "end": risk_slot.end.isoformat(),
+            }
+            for coordinator in self._controller.coordinators:
+                if coordinator.data is not None and coordinator.is_available:
+                    self._controller.set_discharge_block(
+                        "curtailment_negative_window",
+                        "negative_injection_window",
+                        details,
+                        coordinator=coordinator,
+                    )
+            self._set_curtailment_runtime("protected_window", "negative_injection_window")
+            return
+
+        snapshots = self._curtailment_battery_snapshots()
+        current_headroom = sum(
+            max(0.0, (snapshot.max_soc_pct - snapshot.soc_pct) / 100.0 * snapshot.capacity_kwh)
+            for snapshot in snapshots
+            if snapshot.eligible
+        )
+        plan.current_headroom_kwh = current_headroom
+        required = max(0.0, float(plan.required_headroom_kwh))
+        if current_headroom + 1e-6 >= required:
+            self._set_curtailment_runtime("target_reached", "headroom_sufficient")
+            return
+
+        active_slot = self._current_predischarge_slot(plan, now)
+        if active_slot is None:
+            self._set_curtailment_runtime("planned", plan.reason)
+            return
+
+        self._refresh_curtailment_floor_blocks(snapshots)
+        remaining_kwh = max(0.0, required - current_headroom)
+        hours_left = max(0.0, (active_slot.end - now).total_seconds() / 3600.0)
+        max_power = sum(
+            snapshot.max_discharge_power_w
+            for snapshot in snapshots
+            if snapshot.eligible and snapshot.can_discharge
+        )
+        export_cap = max(0.0, float(getattr(self._controller, "predischarge_max_export_power_w", 0.0)))
+        if hours_left <= 0 or max_power <= 0 or remaining_kwh <= 1e-6:
+            self._set_curtailment_runtime("shortfall", "no_live_discharge_capacity")
+            return
+        target_export = 0.0 if export_cap <= 0 else -min(
+            export_cap, max_power, remaining_kwh / hours_left * 1000.0
+        )
+        if export_cap <= 0:
+            # Zero means domestic self-consumption only.  A target of 0 W lets
+            # normal PD cover household load but never deliberately export.
+            target_export = 0.0
+        self._controller.set_setpoint_override(
+            "curtailment_predischarge", target_export, priority=5
+        )
+        self._controller._curtailment_active = True
+        self._set_curtailment_runtime("predischarging", "selected_discharge_slot", target_export)
+
+    # =========================================================================
     # DYNAMIC PRICING: Evaluation and notification methods
     # =========================================================================
 
@@ -593,6 +1030,10 @@ class PricingManager:
         # Cleared up front: the early returns below can still send a notification,
         # and a ceiling from a previous evaluation must not be reported as today's.
         self._controller._dp_arbitrage_ceiling = None
+        # A failed or interrupted reevaluation must never leave yesterday's
+        # negative setpoint/block active.  The new plan is rebuilt below.
+        if self._smart_predischarge_enabled():
+            self.clear_curtailment_runtime("reevaluation")
 
         # Ensure service-based provider slots are current before evaluating.
         await self._maybe_refresh_service_prices(force=True)
@@ -617,6 +1058,7 @@ class PricingManager:
             self._controller._dp_daily_avg_price = sum(s.price for s in slots) / len(slots)
             _LOGGER.debug("Dynamic pricing: daily average price %.4f from %d slots", self._controller._dp_daily_avg_price, len(slots))
         if not slots:
+            self._build_curtailment_plan([], [], now=now)
             if not charging_needed:
                 # No deficit + no price data: nothing to evaluate
                 self._controller._dynamic_pricing_schedule = None
@@ -665,12 +1107,60 @@ class PricingManager:
         )
 
         if not selected:
+            self._build_curtailment_plan(slots, [], now=now)
             self._controller._dynamic_pricing_schedule = None
             self._controller._dynamic_pricing_evaluated_date = today
             self._controller._dp_eval_retry_count = 0
             _LOGGER.warning("Dynamic pricing: no slots selected (all above threshold?)")
             await self._send_dynamic_pricing_notification(decision_data=decision_data, schedule=None)
             return
+
+        # A negative-price solar-surplus slot is protected from ordinary grid
+        # charging.  Build once with the tentative schedule, remove conflicts,
+        # then build the final plan with the remaining cheap slots reserved.
+        tentative_plan = self._build_curtailment_plan(slots, selected, now=now)
+        # Guaranteed-minimum SOC is the safety exception: if that floor is the
+        # reason for grid charging, keep its selected slot even when it overlaps
+        # a risk window.  The risk guard still prevents battery discharge.
+        if tentative_plan.risk_slots and not decision_data.get("floor_active", False):
+            protected_selected = [
+                slot
+                for slot in selected
+                if not any(
+                    slot.start < risk.end and risk.start < slot.end
+                    for risk in tentative_plan.risk_slots
+                )
+            ]
+            if len(protected_selected) != len(selected):
+                _LOGGER.info(
+                    "Dynamic pricing: removed %d grid-charge slots overlapping solar negative-price windows",
+                    len(selected) - len(protected_selected),
+                )
+                # Refill from other normalized slots where possible so the
+                # joint evaluation protects the solar window without needlessly
+                # losing the original grid-charge energy target.
+                safe_slots = [
+                    slot
+                    for slot in slots
+                    if not any(
+                        slot.start < risk.end and risk.start < slot.end
+                        for risk in tentative_plan.risk_slots
+                    )
+                ]
+                reselected = calculations.select_cheapest_hours(
+                    safe_slots, hours_needed, ceiling, now=eval_now
+                )
+                selected = reselected or protected_selected
+                if not selected:
+                    self._build_curtailment_plan(slots, [], now=now)
+                    self._controller._dynamic_pricing_schedule = None
+                    self._controller._dynamic_pricing_evaluated_date = today
+                    self._controller._dp_eval_retry_count = 0
+                    await self._send_dynamic_pricing_notification(
+                        decision_data=decision_data, schedule=None
+                    )
+                    return
+                self._build_curtailment_plan(slots, selected, now=now)
 
         # Step 4: Build schedule
         avg_price = sum(s.price for s in selected) / len(selected)
@@ -1196,6 +1686,7 @@ class PricingManager:
                 self._controller._dp_arbitrage_ceiling = None
                 self._controller._dp_evening_reevaluated_date = None
                 self._controller._dp_last_eval_soc = None
+                self.clear_curtailment_runtime("new_day")
 
         # Phase 4: Check if we're in a selected cheap slot
         if self._controller._dynamic_pricing_schedule and not self._controller.predictive_charging_overridden:

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -309,6 +309,11 @@
           "price_sensor": "Electricity price sensor",
           "max_price_threshold": "Maximum price threshold (optional)",
           "dp_price_discharge_control": "Only discharge when price is above threshold",
+          "smart_predischarge_enabled": "Enable Smart Pre-discharge / Anti-curtailment",
+          "negative_injection_threshold": "Negative injection threshold (currency/kWh)",
+          "predischarge_reserve_soc": "Pre-discharge reserve SOC (%)",
+          "predischarge_max_export_power_w": "Pre-discharge maximum export (W)",
+          "curtailment_headroom_margin_pct": "Curtailment headroom margin (%)",
           "solar_forecast_sensor": "Solar forecast sensor (kWh)",
           "predictive_safety_margin_kwh": "Solar forecast safety margin (kWh)",
           "predictive_grid_charge_margin_pct": "Predictive grid charge margin (%)"
@@ -318,6 +323,11 @@
           "price_sensor": "Sensor providing electricity prices (e.g., the official Nord Pool current-price sensor, a HACS Nordpool sensor, sensor.esios_pvpc for PVPC, or your CKW sensor for Switzerland)",
           "max_price_threshold": "Slots above this price will not be selected. When price-gated discharge is enabled, this value is also used as the discharge threshold. Use major currency/kWh: €/kWh for Nordpool/PVPC, CHF/kWh for CKW. HACS Nordpool prices configured in cents are converted automatically. Leave empty to use all slots and use the daily average as the discharge threshold.",
           "dp_price_discharge_control": "When enabled, the battery only discharges when the current electricity price exceeds the configured maximum price threshold. If no threshold is configured, it uses today's average price computed automatically from the price sensor. If time slots restrict discharge, both conditions must be met.",
+          "smart_predischarge_enabled": "Opt-in dynamic-pricing feature. It creates battery headroom before forecast PV surplus reaches a price slot at or below the negative-injection threshold. Existing SOC floors, user limits, time slots, manual ownership, backup and capacity protection remain authoritative.",
+          "negative_injection_threshold": "A future slot is considered at risk when its normalized price is at or below this inclusive threshold and forecast PV exceeds estimated household consumption.",
+          "predischarge_reserve_soc": "Additional SOC floor for pre-discharge. 0 uses each battery's configured minimum and guaranteed minimum SOC floors.",
+          "predischarge_max_export_power_w": "Maximum deliberate grid export while creating headroom. 0 W means self-consumption only; Omnibattery never controls the PV inverter.",
+          "curtailment_headroom_margin_pct": "Extra headroom reserved above the forecast requirement. 0% follows the forecast estimate exactly.",
           "solar_forecast_sensor": "Sensor providing the solar production forecast in kWh (e.g., Solcast). If you have solar panels, configure this sensor — the system will only charge from the grid when solar forecast is insufficient. If you have no solar panels, leave this empty — the system will charge whenever battery energy is not enough for the day. Not required if you already configured this sensor in the initial setup step — it will be used automatically.",
           "predictive_safety_margin_kwh": "Extra energy buffer added to the consumption forecast before deciding whether to charge. Useful when your solar forecast tends to be optimistic. Set to 0 to disable (default). Capped at total battery capacity.",
           "predictive_grid_charge_margin_pct": "Extra % charged from the grid on top of the solar-deficit, to hedge against optimistic solar forecasts. E.g. a 2 kWh grid need at 50% charges 3 kWh. 0 to disable (default). Capped at the gap to max SOC."
@@ -873,6 +883,11 @@
           "price_sensor": "Electricity price sensor",
           "max_price_threshold": "Maximum price threshold (optional)",
           "dp_price_discharge_control": "Only discharge when price is above threshold",
+          "smart_predischarge_enabled": "Enable Smart Pre-discharge / Anti-curtailment",
+          "negative_injection_threshold": "Negative injection threshold (currency/kWh)",
+          "predischarge_reserve_soc": "Pre-discharge reserve SOC (%)",
+          "predischarge_max_export_power_w": "Pre-discharge maximum export (W)",
+          "curtailment_headroom_margin_pct": "Curtailment headroom margin (%)",
           "solar_forecast_sensor": "Solar forecast sensor (kWh)",
           "predictive_safety_margin_kwh": "Solar forecast safety margin (kWh)",
           "predictive_grid_charge_margin_pct": "Predictive grid charge margin (%)"
@@ -882,6 +897,11 @@
           "price_sensor": "Sensor providing electricity prices (e.g., the official Nord Pool current-price sensor, a HACS Nordpool sensor, sensor.esios_pvpc for PVPC, or your CKW sensor for Switzerland)",
           "max_price_threshold": "Slots above this price will not be selected. When price-gated discharge is enabled, this value is also used as the discharge threshold. Use major currency/kWh: €/kWh for Nordpool/PVPC, CHF/kWh for CKW. HACS Nordpool prices configured in cents are converted automatically. Leave empty to use all slots and use the daily average as the discharge threshold.",
           "dp_price_discharge_control": "When enabled, the battery only discharges when the current electricity price exceeds the configured maximum price threshold. If no threshold is configured, it uses today's average price computed automatically from the price sensor. If time slots restrict discharge, both conditions must be met.",
+          "smart_predischarge_enabled": "Opt-in dynamic-pricing feature. It creates battery headroom before forecast PV surplus reaches a price slot at or below the negative-injection threshold. Existing SOC floors, user limits, time slots, manual ownership, backup and capacity protection remain authoritative.",
+          "negative_injection_threshold": "A future slot is considered at risk when its normalized price is at or below this inclusive threshold and forecast PV exceeds estimated household consumption.",
+          "predischarge_reserve_soc": "Additional SOC floor for pre-discharge. 0 uses each battery's configured minimum and guaranteed minimum SOC floors.",
+          "predischarge_max_export_power_w": "Maximum deliberate grid export while creating headroom. 0 W means self-consumption only; Omnibattery never controls the PV inverter.",
+          "curtailment_headroom_margin_pct": "Extra headroom reserved above the forecast requirement. 0% follows the forecast estimate exactly.",
           "solar_forecast_sensor": "Sensor providing the solar production forecast in kWh (e.g., Solcast). If you have solar panels, configure this sensor — the system will only charge from the grid when solar forecast is insufficient. If you have no solar panels, leave this empty — the system will charge whenever battery energy is not enough for the day. Not required if you already configured this sensor in the initial setup step — it will be used automatically.",
           "predictive_safety_margin_kwh": "Extra energy buffer added to the consumption forecast before deciding whether to charge. Useful when your solar forecast tends to be optimistic. Set to 0 to disable (default). Capped at total battery capacity.",
           "predictive_grid_charge_margin_pct": "Extra % charged from the grid on top of the solar-deficit, to hedge against optimistic solar forecasts. E.g. a 2 kWh grid need at 50% charges 3 kWh. 0 to disable (default). Capped at the gap to max SOC."
@@ -1215,6 +1235,9 @@
       "dp_price_discharge_control": {
         "name": "Price-Based Discharge"
       },
+      "smart_predischarge": {
+        "name": "Smart Pre-discharge / Anti-curtailment"
+      },
       "rt_price_discharge_control": {
         "name": "Price-Based Discharge"
       },
@@ -1542,6 +1565,9 @@
       "predictive_charging_active": {
         "name": "Predictive Charging Active"
       },
+      "curtailment_status": {
+        "name": "Smart Pre-discharge Status"
+      },
       "wifi_status": {
         "name": "WiFi Status"
       },
@@ -1734,6 +1760,18 @@
       },
       "round_trip_efficiency": {
         "name": "Round-Trip Efficiency"
+      },
+      "negative_injection_threshold": {
+        "name": "Negative Injection Threshold"
+      },
+      "predischarge_reserve_soc": {
+        "name": "Pre-discharge Reserve SOC"
+      },
+      "predischarge_max_export_power_w": {
+        "name": "Pre-discharge Maximum Export"
+      },
+      "curtailment_headroom_margin_pct": {
+        "name": "Curtailment Headroom Margin"
       }
     },
     "button": {

--- a/custom_components/omnibattery/switch.py
+++ b/custom_components/omnibattery/switch.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_PREDICTIVE_CHARGING_MODE,
     CONF_DP_PRICE_DISCHARGE_CONTROL,
     CONF_RT_PRICE_DISCHARGE_CONTROL,
+    CONF_SMART_PREDISCHARGE_ENABLED,
     PREDICTIVE_MODE_DYNAMIC_PRICING,
     PREDICTIVE_MODE_REALTIME_PRICE,
     CONF_SYSTEM_MAX_CHARGE_POWER,
@@ -91,6 +92,7 @@ async def async_setup_entry(
         mode = entry.data.get(CONF_PREDICTIVE_CHARGING_MODE)
         if mode == PREDICTIVE_MODE_DYNAMIC_PRICING:
             entities.append(PriceDischargeControlSwitch(hass, entry, controller, "dp"))
+            entities.append(SmartPredischargeSwitch(hass, entry, controller))
         elif mode == PREDICTIVE_MODE_REALTIME_PRICE:
             entities.append(PriceDischargeControlSwitch(hass, entry, controller, "rt"))
 
@@ -1777,6 +1779,58 @@ class PriceDischargeControlSwitch(SwitchEntity):
     @property
     def device_info(self):
         """Return device information for the system."""
+        return {
+            "identifiers": {(DOMAIN, "marstek_venus_system")},
+            "name": "Omnibattery System",
+            "manufacturer": "Omnibattery",
+            "model": "Multi-Battery System",
+        }
+
+
+class SmartPredischargeSwitch(SwitchEntity):
+    """Opt-in anti-curtailment switch scoped to dynamic pricing."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, controller) -> None:
+        self.hass = hass
+        self.entry = entry
+        self.controller = controller
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "smart_predischarge"
+        self._attr_unique_id = f"{SYSTEM_UNIQUE_ID_PREFIX}smart_predischarge"
+        self.entity_id = system_entity_id("switch", "smart_predischarge")
+        self._attr_icon = "mdi:battery-arrow-down-outline"
+        self._attr_should_poll = False
+
+    @property
+    def is_on(self) -> bool:
+        return bool(self.controller.smart_predischarge_enabled)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable and recalculate the current dynamic-pricing plan."""
+        self.controller.smart_predischarge_enabled = True
+        new_data = dict(self.entry.data)
+        new_data[CONF_SMART_PREDISCHARGE_ENABLED] = True
+        self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+        _LOGGER.info("Smart pre-discharge ENABLED")
+        try:
+            await self.controller._pricing_mgr._evaluate_dynamic_pricing(extended_horizon=True)
+        except Exception as err:  # keep a runtime toggle fail-safe
+            _LOGGER.warning("Smart pre-discharge evaluation failed after enable: %s", err)
+            self.controller._pricing_mgr.clear_curtailment_runtime("evaluation_error")
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable and immediately clean every smart runtime action."""
+        self.controller.smart_predischarge_enabled = False
+        new_data = dict(self.entry.data)
+        new_data[CONF_SMART_PREDISCHARGE_ENABLED] = False
+        self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+        self.controller._pricing_mgr.clear_curtailment_runtime("disabled")
+        _LOGGER.info("Smart pre-discharge DISABLED")
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
         return {
             "identifiers": {(DOMAIN, "marstek_venus_system")},
             "name": "Omnibattery System",

--- a/custom_components/omnibattery/translations/ca.json
+++ b/custom_components/omnibattery/translations/ca.json
@@ -294,6 +294,11 @@
           "max_price_threshold": "Preu màxim (opcional)",
           "discharge_price_threshold": "Preu mínim de descàrrega (opcional)",
           "dp_price_discharge_control": "Descarregar només quan el preu superi el llindar",
+          "smart_predischarge_enabled": "Predescàrrega intel·ligent / anti-abocament",
+          "negative_injection_threshold": "Llindar d'injecció negativa",
+          "predischarge_reserve_soc": "Reserva de SOC de predescàrrega (%)",
+          "predischarge_max_export_power_w": "Exportació màxima de predescàrrega (W)",
+          "curtailment_headroom_margin_pct": "Marge d'espai anti-abocament (%)",
           "solar_forecast_sensor": "Sensor de predicció solar (kWh)",
           "predictive_safety_margin_kwh": "Marge de seguretat de previsió solar (kWh)",
           "predictive_grid_charge_margin_pct": "Marge de càrrega de xarxa predictiva (%)"
@@ -304,6 +309,11 @@
           "max_price_threshold": "Les hores per sobre d'aquest preu no seran seleccionades. Quan el control de descàrrega per preu està activat, aquest valor també s'usa com a llindar de descàrrega. Usa moneda principal/kWh: €/kWh per a Nordpool/PVPC, CHF/kWh per a CKW. Els preus Nordpool HACS configurats en cèntims es converteixen automàticament. Deixa buit per usar totes les hores i usar la mitjana diària com a llindar de descàrrega. Tret que configuris a sota un preu mínim de descàrrega per separat.",
           "discharge_price_threshold": "Llindar separat opcional per a la descàrrega per preu. La descàrrega es bloqueja mentre el preu sigui igual o inferior a aquest valor, obrint una banda neutra entre el preu màxim de càrrega (a dalt) i aquest mínim: en aquesta banda la bateria ni carrega de xarxa ni descarrega (la càrrega per excedent solar continua funcionant). Deixa-ho buit per reutilitzar el preu màxim per a tots dos (comportament actual d'un sol llindar).",
           "dp_price_discharge_control": "Si està activat, la bateria només descarrega quan el preu elèctric actual supera el preu màxim configurat. Si no hi ha llindar configurat, usa el preu mitjà del dia calculat automàticament a partir del sensor de preus. Si les franges horàries restringeixen la descàrrega, s'han de complir totes dues condicions.",
+          "smart_predischarge_enabled": "Activa la predescàrrega optativa només en el mode de preus dinàmics per crear espai abans de franges amb preu d'injecció negatiu.",
+          "negative_injection_threshold": "Preus iguals o inferiors a aquest llindar es consideren franges de risc quan hi ha excedent solar previst.",
+          "predischarge_reserve_soc": "SOC que la predescàrrega ha de reservar, a més dels límits mínims existents.",
+          "predischarge_max_export_power_w": "Potència d'exportació permesa durant la predescàrrega. 0 només cobreix el consum de la llar.",
+          "curtailment_headroom_margin_pct": "Marge addicional d'espai requerit abans de la franja de risc.",
           "solar_forecast_sensor": "Sensor que proporciona la predicció de producció solar en kWh (ex: Solcast). Si tens panells solars, configura'l — el sistema només carregarà des de la xarxa quan la previsió solar sigui insuficient. Si no tens panells, deixa'l buit — el sistema carregarà quan la bateria no tingui energia suficient per al dia. No cal si ja has configurat aquest sensor al pas inicial: s'utilitzarà automàticament.",
           "predictive_safety_margin_kwh": "Energia addicional afegida a la previsió de consum abans de decidir si carregar. Útil quan la teva previsió solar tendeix a ser optimista. Posa 0 per desactivar (per defecte). Limitat a la capacitat total de la bateria.",
           "predictive_grid_charge_margin_pct": "Percentatge extra carregat des de la xarxa sobre el dèficit solar, per cobrir previsions solars optimistes. Ex.: una necessitat de 2 kWh de xarxa al 50% carrega 3 kWh. 0 per desactivar (per defecte). Limitat al marge fins al SOC màxim."
@@ -889,6 +899,11 @@
           "max_price_threshold": "Preu màxim (opcional)",
           "discharge_price_threshold": "Preu mínim de descàrrega (opcional)",
           "dp_price_discharge_control": "Descarrega només quan el preu superi el llindar",
+          "smart_predischarge_enabled": "Predescàrrega intel·ligent / anti-abocament",
+          "negative_injection_threshold": "Llindar d'injecció negativa",
+          "predischarge_reserve_soc": "Reserva de SOC de predescàrrega (%)",
+          "predischarge_max_export_power_w": "Exportació màxima de predescàrrega (W)",
+          "curtailment_headroom_margin_pct": "Marge d'espai anti-abocament (%)",
           "solar_forecast_sensor": "Sensor de predicció solar (kWh)",
           "predictive_safety_margin_kwh": "Marge de seguretat de previsió solar (kWh)",
           "predictive_grid_charge_margin_pct": "Marge de càrrega de xarxa predictiva (%)"
@@ -899,6 +914,11 @@
           "max_price_threshold": "Les hores per sobre d'aquest preu no seran seleccionades. Quan el control de descàrrega per preu està activat, aquest valor també s'usa com a llindar de descàrrega. Usa moneda principal/kWh: €/kWh per a Nordpool/PVPC, CHF/kWh per a CKW. Els preus Nordpool HACS configurats en cèntims es converteixen automàticament. Deixa buit per usar totes les hores i usar la mitjana diària com a llindar de descàrrega. Tret que configuris a sota un preu mínim de descàrrega per separat.",
           "discharge_price_threshold": "Llindar separat opcional per a la descàrrega per preu. La descàrrega es bloqueja mentre el preu sigui igual o inferior a aquest valor, obrint una banda neutra entre el preu màxim de càrrega (a dalt) i aquest mínim: en aquesta banda la bateria ni carrega de xarxa ni descarrega (la càrrega per excedent solar continua funcionant). Deixa-ho buit per reutilitzar el preu màxim per a tots dos (comportament actual d'un sol llindar).",
           "dp_price_discharge_control": "Si està activat, la bateria només descarrega quan el preu elèctric actual supera el preu màxim configurat. Si no hi ha llindar configurat, usa el preu mitjà del dia calculat automàticament a partir del sensor de preus. Si les franges horàries restringeixen la descàrrega, s'han de complir totes dues condicions.",
+          "smart_predischarge_enabled": "Activa la predescàrrega optativa només en el mode de preus dinàmics per crear espai abans de franges amb preu d'injecció negatiu.",
+          "negative_injection_threshold": "Preus iguals o inferiors a aquest llindar es consideren franges de risc quan hi ha excedent solar previst.",
+          "predischarge_reserve_soc": "SOC que la predescàrrega ha de reservar, a més dels límits mínims existents.",
+          "predischarge_max_export_power_w": "Potència d'exportació permesa durant la predescàrrega. 0 només cobreix el consum de la llar.",
+          "curtailment_headroom_margin_pct": "Marge addicional d'espai requerit abans de la franja de risc.",
           "solar_forecast_sensor": "Sensor que proporciona la predicció de producció solar en kWh (ex: Solcast). Si tens panells solars, configura'l — el sistema només carregarà des de la xarxa quan la previsió solar sigui insuficient. Si no tens panells, deixa'l buit — el sistema carregarà quan la bateria no tingui energia suficient per al dia. No cal si ja has configurat aquest sensor al pas inicial: s'utilitzarà automàticament.",
           "predictive_safety_margin_kwh": "Energia addicional afegida a la previsió de consum abans de decidir si carregar. Útil quan la teva previsió solar tendeix a ser optimista. Posa 0 per desactivar (per defecte). Limitat a la capacitat total de la bateria.",
           "predictive_grid_charge_margin_pct": "Percentatge extra carregat des de la xarxa sobre el dèficit solar, per cobrir previsions solars optimistes. Ex.: una necessitat de 2 kWh de xarxa al 50% carrega 3 kWh. 0 per desactivar (per defecte). Limitat al marge fins al SOC màxim."
@@ -1233,6 +1253,9 @@
       "dp_price_discharge_control": {
         "name": "Descàrrega segons preu"
       },
+      "smart_predischarge": {
+        "name": "Predescàrrega intel·ligent / anti-abocament"
+      },
       "rt_price_discharge_control": {
         "name": "Descàrrega segons preu"
       },
@@ -1560,6 +1583,9 @@
       "predictive_charging_active": {
         "name": "Càrrega Predictiva Activa"
       },
+      "curtailment_status": {
+        "name": "Estat de predescàrrega intel·ligent"
+      },
       "wifi_status": {
         "name": "Estat WiFi"
       },
@@ -1719,6 +1745,18 @@
       },
       "predictive_grid_charge_margin_pct": {
         "name": "Marge de Càrrega de Xarxa Predictiva"
+      },
+      "negative_injection_threshold": {
+        "name": "Llindar d'injecció negativa"
+      },
+      "predischarge_reserve_soc": {
+        "name": "Reserva de SOC de predescàrrega"
+      },
+      "predischarge_max_export_power_w": {
+        "name": "Exportació màxima de predescàrrega"
+      },
+      "curtailment_headroom_margin_pct": {
+        "name": "Marge d'espai anti-abocament"
       },
       "predictive_min_soc_floor": {
         "name": "SOC mínim garantit"

--- a/custom_components/omnibattery/translations/de.json
+++ b/custom_components/omnibattery/translations/de.json
@@ -294,6 +294,11 @@
           "max_price_threshold": "Maximaler Preisschwellenwert (€/kWh, optional)",
           "discharge_price_threshold": "Entlade-Preisuntergrenze (optional)",
           "dp_price_discharge_control": "Nur entladen wenn Preis über Schwellenwert",
+          "smart_predischarge_enabled": "Intelligente Vorentladung / Anti-Abregelung",
+          "negative_injection_threshold": "Schwellenwert für negative Einspeisung",
+          "predischarge_reserve_soc": "SOC-Reserve für Vorentladung (%)",
+          "predischarge_max_export_power_w": "Maximale Vorentlade-Einspeisung (W)",
+          "curtailment_headroom_margin_pct": "Anti-Abregelungs-Reserve (%)",
           "solar_forecast_sensor": "Solarprognose-Sensor (kWh)",
           "predictive_safety_margin_kwh": "Solarprognose-Sicherheitspuffer (kWh)",
           "predictive_grid_charge_margin_pct": "Prädiktive Netzladungs-Marge (%)"
@@ -304,6 +309,11 @@
           "max_price_threshold": "Stunden über diesem Preis werden nicht ausgewählt. Wenn die preisbasierte Entladesteuerung aktiviert ist, wird dieser Wert auch als Entladeschwellenwert verwendet. Hauptwährung/kWh verwenden: €/kWh für Nordpool/PVPC, CHF/kWh für CKW. In Cent konfigurierte HACS-Nordpool-Preise werden automatisch umgerechnet. Leer lassen, um alle Stunden zu verwenden und den Tagesdurchschnitt als Entladeschwellenwert zu nutzen. Sofern unten keine separate Entlade-Preisuntergrenze festgelegt ist.",
           "discharge_price_threshold": "Optionale separate Untergrenze für die preisgesteuerte Entladung. Die Entladung wird blockiert, solange der Preis kleiner oder gleich diesem Wert ist, wodurch ein neutrales Band zwischen der oberen Ladegrenze und dieser Untergrenze entsteht: In diesem Band lädt die Batterie weder aus dem Netz noch entlädt sie (Laden aus Solarüberschuss funktioniert weiterhin). Leer lassen, um die maximale Preisgrenze für beides zu verwenden (bisheriges Verhalten mit einem Schwellenwert).",
           "dp_price_discharge_control": "Wenn aktiviert, entlädt die Batterie nur, wenn der aktuelle Strompreis den konfigurierten maximalen Preisschwellenwert übersteigt. Wenn kein Schwellenwert konfiguriert ist, wird der automatisch aus dem Preissensor berechnete Tagesdurchschnitt verwendet. Falls Zeitfenster die Entladung einschränken, müssen beide Bedingungen erfüllt sein.",
+          "smart_predischarge_enabled": "Aktiviert die optionale Vorentladung nur im dynamischen Preismodus, um vor negativen Einspeisepreisen Platz zu schaffen.",
+          "negative_injection_threshold": "Preise gleich oder unter diesem Wert gelten bei erwarteter Solarüberschussenergie als Risikofenster.",
+          "predischarge_reserve_soc": "SOC, der zusätzlich zu den vorhandenen Mindestgrenzen reserviert wird.",
+          "predischarge_max_export_power_w": "Erlaubte Einspeiseleistung während der Vorentladung. 0 bedeutet nur Eigenverbrauch.",
+          "curtailment_headroom_margin_pct": "Zusätzlicher erforderlicher Speicherplatz vor dem Risikofenster.",
           "solar_forecast_sensor": "Sensor, der die Solarproduktionsprognose in kWh liefert (z.B. Solcast). Mit Solaranlage: konfigurieren — das System lädt nur dann aus dem Netz, wenn die Solarprognose unzureichend ist. Ohne Solaranlage: leer lassen — das System lädt, wenn die Batterieenergie für den Tag nicht ausreicht. Nicht erforderlich, wenn dieser Sensor bereits im ersten Schritt konfiguriert wurde — er wird automatisch verwendet.",
           "predictive_safety_margin_kwh": "Zusätzlicher Energiepuffer, der der Verbrauchsprognose hinzugefügt wird. Nützlich, wenn die Solarprognose zu optimistisch ist. Auf 0 setzen zum Deaktivieren (Standard). Begrenzt auf Gesamtbatteriekapazität.",
           "predictive_grid_charge_margin_pct": "Zusätzlicher Prozentsatz, der über das Solar-Defizit hinaus aus dem Netz geladen wird, um optimistische Solarprognosen abzufedern. Z. B. lädt ein Netzbedarf von 2 kWh bei 50% 3 kWh. 0 zum Deaktivieren (Standard). Auf die Lücke bis zum max. SOC begrenzt."
@@ -889,6 +899,11 @@
           "max_price_threshold": "Maximaler Preisschwellenwert (€/kWh, optional)",
           "discharge_price_threshold": "Entlade-Preisuntergrenze (optional)",
           "dp_price_discharge_control": "Nur entladen wenn Preis über Schwellenwert",
+          "smart_predischarge_enabled": "Intelligente Vorentladung / Anti-Abregelung",
+          "negative_injection_threshold": "Schwellenwert für negative Einspeisung",
+          "predischarge_reserve_soc": "SOC-Reserve für Vorentladung (%)",
+          "predischarge_max_export_power_w": "Maximale Vorentlade-Einspeisung (W)",
+          "curtailment_headroom_margin_pct": "Anti-Abregelungs-Reserve (%)",
           "solar_forecast_sensor": "Solarprognose-Sensor (kWh)",
           "predictive_safety_margin_kwh": "Solarprognose-Sicherheitspuffer (kWh)",
           "predictive_grid_charge_margin_pct": "Prädiktive Netzladungs-Marge (%)"
@@ -899,6 +914,11 @@
           "max_price_threshold": "Stunden über diesem Preis werden nicht ausgewählt. Wenn die preisbasierte Entladesteuerung aktiviert ist, wird dieser Wert auch als Entladeschwellenwert verwendet. Hauptwährung/kWh verwenden: €/kWh für Nordpool/PVPC, CHF/kWh für CKW. In Cent konfigurierte HACS-Nordpool-Preise werden automatisch umgerechnet. Leer lassen, um alle Stunden zu verwenden und den Tagesdurchschnitt als Entladeschwellenwert zu nutzen. Sofern unten keine separate Entlade-Preisuntergrenze festgelegt ist.",
           "discharge_price_threshold": "Optionale separate Untergrenze für die preisgesteuerte Entladung. Die Entladung wird blockiert, solange der Preis kleiner oder gleich diesem Wert ist, wodurch ein neutrales Band zwischen der oberen Ladegrenze und dieser Untergrenze entsteht: In diesem Band lädt die Batterie weder aus dem Netz noch entlädt sie (Laden aus Solarüberschuss funktioniert weiterhin). Leer lassen, um die maximale Preisgrenze für beides zu verwenden (bisheriges Verhalten mit einem Schwellenwert).",
           "dp_price_discharge_control": "Wenn aktiviert, entlädt die Batterie nur, wenn der aktuelle Strompreis den konfigurierten maximalen Preisschwellenwert übersteigt. Wenn kein Schwellenwert konfiguriert ist, wird der automatisch aus dem Preissensor berechnete Tagesdurchschnitt verwendet. Falls Zeitfenster die Entladung einschränken, müssen beide Bedingungen erfüllt sein.",
+          "smart_predischarge_enabled": "Aktiviert die optionale Vorentladung nur im dynamischen Preismodus, um vor negativen Einspeisepreisen Platz zu schaffen.",
+          "negative_injection_threshold": "Preise gleich oder unter diesem Wert gelten bei erwarteter Solarüberschussenergie als Risikofenster.",
+          "predischarge_reserve_soc": "SOC, der zusätzlich zu den vorhandenen Mindestgrenzen reserviert wird.",
+          "predischarge_max_export_power_w": "Erlaubte Einspeiseleistung während der Vorentladung. 0 bedeutet nur Eigenverbrauch.",
+          "curtailment_headroom_margin_pct": "Zusätzlicher erforderlicher Speicherplatz vor dem Risikofenster.",
           "solar_forecast_sensor": "Sensor, der die Solarproduktionsprognose in kWh liefert (z.B. Solcast). Mit Solaranlage: konfigurieren — das System lädt nur dann aus dem Netz, wenn die Solarprognose unzureichend ist. Ohne Solaranlage: leer lassen — das System lädt, wenn die Batterieenergie für den Tag nicht ausreicht. Nicht erforderlich, wenn dieser Sensor bereits im ersten Schritt konfiguriert wurde — er wird automatisch verwendet.",
           "predictive_safety_margin_kwh": "Zusätzlicher Energiepuffer, der der Verbrauchsprognose hinzugefügt wird. Nützlich, wenn die Solarprognose zu optimistisch ist. Auf 0 setzen zum Deaktivieren (Standard). Begrenzt auf Gesamtbatteriekapazität.",
           "predictive_grid_charge_margin_pct": "Zusätzlicher Prozentsatz, der über das Solar-Defizit hinaus aus dem Netz geladen wird, um optimistische Solarprognosen abzufedern. Z. B. lädt ein Netzbedarf von 2 kWh bei 50% 3 kWh. 0 zum Deaktivieren (Standard). Auf die Lücke bis zum max. SOC begrenzt."
@@ -1233,6 +1253,9 @@
       "dp_price_discharge_control": {
         "name": "Preisbasierte Entladung"
       },
+      "smart_predischarge": {
+        "name": "Intelligente Vorentladung / Anti-Abregelung"
+      },
       "rt_price_discharge_control": {
         "name": "Preisbasierte Entladung"
       },
@@ -1560,6 +1583,9 @@
       "predictive_charging_active": {
         "name": "Prädiktives Laden Aktiv"
       },
+      "curtailment_status": {
+        "name": "Status der intelligenten Vorentladung"
+      },
       "wifi_status": {
         "name": "WLAN-Status"
       },
@@ -1719,6 +1745,18 @@
       },
       "predictive_grid_charge_margin_pct": {
         "name": "Prädiktive Netzladungs-Marge"
+      },
+      "negative_injection_threshold": {
+        "name": "Schwellenwert für negative Einspeisung"
+      },
+      "predischarge_reserve_soc": {
+        "name": "SOC-Reserve für Vorentladung"
+      },
+      "predischarge_max_export_power_w": {
+        "name": "Maximale Vorentlade-Einspeisung"
+      },
+      "curtailment_headroom_margin_pct": {
+        "name": "Anti-Abregelungs-Reserve"
       },
       "predictive_min_soc_floor": {
         "name": "Garantierter Mindest-SOC"

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -288,6 +288,11 @@
           "max_price_threshold": "Maximum price threshold (optional)",
           "discharge_price_threshold": "Discharge price floor (optional)",
           "dp_price_discharge_control": "Only discharge when price is above threshold",
+          "smart_predischarge_enabled": "Enable Smart Pre-discharge / Anti-curtailment",
+          "negative_injection_threshold": "Negative injection threshold (currency/kWh)",
+          "predischarge_reserve_soc": "Pre-discharge reserve SOC (%)",
+          "predischarge_max_export_power_w": "Pre-discharge maximum export (W)",
+          "curtailment_headroom_margin_pct": "Curtailment headroom margin (%)",
           "solar_forecast_sensor": "Solar forecast sensor (kWh)",
           "predictive_safety_margin_kwh": "Solar forecast safety margin (kWh)",
           "predictive_grid_charge_margin_pct": "Predictive grid charge margin (%)"
@@ -298,6 +303,11 @@
           "max_price_threshold": "Slots above this price will not be selected. When price-gated discharge is enabled, this value is also used as the discharge threshold unless a separate discharge floor is set below. Use major currency/kWh: €/kWh for Nordpool/PVPC, CHF/kWh for CKW. HACS Nordpool prices configured in cents are converted automatically. Leave empty to use all slots and use the daily average as the discharge threshold.",
           "discharge_price_threshold": "Optional separate floor for price-gated discharge. Discharge is blocked while the price is at or below this value, opening an idle band between the charge ceiling above and this floor: in that band the battery neither grid-charges nor discharges (solar-surplus charging still works). Leave empty to reuse the maximum price threshold for both (current single-threshold behavior).",
           "dp_price_discharge_control": "When enabled, the battery only discharges when the current electricity price exceeds the configured maximum price threshold. If no threshold is configured, it uses today's average price computed automatically from the price sensor. If time slots restrict discharge, both conditions must be met.",
+          "smart_predischarge_enabled": "Opt-in dynamic-pricing anti-curtailment. It creates headroom before forecast PV reaches a negative-price window while preserving all SOC, user and battery safety limits.",
+          "negative_injection_threshold": "Protect slots whose normalized price is at or below this inclusive threshold when forecast PV exceeds estimated household consumption.",
+          "predischarge_reserve_soc": "Additional SOC floor for pre-discharge. 0 uses the configured and guaranteed minimum SOC floors.",
+          "predischarge_max_export_power_w": "Maximum deliberate grid export during pre-discharge. 0 W means self-consumption only; the PV inverter is never controlled.",
+          "curtailment_headroom_margin_pct": "Extra headroom reserved above the forecast requirement. 0% follows the forecast estimate.",
           "solar_forecast_sensor": "Sensor providing the solar production forecast in kWh (e.g., Solcast). If you have solar panels, configure this sensor — the system will only charge from the grid when solar forecast is insufficient. If you have no solar panels, leave this empty — the system will charge whenever battery energy is not enough for the day. Not required if you already configured this sensor in the initial setup step — it will be used automatically.",
           "predictive_safety_margin_kwh": "Extra energy buffer added to the consumption forecast before deciding whether to charge. Useful when your solar forecast tends to be optimistic. Set to 0 to disable (default). Capped at total battery capacity.",
           "predictive_grid_charge_margin_pct": "Extra % charged from the grid on top of the solar-deficit, to hedge against optimistic solar forecasts. E.g. a 2 kWh grid need at 50% charges 3 kWh. 0 to disable (default). Capped at the gap to max SOC."
@@ -877,6 +887,11 @@
           "max_price_threshold": "Maximum price threshold (optional)",
           "discharge_price_threshold": "Discharge price floor (optional)",
           "dp_price_discharge_control": "Only discharge when price is above threshold",
+          "smart_predischarge_enabled": "Enable Smart Pre-discharge / Anti-curtailment",
+          "negative_injection_threshold": "Negative injection threshold (currency/kWh)",
+          "predischarge_reserve_soc": "Pre-discharge reserve SOC (%)",
+          "predischarge_max_export_power_w": "Pre-discharge maximum export (W)",
+          "curtailment_headroom_margin_pct": "Curtailment headroom margin (%)",
           "solar_forecast_sensor": "Solar forecast sensor (kWh)",
           "predictive_safety_margin_kwh": "Solar forecast safety margin (kWh)",
           "predictive_grid_charge_margin_pct": "Predictive grid charge margin (%)"
@@ -887,6 +902,11 @@
           "max_price_threshold": "Slots above this price will not be selected. When price-gated discharge is enabled, this value is also used as the discharge threshold unless a separate discharge floor is set below. Use major currency/kWh: €/kWh for Nordpool/PVPC, CHF/kWh for CKW. HACS Nordpool prices configured in cents are converted automatically. Leave empty to use all slots and use the daily average as the discharge threshold.",
           "discharge_price_threshold": "Optional separate floor for price-gated discharge. Discharge is blocked while the price is at or below this value, opening an idle band between the charge ceiling above and this floor: in that band the battery neither grid-charges nor discharges (solar-surplus charging still works). Leave empty to reuse the maximum price threshold for both (current single-threshold behavior).",
           "dp_price_discharge_control": "When enabled, the battery only discharges when the current electricity price exceeds the configured maximum price threshold. If no threshold is configured, it uses today's average price computed automatically from the price sensor. If time slots restrict discharge, both conditions must be met.",
+          "smart_predischarge_enabled": "Opt-in dynamic-pricing anti-curtailment. It creates headroom before forecast PV reaches a negative-price window while preserving all SOC, user and battery safety limits.",
+          "negative_injection_threshold": "Protect slots whose normalized price is at or below this inclusive threshold when forecast PV exceeds estimated household consumption.",
+          "predischarge_reserve_soc": "Additional SOC floor for pre-discharge. 0 uses the configured and guaranteed minimum SOC floors.",
+          "predischarge_max_export_power_w": "Maximum deliberate grid export during pre-discharge. 0 W means self-consumption only; the PV inverter is never controlled.",
+          "curtailment_headroom_margin_pct": "Extra headroom reserved above the forecast requirement. 0% follows the forecast estimate.",
           "solar_forecast_sensor": "Sensor providing the solar production forecast in kWh (e.g., Solcast). If you have solar panels, configure this sensor — the system will only charge from the grid when solar forecast is insufficient. If you have no solar panels, leave this empty — the system will charge whenever battery energy is not enough for the day. Not required if you already configured this sensor in the initial setup step — it will be used automatically.",
           "predictive_safety_margin_kwh": "Extra energy buffer added to the consumption forecast before deciding whether to charge. Useful when your solar forecast tends to be optimistic. Set to 0 to disable (default). Capped at total battery capacity.",
           "predictive_grid_charge_margin_pct": "Extra % charged from the grid on top of the solar-deficit, to hedge against optimistic solar forecasts. E.g. a 2 kWh grid need at 50% charges 3 kWh. 0 to disable (default). Capped at the gap to max SOC."
@@ -1148,6 +1168,9 @@
       },
       "dp_price_discharge_control": {
         "name": "Price-Based Discharge"
+      },
+      "smart_predischarge": {
+        "name": "Smart Pre-discharge / Anti-curtailment"
       },
       "rt_price_discharge_control": {
         "name": "Price-Based Discharge"
@@ -1548,6 +1571,9 @@
       "predictive_charging_active": {
         "name": "Predictive Charging Active"
       },
+      "curtailment_status": {
+        "name": "Smart Pre-discharge Status"
+      },
       "wifi_status": {
         "name": "WiFi Status"
       },
@@ -1746,6 +1772,18 @@
       },
       "round_trip_efficiency": {
         "name": "Round-Trip Efficiency"
+      },
+      "negative_injection_threshold": {
+        "name": "Negative Injection Threshold"
+      },
+      "predischarge_reserve_soc": {
+        "name": "Pre-discharge Reserve SOC"
+      },
+      "predischarge_max_export_power_w": {
+        "name": "Pre-discharge Maximum Export"
+      },
+      "curtailment_headroom_margin_pct": {
+        "name": "Curtailment Headroom Margin"
       }
     },
     "button": {

--- a/custom_components/omnibattery/translations/es.json
+++ b/custom_components/omnibattery/translations/es.json
@@ -294,6 +294,11 @@
           "max_price_threshold": "Precio máximo (opcional)",
           "discharge_price_threshold": "Precio mínimo de descarga (opcional)",
           "dp_price_discharge_control": "Descargar solo cuando el precio supere el umbral",
+          "smart_predischarge_enabled": "Predescarga inteligente / anti-vertido",
+          "negative_injection_threshold": "Umbral de inyección negativa",
+          "predischarge_reserve_soc": "Reserva de SOC de predescarga (%)",
+          "predischarge_max_export_power_w": "Exportación máxima de predescarga (W)",
+          "curtailment_headroom_margin_pct": "Margen de espacio anti-vertido (%)",
           "solar_forecast_sensor": "Sensor de predicción solar (kWh)",
           "predictive_safety_margin_kwh": "Margen de seguridad de previsión solar (kWh)",
           "predictive_grid_charge_margin_pct": "Margen de carga de red predictiva (%)"
@@ -304,6 +309,11 @@
           "max_price_threshold": "Las horas por encima de este precio no serán seleccionadas. Cuando el control de descarga por precio está activado, este valor también se usa como umbral de descarga salvo que configures abajo un precio mínimo de descarga aparte. Usa moneda principal/kWh: €/kWh para Nordpool/PVPC, CHF/kWh para CKW. Los precios Nordpool HACS configurados en céntimos se convierten automáticamente. Deja vacío para usar todas las horas y usar la media diaria como umbral de descarga.",
           "discharge_price_threshold": "Umbral separado opcional para la descarga por precio. La descarga se bloquea mientras el precio sea igual o inferior a este valor, abriendo una banda neutra entre el precio máximo de carga (arriba) y este mínimo: en esa banda la batería ni carga de red ni descarga (la carga por excedente solar sigue funcionando). Déjalo vacío para reutilizar el precio máximo para ambos (comportamiento actual de umbral único).",
           "dp_price_discharge_control": "Si está activado, la batería solo descarga cuando el precio eléctrico actual supera el precio máximo configurado. Si no hay umbral configurado, usa el precio medio del día calculado automáticamente a partir del sensor de precios. Si las franjas horarias restringen la descarga, ambas condiciones deben cumplirse.",
+          "smart_predischarge_enabled": "Activa la predescarga opcional solo en el modo de precios dinámicos para crear espacio antes de franjas con precio de inyección negativo.",
+          "negative_injection_threshold": "Los precios iguales o inferiores a este umbral son franjas de riesgo cuando se espera excedente solar.",
+          "predischarge_reserve_soc": "SOC que debe reservar la predescarga, además de los límites mínimos existentes.",
+          "predischarge_max_export_power_w": "Potencia de exportación permitida durante la predescarga. 0 significa solo autoconsumo.",
+          "curtailment_headroom_margin_pct": "Margen adicional de espacio requerido antes de la franja de riesgo.",
           "solar_forecast_sensor": "Sensor que proporciona la predicción de producción solar en kWh (ej: Solcast). Si tienes paneles solares, configúralo — el sistema solo cargará desde la red cuando la previsión solar sea insuficiente. Si no tienes paneles, déjalo vacío — el sistema cargará cuando la batería no tenga energía suficiente para el día. No es necesario si ya configuraste este sensor en el paso inicial: se usará automáticamente.",
           "predictive_safety_margin_kwh": "Energía adicional añadida a la previsión de consumo antes de decidir si cargar. Útil cuando tu previsión solar tiende a ser optimista. Pon 0 para desactivar (por defecto). Limitado a la capacidad total de la batería.",
           "predictive_grid_charge_margin_pct": "Porcentaje extra cargado desde la red sobre el déficit solar, para cubrir previsiones solares optimistas. Ej.: una necesidad de 2 kWh de red al 50% carga 3 kWh. 0 para desactivar (por defecto). Limitado al margen hasta el SOC máximo."
@@ -889,6 +899,11 @@
           "max_price_threshold": "Precio máximo (opcional)",
           "discharge_price_threshold": "Precio mínimo de descarga (opcional)",
           "dp_price_discharge_control": "Descargar solo cuando el precio supere el umbral",
+          "smart_predischarge_enabled": "Predescarga inteligente / anti-vertido",
+          "negative_injection_threshold": "Umbral de inyección negativa",
+          "predischarge_reserve_soc": "Reserva de SOC de predescarga (%)",
+          "predischarge_max_export_power_w": "Exportación máxima de predescarga (W)",
+          "curtailment_headroom_margin_pct": "Margen de espacio anti-vertido (%)",
           "solar_forecast_sensor": "Sensor de predicción solar (kWh)",
           "predictive_safety_margin_kwh": "Margen de seguridad de previsión solar (kWh)",
           "predictive_grid_charge_margin_pct": "Margen de carga de red predictiva (%)"
@@ -899,6 +914,11 @@
           "max_price_threshold": "Las horas por encima de este precio no serán seleccionadas. Cuando el control de descarga por precio está activado, este valor también se usa como umbral de descarga salvo que configures abajo un precio mínimo de descarga aparte. Usa moneda principal/kWh: €/kWh para Nordpool/PVPC, CHF/kWh para CKW. Los precios Nordpool HACS configurados en céntimos se convierten automáticamente. Deja vacío para usar todas las horas y usar la media diaria como umbral de descarga.",
           "discharge_price_threshold": "Umbral separado opcional para la descarga por precio. La descarga se bloquea mientras el precio sea igual o inferior a este valor, abriendo una banda neutra entre el precio máximo de carga (arriba) y este mínimo: en esa banda la batería ni carga de red ni descarga (la carga por excedente solar sigue funcionando). Déjalo vacío para reutilizar el precio máximo para ambos (comportamiento actual de umbral único).",
           "dp_price_discharge_control": "Si está activado, la batería solo descarga cuando el precio eléctrico actual supera el precio máximo configurado. Si no hay umbral configurado, usa el precio medio del día calculado automáticamente a partir del sensor de precios. Si las franjas horarias restringen la descarga, ambas condiciones deben cumplirse.",
+          "smart_predischarge_enabled": "Activa la predescarga opcional solo en el modo de precios dinámicos para crear espacio antes de franjas con precio de inyección negativo.",
+          "negative_injection_threshold": "Los precios iguales o inferiores a este umbral son franjas de riesgo cuando se espera excedente solar.",
+          "predischarge_reserve_soc": "SOC que debe reservar la predescarga, además de los límites mínimos existentes.",
+          "predischarge_max_export_power_w": "Potencia de exportación permitida durante la predescarga. 0 significa solo autoconsumo.",
+          "curtailment_headroom_margin_pct": "Margen adicional de espacio requerido antes de la franja de riesgo.",
           "solar_forecast_sensor": "Sensor que proporciona la predicción de producción solar en kWh (ej: Solcast). Si tienes paneles solares, configúralo — el sistema solo cargará desde la red cuando la previsión solar sea insuficiente. Si no tienes paneles, déjalo vacío — el sistema cargará cuando la batería no tenga energía suficiente para el día. No es necesario si ya configuraste este sensor en el paso inicial: se usará automáticamente.",
           "predictive_safety_margin_kwh": "Energía adicional añadida a la previsión de consumo antes de decidir si cargar. Útil cuando tu previsión solar tiende a ser optimista. Pon 0 para desactivar (por defecto). Limitado a la capacidad total de la batería.",
           "predictive_grid_charge_margin_pct": "Porcentaje extra cargado desde la red sobre el déficit solar, para cubrir previsiones solares optimistas. Ej.: una necesidad de 2 kWh de red al 50% carga 3 kWh. 0 para desactivar (por defecto). Limitado al margen hasta el SOC máximo."
@@ -1160,6 +1180,9 @@
       },
       "dp_price_discharge_control": {
         "name": "Descarga según precio"
+      },
+      "smart_predischarge": {
+        "name": "Predescarga inteligente / anti-vertido"
       },
       "rt_price_discharge_control": {
         "name": "Descarga según precio"
@@ -1560,6 +1583,9 @@
       "predictive_charging_active": {
         "name": "Carga Predictiva Activa"
       },
+      "curtailment_status": {
+        "name": "Estado de predescarga inteligente"
+      },
       "wifi_status": {
         "name": "Estado WiFi"
       },
@@ -1722,6 +1748,18 @@
       },
       "predictive_grid_charge_margin_pct": {
         "name": "Margen de Carga de Red Predictiva"
+      },
+      "negative_injection_threshold": {
+        "name": "Umbral de inyección negativa"
+      },
+      "predischarge_reserve_soc": {
+        "name": "Reserva de SOC de predescarga"
+      },
+      "predischarge_max_export_power_w": {
+        "name": "Exportación máxima de predescarga"
+      },
+      "curtailment_headroom_margin_pct": {
+        "name": "Margen de espacio anti-vertido"
       },
       "predictive_min_soc_floor": {
         "name": "SOC mínimo garantizado"

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -294,6 +294,11 @@
           "max_price_threshold": "Seuil de prix maximum (€/kWh, optionnel)",
           "discharge_price_threshold": "Prix plancher de décharge (optionnel)",
           "dp_price_discharge_control": "Décharger uniquement si le prix dépasse le seuil",
+          "smart_predischarge_enabled": "Pré-décharge intelligente / anti-écrêtement",
+          "negative_injection_threshold": "Seuil d'injection négative",
+          "predischarge_reserve_soc": "Réserve de SOC de pré-décharge (%)",
+          "predischarge_max_export_power_w": "Exportation maximale de pré-décharge (W)",
+          "curtailment_headroom_margin_pct": "Marge d'espace anti-écrêtement (%)",
           "solar_forecast_sensor": "Capteur de prévision solaire (kWh)",
           "predictive_safety_margin_kwh": "Marge de sécurité prévision solaire (kWh)",
           "predictive_grid_charge_margin_pct": "Marge de charge réseau prédictive (%)"
@@ -304,6 +309,11 @@
           "max_price_threshold": "Les créneaux au-dessus de ce prix ne seront pas sélectionnés. Quand le contrôle de décharge par prix est activé, cette valeur sert aussi de seuil de décharge. Utiliser la devise principale/kWh : €/kWh pour Nordpool/PVPC, CHF/kWh pour CKW. Les prix Nordpool HACS configurés en centimes sont convertis automatiquement. Laisser vide pour utiliser tous les créneaux et utiliser la moyenne journalière comme seuil de décharge. Sauf si un prix plancher de décharge distinct est défini ci-dessous.",
           "discharge_price_threshold": "Seuil distinct optionnel pour la décharge pilotée par le prix. La décharge est bloquée tant que le prix est inférieur ou égal à cette valeur, ouvrant une bande neutre entre le prix maximal de charge (au-dessus) et ce plancher : dans cette bande, la batterie ne se charge pas depuis le réseau et ne se décharge pas (la charge par surplus solaire fonctionne toujours). Laissez vide pour réutiliser le prix maximal pour les deux (comportement actuel à seuil unique).",
           "dp_price_discharge_control": "Si activé, la batterie ne se décharge que lorsque le prix actuel dépasse le seuil de prix maximum configuré. Si aucun seuil n'est configuré, la moyenne journalière calculée automatiquement depuis le capteur de prix est utilisée. Si les plages horaires limitent la décharge, les deux conditions doivent être remplies.",
+          "smart_predischarge_enabled": "Active la pré-décharge optionnelle uniquement en mode de tarification dynamique pour créer de l'espace avant les créneaux d'injection négative.",
+          "negative_injection_threshold": "Les prix inférieurs ou égaux à ce seuil sont considérés comme des créneaux à risque lorsqu'un surplus solaire est prévu.",
+          "predischarge_reserve_soc": "SOC à réserver en plus des limites minimales existantes.",
+          "predischarge_max_export_power_w": "Puissance d'exportation autorisée pendant la pré-décharge. 0 signifie autoconsommation uniquement.",
+          "curtailment_headroom_margin_pct": "Marge d'espace supplémentaire requise avant le créneau à risque.",
           "solar_forecast_sensor": "Capteur fournissant la prévision de production solaire en kWh (ex : Solcast). Avec panneaux solaires : configurez ce capteur — le système ne chargera depuis le réseau que si la prévision est insuffisante. Sans panneaux solaires : laissez vide — le système chargera quand l'énergie de la batterie est insuffisante pour la journée. Non requis si ce capteur a déjà été configuré à l'étape initiale — il sera utilisé automatiquement.",
           "predictive_safety_margin_kwh": "Tampon d'énergie supplémentaire ajouté à la prévision de consommation. Utile si la prévision solaire est trop optimiste. Mettre à 0 pour désactiver (défaut). Limité à la capacité totale de la batterie.",
           "predictive_grid_charge_margin_pct": "Pourcentage supplémentaire chargé depuis le réseau au-dessus du déficit solaire, pour couvrir des prévisions solaires optimistes. Ex. : un besoin réseau de 2 kWh à 50% charge 3 kWh. 0 pour désactiver (défaut). Plafonné à l'écart jusqu'au SOC max."
@@ -889,6 +899,11 @@
           "max_price_threshold": "Seuil de prix maximum (€/kWh, optionnel)",
           "discharge_price_threshold": "Prix plancher de décharge (optionnel)",
           "dp_price_discharge_control": "Décharger uniquement si le prix dépasse le seuil",
+          "smart_predischarge_enabled": "Pré-décharge intelligente / anti-écrêtement",
+          "negative_injection_threshold": "Seuil d'injection négative",
+          "predischarge_reserve_soc": "Réserve de SOC de pré-décharge (%)",
+          "predischarge_max_export_power_w": "Exportation maximale de pré-décharge (W)",
+          "curtailment_headroom_margin_pct": "Marge d'espace anti-écrêtement (%)",
           "solar_forecast_sensor": "Capteur de prévision solaire (kWh)",
           "predictive_safety_margin_kwh": "Marge de sécurité prévision solaire (kWh)",
           "predictive_grid_charge_margin_pct": "Marge de charge réseau prédictive (%)"
@@ -899,6 +914,11 @@
           "max_price_threshold": "Les créneaux au-dessus de ce prix ne seront pas sélectionnés. Quand le contrôle de décharge par prix est activé, cette valeur sert aussi de seuil de décharge. Utiliser la devise principale/kWh : €/kWh pour Nordpool/PVPC, CHF/kWh pour CKW. Les prix Nordpool HACS configurés en centimes sont convertis automatiquement. Laisser vide pour utiliser tous les créneaux et utiliser la moyenne journalière comme seuil de décharge. Sauf si un prix plancher de décharge distinct est défini ci-dessous.",
           "discharge_price_threshold": "Seuil distinct optionnel pour la décharge pilotée par le prix. La décharge est bloquée tant que le prix est inférieur ou égal à cette valeur, ouvrant une bande neutre entre le prix maximal de charge (au-dessus) et ce plancher : dans cette bande, la batterie ne se charge pas depuis le réseau et ne se décharge pas (la charge par surplus solaire fonctionne toujours). Laissez vide pour réutiliser le prix maximal pour les deux (comportement actuel à seuil unique).",
           "dp_price_discharge_control": "Si activé, la batterie ne se décharge que lorsque le prix actuel dépasse le seuil de prix maximum configuré. Si aucun seuil n'est configuré, la moyenne journalière calculée automatiquement depuis le capteur de prix est utilisée. Si les plages horaires limitent la décharge, les deux conditions doivent être remplies.",
+          "smart_predischarge_enabled": "Active la pré-décharge optionnelle uniquement en mode de tarification dynamique pour créer de l'espace avant les créneaux d'injection négative.",
+          "negative_injection_threshold": "Les prix inférieurs ou égaux à ce seuil sont considérés comme des créneaux à risque lorsqu'un surplus solaire est prévu.",
+          "predischarge_reserve_soc": "SOC à réserver en plus des limites minimales existantes.",
+          "predischarge_max_export_power_w": "Puissance d'exportation autorisée pendant la pré-décharge. 0 signifie autoconsommation uniquement.",
+          "curtailment_headroom_margin_pct": "Marge d'espace supplémentaire requise avant le créneau à risque.",
           "solar_forecast_sensor": "Capteur fournissant la prévision de production solaire en kWh (ex : Solcast). Avec panneaux solaires : configurez ce capteur — le système ne chargera depuis le réseau que si la prévision est insuffisante. Sans panneaux solaires : laissez vide — le système chargera quand l'énergie de la batterie est insuffisante pour la journée. Non requis si ce capteur a déjà été configuré à l'étape initiale — il sera utilisé automatiquement.",
           "predictive_safety_margin_kwh": "Tampon d'énergie supplémentaire ajouté à la prévision de consommation. Utile si la prévision solaire est trop optimiste. Mettre à 0 pour désactiver (défaut). Limité à la capacité totale de la batterie.",
           "predictive_grid_charge_margin_pct": "Pourcentage supplémentaire chargé depuis le réseau au-dessus du déficit solaire, pour couvrir des prévisions solaires optimistes. Ex. : un besoin réseau de 2 kWh à 50% charge 3 kWh. 0 pour désactiver (défaut). Plafonné à l'écart jusqu'au SOC max."
@@ -1233,6 +1253,9 @@
       "dp_price_discharge_control": {
         "name": "Décharge selon le prix"
       },
+      "smart_predischarge": {
+        "name": "Pré-décharge intelligente / anti-écrêtement"
+      },
       "rt_price_discharge_control": {
         "name": "Décharge selon le prix"
       },
@@ -1560,6 +1583,9 @@
       "predictive_charging_active": {
         "name": "Charge Prédictive Active"
       },
+      "curtailment_status": {
+        "name": "État de la pré-décharge intelligente"
+      },
       "wifi_status": {
         "name": "État WiFi"
       },
@@ -1719,6 +1745,18 @@
       },
       "predictive_grid_charge_margin_pct": {
         "name": "Marge de Charge Réseau Prédictive"
+      },
+      "negative_injection_threshold": {
+        "name": "Seuil d'injection négative"
+      },
+      "predischarge_reserve_soc": {
+        "name": "Réserve de SOC de pré-décharge"
+      },
+      "predischarge_max_export_power_w": {
+        "name": "Exportation maximale de pré-décharge"
+      },
+      "curtailment_headroom_margin_pct": {
+        "name": "Marge d'espace anti-écrêtement"
       },
       "predictive_min_soc_floor": {
         "name": "SOC minimum garanti"

--- a/custom_components/omnibattery/translations/nl.json
+++ b/custom_components/omnibattery/translations/nl.json
@@ -294,6 +294,11 @@
           "max_price_threshold": "Maximale prijsdrempel (€/kWh, optioneel)",
           "discharge_price_threshold": "Ontlaad-prijsondergrens (optioneel)",
           "dp_price_discharge_control": "Alleen ontladen als prijs boven drempelwaarde",
+          "smart_predischarge_enabled": "Slim voorontladen / anti-afregeling",
+          "negative_injection_threshold": "Drempelwaarde negatieve teruglevering",
+          "predischarge_reserve_soc": "SOC-reserve voor voorontladen (%)",
+          "predischarge_max_export_power_w": "Maximale teruglevering bij voorontladen (W)",
+          "curtailment_headroom_margin_pct": "Anti-afregelingsmarge (%)",
           "solar_forecast_sensor": "Zonnevoorspellingssensor (kWh)",
           "predictive_safety_margin_kwh": "Veiligheidsmarge zonne-energieprognose (kWh)",
           "predictive_grid_charge_margin_pct": "Voorspellende netladingsmarge (%)"
@@ -304,6 +309,11 @@
           "max_price_threshold": "Tijdsloten boven deze prijs worden niet geselecteerd. Wanneer prijsgestuurde ontlading is ingeschakeld, wordt deze waarde ook gebruikt als ontlaaddrempel. Gebruik hoofdvaluta/kWh: €/kWh voor Nordpool/PVPC, CHF/kWh voor CKW. HACS Nordpool-prijzen die in centen zijn ingesteld, worden automatisch omgerekend. Leeg laten om alle slots te gebruiken en het daggemiddelde als ontlaaddrempel te gebruiken. Tenzij hieronder een aparte ontlaadondergrens is ingesteld.",
           "discharge_price_threshold": "Optionele aparte ondergrens voor prijsgestuurde ontlading. Ontlading wordt geblokkeerd zolang de prijs lager dan of gelijk aan deze waarde is, waardoor een neutrale band ontstaat tussen de maximale laadprijs (hierboven) en deze ondergrens: in die band laadt de batterij niet vanaf het net en ontlaadt deze niet (laden met zonne-overschot blijft werken). Laat leeg om de maximale prijs voor beide te gebruiken (huidig gedrag met één drempel).",
           "dp_price_discharge_control": "Indien ingeschakeld, ontlaadt de batterij alleen wanneer de huidige elektriciteitsprijs de geconfigureerde maximale prijsdrempel overschrijdt. Als er geen drempel is geconfigureerd, wordt het automatisch uit de prijssensor berekende daggemiddelde gebruikt. Als tijdslots het ontladen beperken, moet aan beide voorwaarden worden voldaan.",
+          "smart_predischarge_enabled": "Schakelt optioneel voorontladen alleen in de dynamische prijsmode in om ruimte te maken vóór slots met negatieve terugleveringsprijzen.",
+          "negative_injection_threshold": "Prijzen gelijk aan of lager dan deze drempel zijn risicoslots wanneer een zonne-overschot wordt verwacht.",
+          "predischarge_reserve_soc": "SOC die naast de bestaande minimumgrenzen moet worden gereserveerd.",
+          "predischarge_max_export_power_w": "Toegestaan terugleververmogen tijdens voorontladen. 0 betekent alleen eigen verbruik.",
+          "curtailment_headroom_margin_pct": "Extra benodigde ruimte vóór het risicoslot.",
           "solar_forecast_sensor": "Sensor die de zonneproductievoorspelling in kWh levert (bijv. Solcast). Met zonnepanelen: configureer deze sensor — het systeem laadt alleen van het net als de voorspelling onvoldoende is. Zonder zonnepanelen: laat leeg — het systeem laadt wanneer de batterij-energie niet voldoende is voor de dag. Niet vereist als u deze sensor al in de eerste stap heeft geconfigureerd — hij wordt automatisch gebruikt.",
           "predictive_safety_margin_kwh": "Extra energiebuffer opgeteld bij de verbruiksprognose. Nuttig als de zonne-energieprognose te optimistisch is. Op 0 zetten om uit te schakelen (standaard). Begrensd door de totale batterijcapaciteit.",
           "predictive_grid_charge_margin_pct": "Extra percentage dat boven het zonne-tekort uit het net wordt geladen om optimistische zonneprognoses op te vangen. Bijv.: een netbehoefte van 2 kWh laadt bij 50% 3 kWh. 0 om uit te schakelen (standaard). Begrensd tot het gat tot max SOC."
@@ -889,6 +899,11 @@
           "max_price_threshold": "Maximale prijsdrempel (€/kWh, optioneel)",
           "discharge_price_threshold": "Ontlaad-prijsondergrens (optioneel)",
           "dp_price_discharge_control": "Alleen ontladen als prijs boven drempelwaarde",
+          "smart_predischarge_enabled": "Slim voorontladen / anti-afregeling",
+          "negative_injection_threshold": "Drempelwaarde negatieve teruglevering",
+          "predischarge_reserve_soc": "SOC-reserve voor voorontladen (%)",
+          "predischarge_max_export_power_w": "Maximale teruglevering bij voorontladen (W)",
+          "curtailment_headroom_margin_pct": "Anti-afregelingsmarge (%)",
           "solar_forecast_sensor": "Zonnevoorspellingssensor (kWh)",
           "predictive_safety_margin_kwh": "Veiligheidsmarge zonne-energieprognose (kWh)",
           "predictive_grid_charge_margin_pct": "Voorspellende netladingsmarge (%)"
@@ -899,6 +914,11 @@
           "max_price_threshold": "Tijdsloten boven deze prijs worden niet geselecteerd. Wanneer prijsgestuurde ontlading is ingeschakeld, wordt deze waarde ook gebruikt als ontlaaddrempel. Gebruik hoofdvaluta/kWh: €/kWh voor Nordpool/PVPC, CHF/kWh voor CKW. HACS Nordpool-prijzen die in centen zijn ingesteld, worden automatisch omgerekend. Leeg laten om alle slots te gebruiken en het daggemiddelde als ontlaaddrempel te gebruiken. Tenzij hieronder een aparte ontlaadondergrens is ingesteld.",
           "discharge_price_threshold": "Optionele aparte ondergrens voor prijsgestuurde ontlading. Ontlading wordt geblokkeerd zolang de prijs lager dan of gelijk aan deze waarde is, waardoor een neutrale band ontstaat tussen de maximale laadprijs (hierboven) en deze ondergrens: in die band laadt de batterij niet vanaf het net en ontlaadt deze niet (laden met zonne-overschot blijft werken). Laat leeg om de maximale prijs voor beide te gebruiken (huidig gedrag met één drempel).",
           "dp_price_discharge_control": "Indien ingeschakeld, ontlaadt de batterij alleen wanneer de huidige elektriciteitsprijs de geconfigureerde maximale prijsdrempel overschrijdt. Als er geen drempel is geconfigureerd, wordt het automatisch uit de prijssensor berekende daggemiddelde gebruikt. Als tijdslots het ontladen beperken, moet aan beide voorwaarden worden voldaan.",
+          "smart_predischarge_enabled": "Schakelt optioneel voorontladen alleen in de dynamische prijsmode in om ruimte te maken vóór slots met negatieve terugleveringsprijzen.",
+          "negative_injection_threshold": "Prijzen gelijk aan of lager dan deze drempel zijn risicoslots wanneer een zonne-overschot wordt verwacht.",
+          "predischarge_reserve_soc": "SOC die naast de bestaande minimumgrenzen moet worden gereserveerd.",
+          "predischarge_max_export_power_w": "Toegestaan terugleververmogen tijdens voorontladen. 0 betekent alleen eigen verbruik.",
+          "curtailment_headroom_margin_pct": "Extra benodigde ruimte vóór het risicoslot.",
           "solar_forecast_sensor": "Sensor die de zonneproductievoorspelling in kWh levert (bijv. Solcast). Met zonnepanelen: configureer deze sensor — het systeem laadt alleen van het net als de voorspelling onvoldoende is. Zonder zonnepanelen: laat leeg — het systeem laadt wanneer de batterij-energie niet voldoende is voor de dag. Niet vereist als u deze sensor al in de eerste stap heeft geconfigureerd — hij wordt automatisch gebruikt.",
           "predictive_safety_margin_kwh": "Extra energiebuffer opgeteld bij de verbruiksprognose. Nuttig als de zonne-energieprognose te optimistisch is. Op 0 zetten om uit te schakelen (standaard). Begrensd door de totale batterijcapaciteit.",
           "predictive_grid_charge_margin_pct": "Extra percentage dat boven het zonne-tekort uit het net wordt geladen om optimistische zonneprognoses op te vangen. Bijv.: een netbehoefte van 2 kWh laadt bij 50% 3 kWh. 0 om uit te schakelen (standaard). Begrensd tot het gat tot max SOC."
@@ -1233,6 +1253,9 @@
       "dp_price_discharge_control": {
         "name": "Prijsgebaseerd ontladen"
       },
+      "smart_predischarge": {
+        "name": "Slim voorontladen / anti-afregeling"
+      },
       "rt_price_discharge_control": {
         "name": "Prijsgebaseerd ontladen"
       },
@@ -1560,6 +1583,9 @@
       "predictive_charging_active": {
         "name": "Voorspellend Laden Actief"
       },
+      "curtailment_status": {
+        "name": "Status slim voorontladen"
+      },
       "wifi_status": {
         "name": "WiFi-status"
       },
@@ -1719,6 +1745,18 @@
       },
       "predictive_grid_charge_margin_pct": {
         "name": "Voorspellende Netladingsmarge"
+      },
+      "negative_injection_threshold": {
+        "name": "Drempelwaarde negatieve teruglevering"
+      },
+      "predischarge_reserve_soc": {
+        "name": "SOC-reserve voor voorontladen"
+      },
+      "predischarge_max_export_power_w": {
+        "name": "Maximale teruglevering bij voorontladen"
+      },
+      "curtailment_headroom_margin_pct": {
+        "name": "Anti-afregelingsmarge"
       },
       "predictive_min_soc_floor": {
         "name": "Gegarandeerde minimale SOC"

--- a/site-docs/configuration/predictive-charging/dynamic-pricing.es.md
+++ b/site-docs/configuration/predictive-charging/dynamic-pricing.es.md
@@ -51,6 +51,29 @@ Si HA se reinicia después de la ventana de las 00:05 sin evaluación previa, el
 
 ---
 
+## Predescarga inteligente / anti-vertido
+
+Es una **subfunción optativa de Precio Dinámico** y no controla ningún inversor FV. Al activarla, Omnibattery reutiliza las franjas de precios normalizadas de 15 o 60 minutos y el modelo solar existente para encontrar franjas futuras donde:
+
+- el precio sea igual o inferior al **Umbral de inyección negativa** (por defecto `0 €/kWh`), y
+- el excedente FV previsto supere el consumo doméstico.
+
+El plan calcula el espacio actual hasta el SOC máximo de cada batería, añade el **Margen de espacio anti-vertido** y selecciona las franjas elegibles de mayor precio antes de la ventana de riesgo para descargar mediante el PD existente. Agrupa subfranjas en bloques de aproximadamente una hora para evitar cambios constantes. Si no hay un modelo de consumo más detallado, reparte uniformemente por franja la estimación diaria histórica.
+
+Los controles solo aparecen cuando la Carga Predictiva usa Precio Dinámico:
+
+| Control | Significado |
+|---|---|
+| **Predescarga inteligente** | Interruptor optativo en tiempo de ejecución; desactivado por defecto |
+| **Umbral de inyección negativa** | Umbral inclusivo para detectar una franja de riesgo |
+| **Reserva de SOC de predescarga** | Suelo adicional; `0` usa los suelos existentes |
+| **Exportación máxima de predescarga** | Exportación de red permitida durante la predescarga; `0 W` significa solo autoconsumo |
+| **Margen de espacio anti-vertido** | Espacio adicional sobre el excedente previsto, en porcentaje |
+
+Durante la ventana de riesgo se bloquea la descarga para conservar capacidad de absorción solar. La función nunca ignora SOC mínimo o garantizado, franjas y ownership manual del usuario, balance activo, backup, baterías no disponibles/no responsivas ni protección de capacidad. Sin precios, previsión, SOC, capacidad o contador de red válido actúa de forma segura: elimina cualquier override o bloqueo inteligente. El plan se reconstruye tras reinicio, en las evaluaciones diarias normales, al activar la función y con el botón existente **Reevaluar Precios Dinámicos**. Los cambios de parámetros invalidan el plan anterior; usa ese botón para aplicarlos inmediatamente en vez de esperar a la siguiente evaluación. El plan no se persiste.
+
+El sensor binario `curtailment_status` muestra estado, motivo, próxima ventana de riesgo, franjas de riesgo, espacio requerido/actual, descarga planificada, shortfall, objetivos por batería, franjas seleccionadas y objetivo de exportación activo.
+
 ## Control de descarga por precio
 
 La opción **"Descargar solo cuando el precio supere el umbral"** añade una condición adicional al comportamiento de descarga.

--- a/site-docs/configuration/predictive-charging/dynamic-pricing.md
+++ b/site-docs/configuration/predictive-charging/dynamic-pricing.md
@@ -51,6 +51,31 @@ If HA restarts after the 00:05 window without a prior evaluation, the controller
 
 ---
 
+## Smart Pre-discharge / Anti-curtailment
+
+This is an **opt-in subfunction of Dynamic Pricing**. It does not control a PV inverter. When enabled, Omnibattery reuses the normalized 15-minute or hourly price slots and the existing solar model to find future slots where:
+
+- the price is at or below **Negative injection threshold** (default `0 €/kWh`), and
+- forecast solar surplus would exceed household consumption.
+
+The planner calculates current battery headroom to each battery's maximum SOC, adds the configured **Curtailment headroom margin**, and selects the most valuable (highest-price) eligible slots before the risk window for extra PD discharge. Slots are grouped into approximately one-hour blocks to avoid chatter. Consumption is distributed uniformly from the existing daily-history estimate when no more detailed model is available.
+
+The live controls are available only when Predictive Grid Charging uses Dynamic Pricing:
+
+| Control | Meaning |
+|---|---|
+| **Smart Pre-discharge** | Runtime opt-in switch; default off |
+| **Negative injection threshold** | Inclusive price threshold for a risk slot |
+| **Pre-discharge reserve SOC** | Additional SOC floor; `0` uses existing floors |
+| **Pre-discharge maximum export** | Allowed grid export while pre-discharging; `0 W` means self-consumption only |
+| **Curtailment headroom margin** | Extra headroom above forecast surplus, as a percentage |
+
+During a risk window, discharge is blocked so the battery can absorb PV. The feature never bypasses minimum or guaranteed-minimum SOC, user time-slot ownership, manual control, active balance, backup mode, unavailable/non-responsive batteries, or capacity protection. Missing prices, forecast, SOC, capacity or a valid grid meter are fail-safe conditions: any smart override and blocker are cleared. The plan is rebuilt after restart, at the normal daily evaluations, when the feature is enabled, and by the existing **Re-evaluate Dynamic Pricing** button. Parameter changes invalidate the old plan; use that button to apply them immediately instead of waiting for the next evaluation. Plans are not persisted.
+
+The `curtailment_status` binary sensor reports the current state, reason, next risk window, risk slots, required/current headroom, planned discharge, shortfall, per-battery targets, selected discharge slots and active export target.
+
+---
+
 ## Price-based discharge control
 
 The **"Only discharge when price is above threshold"** option adds an extra condition to discharge behaviour.

--- a/site-docs/reference/entities.es.md
+++ b/site-docs/reference/entities.es.md
@@ -53,6 +53,7 @@ Solo presentes cuando el [monitor de equilibrio de celdas](../features/cell-bala
 | `binary_sensor.*_wifi_status` | Estado WiFi |
 | `binary_sensor.*_cloud_status` | Estado Cloud |
 | `binary_sensor.marstek_venus_system_predictive_charging_active` | Carga predictiva activa (sistema) |
+| `binary_sensor.omnibattery_curtailment_status` | Estado de predescarga inteligente / anti-vertido (solo Precio Dinámico) |
 
 ## Números (sliders)
 
@@ -64,6 +65,10 @@ Solo presentes cuando el [monitor de equilibrio de celdas](../features/cell-bala
 | `number.*_max_discharge_power` | Potencia máx. de descarga | W |
 | `number.marstek_venus_system_system_max_charge_power` | Límite opcional de carga combinada para todo el sistema (`0 W` = desactivado). Solo se crea cuando los límites del sistema están activados. | 0–15000 W |
 | `number.marstek_venus_system_system_max_discharge_power` | Límite opcional de descarga combinada para todo el sistema (`0 W` = desactivado). Solo se crea cuando los límites del sistema están activados. | 0–15000 W |
+| `number.omnibattery_negative_injection_threshold` | Umbral inclusivo de precio para franjas de riesgo de inyección negativa | -2–2 moneda/kWh |
+| `number.omnibattery_predischarge_reserve_soc` | Suelo de SOC adicional para la predescarga inteligente | 0–100 % |
+| `number.omnibattery_predischarge_max_export_power_w` | Exportación máxima durante la predescarga (`0 W` = solo autoconsumo) | 0–10000 W |
+| `number.omnibattery_curtailment_headroom_margin_pct` | Margen adicional de espacio | 0–100 % |
 
 ## Selectores
 
@@ -81,6 +86,7 @@ Solo presentes cuando el [monitor de equilibrio de celdas](../features/cell-bala
 | `switch.*_allow_discharge` | Control de software que permite que esta batería participe en la descarga automática |
 | `switch.*_backup_function` | Función de reserva — cuando está activo **y** la potencia AC offgrid ≠ 0 W, la batería queda excluida del control PD (no se envían comandos de escritura) |
 | `switch.marstek_venus_system_override_predictive_charging` | Cancelar carga predictiva |
+| `switch.omnibattery_smart_predischarge` | Activar predescarga inteligente / anti-vertido (solo Precio Dinámico) |
 
 ## Botones
 

--- a/site-docs/reference/entities.md
+++ b/site-docs/reference/entities.md
@@ -58,6 +58,7 @@ Only present when the [cell balance monitor](../features/cell-balance-monitor.md
 | `binary_sensor.*_wifi_status` | WiFi status |
 | `binary_sensor.*_cloud_status` | Cloud status |
 | `binary_sensor.marstek_venus_system_predictive_charging_active` | Predictive charging active (system) |
+| `binary_sensor.omnibattery_curtailment_status` | Smart pre-discharge / anti-curtailment status (Dynamic Pricing only) |
 | `binary_sensor.*_wifi_status` | WiFi status |
 | `binary_sensor.*_cloud_status` | Cloud status |
 | `binary_sensor.marstek_venus_system_predictive_charging_active` | Predictive charging active (system) |
@@ -72,6 +73,10 @@ Only present when the [cell balance monitor](../features/cell-balance-monitor.md
 | `number.*_max_discharge_power` | Max discharge power | W |
 | `number.marstek_venus_system_system_max_charge_power` | Optional combined charge cap for the whole system (`0 W` = disabled). Only created when system power limits are enabled. | 0–15000 W |
 | `number.marstek_venus_system_system_max_discharge_power` | Optional combined discharge cap for the whole system (`0 W` = disabled). Only created when system power limits are enabled. | 0–15000 W |
+| `number.omnibattery_negative_injection_threshold` | Inclusive price threshold for forecast negative-injection risk slots | -2–2 currency/kWh |
+| `number.omnibattery_predischarge_reserve_soc` | Additional SOC floor for smart pre-discharge | 0–100 % |
+| `number.omnibattery_predischarge_max_export_power_w` | Maximum grid export during smart pre-discharge (`0 W` = self-consumption only) | 0–10000 W |
+| `number.omnibattery_curtailment_headroom_margin_pct` | Additional headroom margin | 0–100 % |
 | `number.*_max_soc` | Maximum SOC | 0–100 % |
 | `number.*_min_soc` | Minimum SOC | 0–100 % |
 | `number.*_max_charge_power` | Max charge power | W |
@@ -93,6 +98,7 @@ Only present when the [cell balance monitor](../features/cell-balance-monitor.md
 | `switch.*_allow_discharge` | Software control that allows this battery to participate in automatic discharging |
 | `switch.*_backup_function` | Backup function — when enabled **and** AC offgrid power ≠ 0 W, the battery is excluded from PD control (no write commands sent) |
 | `switch.marstek_venus_system_override_predictive_charging` | Override predictive charging |
+| `switch.omnibattery_smart_predischarge` | Opt-in smart pre-discharge / anti-curtailment (Dynamic Pricing only) |
 
 ## Buttons
 

--- a/tests/test_curtailment_planner.py
+++ b/tests/test_curtailment_planner.py
@@ -1,0 +1,328 @@
+"""Pure tests for Smart Pre-discharge / Anti-curtailment planning."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from custom_components.omnibattery.pricing import PriceSlot
+from custom_components.omnibattery.pricing.curtailment import (
+    BatterySnapshot,
+    distribute_solar_forecast,
+    plan_curtailment,
+)
+
+
+DAY = datetime(2026, 8, 2)
+
+
+def _slot(hour: int, price: float, *, minutes: int = 60, offset: int = 0) -> PriceSlot:
+    start = DAY + timedelta(hours=hour, minutes=offset)
+    return PriceSlot(start, start + timedelta(minutes=minutes), price)
+
+
+def _battery(
+    *,
+    name: str = "battery-1",
+    soc: float = 80.0,
+    capacity: float = 10.0,
+    max_soc: float = 100.0,
+    floor: float = 10.0,
+    power: float = 2000.0,
+    eligible: bool = True,
+) -> BatterySnapshot:
+    return BatterySnapshot(name, soc, capacity, max_soc, floor, power, eligible)
+
+
+def test_solar_distribution_uses_cumulative_model_for_15_minute_slots():
+    slots = [
+        _slot(6, 0.2, minutes=15),
+        _slot(6, 0.2, minutes=15, offset=15),
+        _slot(23, -0.1, minutes=15),
+    ]
+
+    def solar_fraction(hour: float) -> float:
+        return max(0.0, min(1.0, (hour - 6.0) / 6.0))
+
+    distributed = distribute_solar_forecast(slots, 12.0, solar_fraction)
+
+    assert distributed[slots[0]] == pytest.approx(0.5)
+    assert distributed[slots[1]] == pytest.approx(0.5)
+    assert distributed[slots[2]] == 0.0
+
+
+def test_threshold_is_inclusive_and_hourly_slots_are_supported():
+    candidates = [_slot(8, 0.30), _slot(9, 0.0), _slot(10, -0.01)]
+    plan = plan_curtailment(
+        candidates,
+        solar_forecast_kwh=3.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=95.0)],
+        charge_power_w=2000.0,
+        max_export_power_w=2000.0,
+        solar_by_slot={candidates[0]: 0.0, candidates[1]: 0.0, candidates[2]: 2.0},
+        consumption_by_slot={slot: 0.0 for slot in candidates},
+        now=DAY,
+    )
+
+    assert plan.risk_slots == [candidates[2]]
+    assert plan.required_headroom_kwh == pytest.approx(1.7)
+    assert plan.status == "planned"
+    assert plan.selected_discharge_slots
+
+
+def test_no_solar_surplus_is_not_a_risk():
+    slots = [_slot(9, -0.20), _slot(10, 0.10)]
+    plan = plan_curtailment(
+        slots,
+        solar_forecast_kwh=8.0,
+        daily_consumption_kwh=2.0,
+        batteries=[_battery()],
+        charge_power_w=3000.0,
+        solar_by_slot={slot: 0.0 for slot in slots},
+        consumption_by_slot={slot: 1.0 for slot in slots},
+        now=DAY,
+    )
+
+    assert plan.status == "no_risk"
+    assert plan.reason == "no_negative_injection_window"
+    assert plan.risk_slots == []
+
+
+def test_headroom_sufficient_protects_without_selecting_discharge():
+    risk = _slot(12, -0.05)
+    plan = plan_curtailment(
+        [_slot(11, 0.25), risk],
+        solar_forecast_kwh=2.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=80.0, capacity=10.0)],
+        charge_power_w=5000.0,
+        solar_by_slot={risk: 1.0},
+        consumption_by_slot={risk: 0.0},
+        now=DAY,
+    )
+
+    assert plan.status == "protected"
+    assert plan.reason == "headroom_sufficient"
+    assert plan.selected_discharge_slots == []
+
+
+def test_existing_headroom_and_margin_are_accounted_for():
+    risk = _slot(12, -0.05)
+    slots = [_slot(11, 0.25), risk]
+    base = dict(
+        price_slots=slots,
+        solar_forecast_kwh=3.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=90.0, capacity=10.0)],
+        charge_power_w=5000.0,
+        solar_by_slot={slots[0]: 0.0, risk: 2.0},
+        consumption_by_slot={slots[0]: 0.0, risk: 0.0},
+        max_export_power_w=2000.0,
+        now=DAY,
+    )
+
+    plan = plan_curtailment(**base, headroom_margin_pct=50.0)
+
+    assert plan.required_headroom_kwh == pytest.approx(2.55)
+    assert plan.current_headroom_kwh == pytest.approx(1.0)
+    assert plan.status == "planned"
+
+
+def test_multiple_risk_windows_choose_the_most_expensive_previous_slots():
+    slots = [
+        _slot(8, 0.10),
+        _slot(9, 0.55),
+        _slot(10, -0.05),
+        _slot(11, 0.20),
+        _slot(12, -0.10),
+    ]
+    solar = {slot: (1.0 if slot.price < 0 else 0.0) for slot in slots}
+    plan = plan_curtailment(
+        slots,
+        solar_forecast_kwh=5.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=100.0, power=1000.0)],
+        charge_power_w=1000.0,
+        solar_by_slot=solar,
+        consumption_by_slot={slot: 0.0 for slot in slots},
+        max_export_power_w=1000.0,
+        now=DAY,
+    )
+
+    assert [slot.price for slot in plan.risk_slots] == [-0.05, -0.10]
+    assert [slot.price for slot in plan.selected_discharge_slots] == [0.10, 0.55]
+
+
+def test_export_cap_does_not_reduce_headroom_required_in_risk_window():
+    candidate = _slot(8, 0.30)
+    risk = _slot(9, -0.10)
+    kwargs = dict(
+        price_slots=[candidate, risk],
+        solar_forecast_kwh=4.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=100.0, power=3000.0)],
+        charge_power_w=3000.0,
+        solar_by_slot={candidate: 0.0, risk: 2.0},
+        consumption_by_slot={candidate: 1.0, risk: 0.0},
+        now=DAY,
+    )
+
+    no_export = plan_curtailment(**kwargs, max_export_power_w=0.0)
+    with_export = plan_curtailment(**kwargs, max_export_power_w=1000.0)
+
+    assert no_export.required_headroom_kwh == pytest.approx(1.7)
+    assert with_export.required_headroom_kwh == pytest.approx(1.7)
+
+
+def test_self_consumption_only_limits_plan_to_forecast_household_load():
+    candidate = _slot(8, 0.30)
+    risk = _slot(9, -0.10)
+    plan = plan_curtailment(
+        [candidate, risk],
+        solar_forecast_kwh=5.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=100.0, power=3000.0)],
+        charge_power_w=3000.0,
+        max_export_power_w=0.0,
+        solar_by_slot={candidate: 0.0, risk: 3.0},
+        consumption_by_slot={candidate: 0.4, risk: 0.0},
+        now=DAY,
+    )
+
+    assert plan.planned_discharge_kwh == pytest.approx(0.4)
+    assert plan.shortfall_kwh > 0
+
+
+def test_export_cap_increases_feasible_predischarge_without_changing_risk():
+    candidate = _slot(8, 0.30)
+    risk = _slot(9, -0.10)
+    kwargs = dict(
+        price_slots=[candidate, risk],
+        solar_forecast_kwh=5.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=100.0, power=3000.0)],
+        charge_power_w=3000.0,
+        solar_by_slot={candidate: 0.0, risk: 3.0},
+        consumption_by_slot={candidate: 0.4, risk: 0.0},
+        now=DAY,
+    )
+
+    no_export = plan_curtailment(**kwargs, max_export_power_w=0.0)
+    with_export = plan_curtailment(**kwargs, max_export_power_w=1000.0)
+
+    assert with_export.planned_discharge_kwh == pytest.approx(1.4)
+    assert with_export.planned_discharge_kwh > no_export.planned_discharge_kwh
+
+
+def test_non_dischargeable_battery_headroom_still_absorbs_forecast_solar():
+    risk = _slot(9, -0.10)
+    plan = plan_curtailment(
+        [_slot(8, 0.30), risk],
+        solar_forecast_kwh=2.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=80.0, power=0.0)],
+        charge_power_w=3000.0,
+        solar_by_slot={risk: 1.0},
+        consumption_by_slot={risk: 0.0},
+        now=DAY,
+    )
+
+    assert plan.status == "protected"
+    assert plan.current_headroom_kwh == pytest.approx(2.0)
+
+
+def test_discharge_slots_are_grouped_for_15_minute_feeds():
+    candidates = [
+        _slot(8, 0.10, minutes=15, offset=15 * index)
+        for index in range(4)
+    ]
+    risk = _slot(9, -0.05, minutes=15)
+    slots = candidates + [risk]
+    plan = plan_curtailment(
+        slots,
+        solar_forecast_kwh=4.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=100.0, power=1000.0)],
+        charge_power_w=1000.0,
+        solar_by_slot={risk: 1.0, **{slot: 0.0 for slot in candidates}},
+        consumption_by_slot={slot: 0.0 for slot in slots},
+        max_export_power_w=1000.0,
+        now=DAY,
+    )
+
+    assert len(plan.selected_discharge_slots) == 4
+    assert plan.selected_discharge_slots[0].start == candidates[0].start
+    assert plan.selected_discharge_slots[-1].end == candidates[-1].end
+
+
+def test_reserve_soc_and_insufficient_power_report_shortfall():
+    candidates = [_slot(8, 0.4), _slot(9, 0.3)]
+    risk = _slot(10, -0.1)
+    slots = candidates + [risk]
+    plan = plan_curtailment(
+        slots,
+        solar_forecast_kwh=8.0,
+        daily_consumption_kwh=1.0,
+        batteries=[_battery(soc=80.0, floor=10.0, power=250.0)],
+        charge_power_w=5000.0,
+        predischarge_reserve_soc=70.0,
+        solar_by_slot={**{slot: 0.0 for slot in candidates}, risk: 5.0},
+        consumption_by_slot={slot: 0.0 for slot in slots},
+        now=DAY,
+    )
+
+    assert plan.status == "shortfall"
+    assert plan.shortfall_kwh > 0
+    assert plan.target_soc_by_battery["battery-1"] >= 70.0
+
+
+def test_multibattery_headroom_and_targets_are_allocated():
+    candidate = _slot(8, 0.4)
+    risk = _slot(9, -0.1)
+    plan = plan_curtailment(
+        [candidate, risk],
+        solar_forecast_kwh=4.0,
+        daily_consumption_kwh=1.0,
+        batteries=[
+            _battery(name="a", soc=100.0, capacity=10.0, power=1000.0),
+            _battery(name="b", soc=90.0, capacity=20.0, power=1000.0),
+        ],
+        charge_power_w=4000.0,
+        solar_by_slot={candidate: 0.0, risk: 4.0},
+        consumption_by_slot={candidate: 0.0, risk: 0.0},
+        max_export_power_w=2000.0,
+        now=DAY,
+    )
+
+    assert set(plan.target_soc_by_battery) == {"a", "b"}
+    assert plan.target_soc_by_battery["a"] >= 10.0
+    assert plan.target_soc_by_battery["b"] >= 10.0
+    assert plan.planned_discharge_kwh > 0
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"price_slots": []}, "missing_prices"),
+        ({"price_slots": [_slot(8, 0.2)]}, "missing_solar_forecast"),
+        (
+            {"price_slots": [_slot(8, 0.2)], "solar_forecast_kwh": 1.0},
+            "missing_consumption",
+        ),
+        (
+            {
+                "price_slots": [_slot(8, 0.2)],
+                "solar_forecast_kwh": 1.0,
+                "daily_consumption_kwh": 1.0,
+            },
+            "missing_battery_capacity_or_soc",
+        ),
+    ],
+)
+def test_missing_inputs_fail_safe(kwargs, reason):
+    plan = plan_curtailment(**kwargs, now=DAY)
+
+    assert plan.status == "fail_safe"
+    assert plan.reason == reason
+    assert plan.selected_discharge_slots == []

--- a/tests/test_pricing_engine.py
+++ b/tests/test_pricing_engine.py
@@ -25,7 +25,12 @@ from custom_components.omnibattery.const import (
     PREDICTIVE_MODE_REALTIME_PRICE,
     PREDICTIVE_MODE_TIME_SLOT,
 )
-from custom_components.omnibattery.pricing import PriceSlot
+from custom_components.omnibattery.pricing import (
+    BatterySnapshot,
+    CurtailmentPlan,
+    PreDischargeSlot,
+    PriceSlot,
+)
 from custom_components.omnibattery.pricing import engine as pricing_engine
 from custom_components.omnibattery.pricing.engine import PricingManager
 from custom_components.omnibattery.pricing.nordpool import OfficialNordPoolSource
@@ -563,3 +568,110 @@ def test_hacs_nordpool_raw_today_does_not_call_official_service():
     asyncio.run(PricingManager(hass, ctrl)._maybe_refresh_nordpool_prices(force=True))
 
     assert services.calls == []
+
+
+# ----------------------------------------------------------------------
+# Smart pre-discharge runtime lifecycle
+# ----------------------------------------------------------------------
+
+def test_smart_predischarge_is_scoped_to_predictive_dynamic_pricing():
+    ctrl = _controller(
+        smart_predischarge_enabled=True,
+        predictive_charging_enabled=True,
+        predictive_charging_mode=PREDICTIVE_MODE_DYNAMIC_PRICING,
+    )
+    manager = _mgr(ctrl)
+
+    assert manager._smart_predischarge_enabled() is True
+
+    ctrl.predictive_charging_mode = PREDICTIVE_MODE_REALTIME_PRICE
+    assert manager._smart_predischarge_enabled() is False
+
+
+def test_smart_predischarge_cleanup_removes_override_and_blockers():
+    calls = []
+    ctrl = _controller()
+    ctrl.coordinators = []
+    ctrl.remove_setpoint_override = lambda source: calls.append(("override", source))
+    ctrl.remove_discharge_block = lambda source, coordinator=None: calls.append(
+        ("block", source, coordinator)
+    )
+    ctrl._curtailment_plan = CurtailmentPlan(status="predischarging", reason="selected")
+    manager = _mgr(ctrl)
+
+    manager.clear_curtailment_runtime("disabled")
+
+    assert ("override", "curtailment_predischarge") in calls
+    assert ("block", "curtailment_negative_window", None) in calls
+    assert ctrl._curtailment_runtime_status == "disabled"
+    assert ctrl._curtailment_runtime_reason == "disabled"
+
+
+def test_smart_predischarge_runtime_starts_stops_and_protects_negative_window():
+    now = datetime.now()
+    active_pre_slot = PreDischargeSlot(
+        now - timedelta(minutes=1), now + timedelta(minutes=10), 0.40
+    )
+    future_risk = PriceSlot(
+        now + timedelta(hours=1), now + timedelta(hours=2), -0.10
+    )
+    calls = []
+    state = SimpleNamespace(state="0.0", attributes={})
+    hass = SimpleNamespace(states=SimpleNamespace(get=lambda _entity_id: state))
+    coordinator = SimpleNamespace(data={"battery_soc": 80.0}, is_available=True, name="b1")
+    ctrl = _controller(
+        smart_predischarge_enabled=True,
+        predictive_charging_enabled=True,
+        predictive_charging_mode=PREDICTIVE_MODE_DYNAMIC_PRICING,
+        coordinators=[coordinator],
+        consumption_sensor="sensor.grid",
+        _curtailment_plan=CurtailmentPlan(
+            status="planned",
+            reason="headroom_required",
+            risk_slots=[future_risk],
+            selected_discharge_slots=[active_pre_slot],
+            required_headroom_kwh=3.0,
+        ),
+        remove_setpoint_override=lambda source: calls.append(("remove_override", source)),
+        set_setpoint_override=lambda source, value, priority=0: calls.append(
+            ("set_override", source, value, priority)
+        ),
+        remove_discharge_block=lambda source, coordinator=None: calls.append(
+            ("remove_block", source, coordinator)
+        ),
+        set_discharge_block=lambda source, reason, details=None, coordinator=None: calls.append(
+            ("set_block", source, reason, coordinator)
+        ),
+        _apply_meter_transform=lambda _state: 0.0,
+        _curtailment_active=False,
+        _curtailment_active_export_target_w=0.0,
+    )
+    manager = PricingManager(hass, ctrl)
+    manager._get_current_price = lambda: 0.30
+    manager._curtailment_battery_snapshots = lambda: [
+        BatterySnapshot("b1", 80.0, 10.0, 100.0, 10.0, 2000.0)
+    ]
+
+    manager.refresh_curtailment_runtime()
+
+    assert any(call[:2] == ("set_override", "curtailment_predischarge") for call in calls)
+    assert ctrl._curtailment_runtime_status == "predischarging"
+
+    # The same runtime plan blocks normal discharge during the negative window.
+    ctrl._curtailment_plan = CurtailmentPlan(
+        status="planned",
+        reason="headroom_required",
+        risk_slots=[PriceSlot(now - timedelta(minutes=1), now + timedelta(minutes=10), -0.10)],
+        selected_discharge_slots=[],
+        required_headroom_kwh=3.0,
+    )
+    manager._get_current_price = lambda: -0.10
+    manager.refresh_curtailment_runtime()
+
+    assert ctrl._curtailment_runtime_status == "protected_window"
+    assert any(call[0] == "set_block" and call[1] == "curtailment_negative_window" for call in calls)
+
+    ctrl.smart_predischarge_enabled = False
+    manager.refresh_curtailment_runtime()
+    assert ctrl._curtailment_runtime_status == "disabled"
+    assert ("remove_override", "curtailment_predischarge") in calls


### PR DESCRIPTION
Add an opt-in dynamic-pricing planner that forecasts negative-price solar surplus, creates feasible battery headroom through the existing PD controller, and protects risk windows without bypassing safety ownership.

Expose runtime controls, diagnostics, frontend support, translations and documentation. Cover hourly and quarter-hour prices, multi-battery limits, fail-safe cleanup, export caps, SOC floors and planner edge cases with tests.