### PR TITLE
fix: keep the failure counter alive across suspension retries

### DIFF
--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -628,10 +628,16 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
             if now >= self._suspension_reset_time:
                 _LOGGER.info("[%s] Connection suspension expired - attempting fresh reconnection", self.name)
                 self._suspension_reset_time = None
-                self._consecutive_failures = 0
+                # Do NOT clear _consecutive_failures here: async_reconnect_fresh()
+                # already clears it when it succeeds, and clearing it up front
+                # makes a battery that never comes back look healthy. The counter
+                # is what non_responsive_battery_names, the non_responsive_batteries
+                # sensor and diagnostics all gate on, and unreachable entities keep
+                # their last read value rather than going unavailable.
                 reconnected = await self.async_reconnect_fresh()
                 if not reconnected:
                     # Suspend again for another 2 minutes
+                    self._consecutive_failures += 1
                     self._suspension_reset_time = now + timedelta(minutes=2)
                     _LOGGER.warning("[%s] Reconnection failed, suspending for another 2 minutes", self.name)
                     return self.data or {}

--- a/tests/test_coordinator_suspension_recovery.py
+++ b/tests/test_coordinator_suspension_recovery.py
@@ -1,0 +1,122 @@
+"""Regression tests for the failure counter across a suspension window.
+
+A battery that stops answering fails five polls, gets suspended for two
+minutes, and is then given one fresh reconnection attempt. When that attempt
+also fails the battery must stay *visibly* unreachable.
+
+``_consecutive_failures`` is the flag every consumer gates on
+(``ChargeDischargeController.non_responsive_battery_names``, the
+``non_responsive_batteries`` diagnostic sensor, and the diagnostics
+``health`` block). Its value is the only thing that separates "unreachable"
+from "idle": the entities of an unreachable battery keep their last read
+value instead of going ``unavailable``, so a dead battery and a healthy one
+sitting in standby look identical without it.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.omnibattery import ChargeDischargeController
+from custom_components.omnibattery.infra.coordinator import (
+    MarstekVenusDataUpdateCoordinator,
+)
+from custom_components.omnibattery.tracking.non_responsive_tracker import (
+    NonResponsiveTracker,
+)
+from tests.conftest import FakeCoordinator
+
+
+def _expired_suspension(coordinator):
+    """Put the coordinator back at the moment its suspension window elapses."""
+    coordinator._suspension_reset_time = dt_util.utcnow() - timedelta(seconds=1)
+    return coordinator
+
+
+def _suspended_coordinator(*, reconnects: bool, consecutive_failures: int = 5):
+    """A coordinator suspended after ``_max_failures_before_suspend`` failures.
+
+    Only the attributes the suspension branch touches are needed: that branch
+    returns before any telemetry read.
+    """
+    return _expired_suspension(
+        SimpleNamespace(
+            name="Battery",
+            data={"battery_soc": 25},
+            _is_shutting_down=False,
+            _is_connected=False,
+            _consecutive_failures=consecutive_failures,
+            async_reconnect_fresh=AsyncMock(return_value=reconnects),
+        )
+    )
+
+
+async def test_failed_reconnect_after_suspension_counts_as_a_failure():
+    coordinator = _suspended_coordinator(reconnects=False)
+
+    await MarstekVenusDataUpdateCoordinator._async_update_data(coordinator)
+
+    coordinator.async_reconnect_fresh.assert_awaited_once()
+    assert coordinator._consecutive_failures == 6
+    assert coordinator._suspension_reset_time is not None
+
+
+async def test_battery_stuck_in_suspension_never_looks_healthy():
+    """Ten suspension cycles must not walk the counter back down to zero."""
+    coordinator = _suspended_coordinator(reconnects=False)
+
+    for _ in range(10):
+        _expired_suspension(coordinator)
+        await MarstekVenusDataUpdateCoordinator._async_update_data(coordinator)
+
+    assert coordinator._consecutive_failures == 15
+
+
+async def test_battery_stuck_in_suspension_is_reported_non_responsive():
+    """The end-to-end contract: the sensor keeps naming an unreachable battery."""
+    coordinator = FakeCoordinator(name="Battery", is_available=False)
+    coordinator._is_shutting_down = False
+    coordinator._consecutive_failures = 5
+    coordinator.async_reconnect_fresh = AsyncMock(return_value=False)
+
+    for _ in range(10):
+        _expired_suspension(coordinator)
+        await MarstekVenusDataUpdateCoordinator._async_update_data(coordinator)
+
+    controller = SimpleNamespace(
+        _non_responsive=NonResponsiveTracker(),
+        coordinators=[coordinator],
+    )
+
+    names = ChargeDischargeController.non_responsive_battery_names.fget(controller)
+
+    assert names == ["Battery"]
+
+
+async def test_successful_fresh_reconnect_clears_the_counter():
+    """Resetting the counter is ``async_reconnect_fresh``'s job, on success only."""
+    coordinator = SimpleNamespace(
+        name="Battery",
+        host="192.0.2.10",
+        port=502,
+        lock=asyncio.Lock(),
+        driver=SimpleNamespace(connect=AsyncMock(return_value=True)),
+        capabilities=SimpleNamespace(has_rs485_control=False),
+        rs485_user_disabled=False,
+        _consecutive_failures=7,
+        _is_connected=False,
+        _suspension_reset_time=dt_util.utcnow(),
+        _last_rs485_reenable_success=None,
+        _last_update_times={"battery_soc": 1.0},
+        _critical_group_failures={("battery_soc",): 2},
+    )
+
+    assert await MarstekVenusDataUpdateCoordinator.async_reconnect_fresh(coordinator)
+
+    assert coordinator._consecutive_failures == 0
+    assert coordinator._is_connected is True
+    assert coordinator._suspension_reset_time is None


### PR DESCRIPTION
Refs #245

## Problem

When a suspension window expires, `_async_update_data` clears `_consecutive_failures` **before** attempting the fresh reconnection, and does not increment it when that reconnection fails — the failure branch re-arms the suspension and returns early, so it never reaches the health-tracking block that would have counted it.

A battery that never comes back therefore loops every two minutes with the counter pinned at 0:

```text
[Marstek Venus 2] Connection suspension expired - attempting fresh reconnection
[Marstek Venus 2] Creating fresh connection to 192.168.x.x:502 (consecutive failures: 0)
Failed to connect to Modbus server at 192.168.x.x:502 with unit 1
[Marstek Venus 2] Reconnection failed, suspending for another 2 minutes
```

That counter is what every "is this battery unreachable" consumer gates on with `> 0`:

- `ChargeDischargeController.non_responsive_battery_names` (`__init__.py`)
- the `unreachable` flag on the `non_responsive_batteries` sensor (`sensor.py`)
- `health.consecutive_failures` in the downloadable diagnostics

So an unreachable battery is named for the first few minutes and then silently filtered out of all three, indefinitely. `is_available` stays correctly `False` throughout — only the counter lies.

This matters more than a wrong number because the entities of an unreachable battery keep their last read value instead of going `unavailable`. In my case the panel showed "25 % / Standby / Idle / 30.1 °C" for 19 hours, indistinguishable from a healthy battery resting at its minimum SoC. The `non_responsive_batteries` sensor is the only signal that separates the two, which is why it going quiet went unnoticed for so long.

## Change

`async_reconnect_fresh()` already sets `_consecutive_failures = 0` itself when it succeeds, so the pre-emptive reset was redundant on the success path and harmful on the failure path. This drops it and counts the failed reconnection instead:

```python
self._suspension_reset_time = None
reconnected = await self.async_reconnect_fresh()
if not reconnected:
    self._consecutive_failures += 1
    self._suspension_reset_time = now + timedelta(minutes=2)
    ...
```

Four lines of behaviour change, plus a comment explaining why the reset must not move back.

### Interaction with `_max_failures_before_suspend`

The counter now climbs past the threshold (5) while the battery stays suspended. That is safe: the suspension branch re-arms its own two-minute window explicitly and never consults `_max_failures_before_suspend` or `_max_failures_before_reconnect`. Those thresholds are only read in the normal polling path, which a suspended coordinator returns before reaching. A successful reconnection clears the counter back to 0, so the value cannot leak into a recovered battery.

As a side benefit `Creating fresh connection to ... (consecutive failures: %d)` now logs the real count instead of always 0, and diagnostics stop reporting a healthy-looking `consecutive_failures: 0` for a coordinator that is looping on failed reconnections.

## Tests

New `tests/test_coordinator_suspension_recovery.py`, four cases:

- a failed reconnection after suspension counts as a failure and re-arms the window
- ten suspension cycles do not walk the counter back to zero
- end-to-end: `non_responsive_battery_names` still names the battery after ten cycles (this one exercises the real property, not a stub)
- a successful `async_reconnect_fresh` still clears the counter and the suspension — this passed before the change too, and is what makes removing the pre-emptive reset safe

Verified red before the change (3 of the 4 failing, the success-path one already green), green after.

Full suite on `release/v1.3.0`, Python 3.12:

- before: `1072 passed, 10 skipped`
- after: `1076 passed, 10 skipped`

## Notes

Happy to rework this if you would rather solve it elsewhere — gating those three consumers on `is_available` alone instead of `is_available and _consecutive_failures > 0` would also cover the case. I fixed the counter because it keeps diagnostics honest as well, but it is your call.
