### PR TITLE
feat(config_flow): follow a battery's IP address by its MAC (opt-in)

### DIFF
--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -195,6 +195,7 @@ from .const import (
 )
 from .control.charge_delay import ChargeDelayManager
 from .infra.coordinator import MarstekVenusDataUpdateCoordinator
+from .infra.mac_tracking import publishable_macs
 from .tracking.hourly_balance import HourlyBalanceManager
 from .tracking.non_responsive_tracker import NonResponsiveTracker
 from .control.weekly_full_charge import WeeklyFullChargeManager
@@ -7196,7 +7197,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_get_backup(hass)
 
     coordinators = []
-    for battery_config in entry.data["batteries"]:
+    # A MAC shared by several batteries belongs to a Modbus gateway, not to a
+    # battery; publishing it would merge them into one registry device.
+    entry_macs = publishable_macs(entry.data["batteries"])
+    for battery_index, battery_config in enumerate(entry.data["batteries"]):
         coordinator = MarstekVenusDataUpdateCoordinator(
             hass,
             name=battery_config[CONF_NAME],
@@ -7230,7 +7234,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             battery_manual_mode_enabled=battery_config.get(
                 CONF_BATTERY_MANUAL_MODE_ENABLED, False
             ),
-            mac=battery_config.get("mac") if battery_config.get("track_mac") else None,
+            mac=entry_macs[battery_index],
         )
         # Physical phase is metadata for the safety limiter only.  It is never
         # used as an input to the global Grid 0 controller.

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -7230,6 +7230,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             battery_manual_mode_enabled=battery_config.get(
                 CONF_BATTERY_MANUAL_MODE_ENABLED, False
             ),
+            mac=battery_config.get("mac") if battery_config.get("track_mac") else None,
         )
         # Physical phase is metadata for the safety limiter only.  It is never
         # used as an input to the global Grid 0 controller.

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -37,6 +37,14 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
+from .infra.mac_tracking import (
+    CONF_MAC,
+    CONF_TRACK_MAC,
+    detect_mac,
+    evaluate_lease,
+    is_ip_based,
+    normalise_mac,
+)
 from .migration_flow import (
     LegacyDomainMigrationMixin,
     async_has_legacy_entries,
@@ -836,6 +844,67 @@ def _finalize_slot(step_a: dict, step_b: dict | None) -> dict:
     }
 
 
+
+def _mac_tracking_schema(defaults: dict) -> dict:
+    """Schema entries for the per-battery "find me again by MAC" opt-in.
+
+    Offered only for batteries addressed by IP; serial, ESPHome and MQTT are
+    reached by a device path or device id, so they have no address that can
+    drift. Defaults to off, so an install that never touches it is unaffected.
+    """
+    return {
+        vol.Optional(
+            CONF_TRACK_MAC, default=bool(defaults.get(CONF_TRACK_MAC, False))
+        ): BooleanSelector(),
+        vol.Optional(CONF_MAC, default=defaults.get(CONF_MAC) or ""): str,
+    }
+
+
+def _mac_defaults(hass, battery: dict) -> dict:
+    """Battery values with the MAC pre-filled from Home Assistant's DHCP cache.
+
+    Home Assistant keeps the leases it has seen, so on a setup where it shares a
+    network with the batteries the field arrives already filled and the user
+    only ticks the box. Where that cache is empty — Home Assistant on another
+    subnet, or in a container without host networking — the field stays blank
+    and is typed in by hand. The import is local and guarded because the dhcp
+    component is not a declared dependency of this integration.
+    """
+    defaults = dict(battery)
+    if defaults.get(CONF_MAC):
+        return defaults
+    try:
+        from homeassistant.components import dhcp
+
+        discovered = dhcp.async_discovered_service_info(hass)
+    except Exception:  # noqa: BLE001 - absence of the cache is not an error
+        return defaults
+    if detected := detect_mac(discovered or [], defaults.get(CONF_HOST) or ""):
+        defaults[CONF_MAC] = detected
+    return defaults
+
+
+def _validate_mac_tracking(user_input: dict) -> str | None:
+    """Return an error key when tracking is enabled without a usable MAC.
+
+    Refusing here rather than storing a malformed value keeps the lookup in
+    ``evaluate_lease`` a plain comparison: whatever is stored is already
+    normalised, so a lease can never silently fail to match.
+    """
+    if not user_input.get(CONF_TRACK_MAC):
+        return None
+    if normalise_mac(user_input.get(CONF_MAC)) is None:
+        return "invalid_mac"
+    return None
+
+
+def _apply_mac_tracking(user_input: dict, merged: dict) -> None:
+    """Persist the opt-in and the normalised MAC onto a battery entry."""
+    enabled = bool(user_input.get(CONF_TRACK_MAC))
+    merged[CONF_TRACK_MAC] = enabled
+    merged[CONF_MAC] = (normalise_mac(user_input.get(CONF_MAC)) or "") if enabled else ""
+
+
 class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Omnibattery."""
 
@@ -1366,6 +1435,8 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             phase = user_input.get(CONF_BATTERY_PHASE, "")
             if self.config_data.get(CONF_THREE_PHASE_ENABLED) and not _phase_assignment_is_valid(phase):
                 errors[CONF_BATTERY_PHASE] = "battery_phase_required"
+            if mac_error := _validate_mac_tracking(user_input):
+                errors[CONF_MAC] = mac_error
             if errors:
                 user_input = None
             else:
@@ -1396,6 +1467,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 )
                 if brand in ("zendure", "sessy", "hoymiles"):
                     merged["battery_capacity_kwh"] = round(float(user_input.get("battery_capacity_kwh", 2.24 if brand == "hoymiles" else 0.0)), 2)
+                _apply_mac_tracking(user_input, merged)
                 self.battery_configs.append(merged)
                 self.battery_index += 1
 
@@ -1445,6 +1517,10 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             # allowing the explicit Unassigned option when needed.
             phase_field, phase_selector = _battery_phase_schema(PHASE_L1)
             _schema[phase_field] = phase_selector
+        if is_ip_based(self._current_battery_data):
+            _schema.update(
+                _mac_tracking_schema(_mac_defaults(self.hass, self._current_battery_data))
+            )
         return self.async_show_form(
             step_id="battery_limits",
             data_schema=vol.Schema(_schema),
@@ -2575,6 +2651,79 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         return OptionsFlowHandler(config_entry)
 
 
+    async def async_step_dhcp(self, discovery_info: Any) -> FlowResult:
+        """Follow a tracked battery when its router hands it a different address.
+
+        Reached through the ``registered_devices`` matcher in the manifest, which
+        fires for any device whose MAC sits in the device registry. All this step
+        does is turn the lease into a verdict and act on it; every guard lives in
+        ``infra.mac_tracking`` so it can be tested without a running Home
+        Assistant. It always aborts — there is no user-facing flow here.
+        """
+        reason = await self._async_apply_dhcp_lease(
+            getattr(discovery_info, "macaddress", None),
+            getattr(discovery_info, "ip", "") or "",
+        )
+        return self.async_abort(reason=reason)
+
+    def _dhcp_reachability_probe(self, entry: ConfigEntry):
+        """Return a callable answering whether battery *index* still responds.
+
+        A device can hold two addresses at once, so a lease for a new address is
+        not on its own a reason to abandon one that still works.
+        """
+
+        def _is_reachable(index: int) -> bool:
+            data = (self.hass.data.get(DOMAIN) or {}).get(entry.entry_id) or {}
+            coordinators = data.get("coordinators") or []
+            if index >= len(coordinators):
+                return False
+            return bool(getattr(coordinators[index], "is_available", False))
+
+        return _is_reachable
+
+    async def _async_apply_dhcp_lease(self, mac: Any, host: str) -> str:
+        """Move a battery onto ``host`` when exactly one may safely be moved.
+
+        Returns the abort reason, which doubles as the log line: every refusal
+        names the single guard that fired.
+        """
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            batteries = [dict(b) for b in entry.data.get("batteries", [])]
+            verdict = evaluate_lease(
+                batteries, mac, host, self._dhcp_reachability_probe(entry)
+            )
+            if not verdict.should_update:
+                if verdict.reason not in ("no_match", "invalid_mac"):
+                    _LOGGER.debug(
+                        "DHCP lease %s -> %s not applied to %s: %s",
+                        mac, host, entry.title, verdict.reason,
+                    )
+                continue
+
+            battery = batteries[verdict.index]
+            old_host = battery.get(CONF_HOST) or ""
+            port = battery.get(CONF_PORT)
+            slave = battery.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID)
+            battery[CONF_HOST] = host
+
+            # Rewrites the device key and the entity unique_ids while keeping the
+            # entity_ids, so history and long-term statistics survive the move.
+            self._migrate_battery_registry_ids(
+                entry, old_host, port, host, port, slave, slave
+            )
+            self.hass.config_entries.async_update_entry(
+                entry, data={**entry.data, "batteries": batteries}
+            )
+            _LOGGER.info(
+                "Battery %s moved from %s to %s (MAC %s); connection updated",
+                battery.get(CONF_NAME, "?"), old_host, host, mac,
+            )
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return "ip_updated"
+        return "no_tracked_battery"
+
+
 class OptionsFlowHandler(OptionsFlow):
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
@@ -3302,6 +3451,11 @@ class OptionsFlowHandler(OptionsFlow):
                 ) and not _phase_assignment_is_valid(phase):
                     errors[CONF_BATTERY_PHASE] = "battery_phase_required"
                     user_input = None
+                if user_input is not None and (
+                    mac_error := _validate_mac_tracking(user_input)
+                ):
+                    errors[CONF_MAC] = mac_error
+                    user_input = None
 
             if user_input is not None:
                 # Start from existing battery config to preserve persisted keys not in this form.
@@ -3338,6 +3492,7 @@ class OptionsFlowHandler(OptionsFlow):
                 )
                 if brand in ("zendure", "sessy", "hoymiles"):
                     merged["battery_capacity_kwh"] = round(float(user_input.get("battery_capacity_kwh", 2.24 if brand == "hoymiles" else 0.0)), 2)
+                _apply_mac_tracking(user_input, merged)
                 self.battery_configs.append(merged)
                 self.battery_index += 1
 
@@ -3438,6 +3593,10 @@ class OptionsFlowHandler(OptionsFlow):
                 defaults.get(CONF_BATTERY_PHASE, PHASE_UNASSIGNED)
             )
             _schema[phase_field] = phase_selector
+        if is_ip_based(self._current_battery_data):
+            _schema.update(
+                _mac_tracking_schema(_mac_defaults(self.hass, self._current_battery_data))
+            )
         return self.async_show_form(
             step_id="battery_limits",
             data_schema=vol.Schema(_schema),

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -877,7 +877,12 @@ def _mac_defaults(hass, battery: dict) -> dict:
         from homeassistant.components import dhcp
 
         discovered = dhcp.async_discovered_service_info(hass)
-    except Exception:  # noqa: BLE001 - absence of the cache is not an error
+    except Exception as err:  # noqa: BLE001 - absence of the cache is not an error
+        # Expected on a large part of the supported range: the helper does not
+        # exist before recent Home Assistant releases, and the dhcp component
+        # itself may be absent. Log it so an empty field is explainable rather
+        # than mysterious; the user types the MAC by hand.
+        _LOGGER.debug("MAC auto-detection unavailable, manual entry required: %s", err)
         return defaults
     if detected := detect_mac(discovered or [], defaults.get(CONF_HOST) or ""):
         defaults[CONF_MAC] = detected

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -6,7 +6,7 @@ from datetime import timedelta, datetime
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import device_registry as dr, entity_registry
 from homeassistant.util import dt as dt_util
 
 from ..const import (
@@ -27,6 +27,7 @@ from ..drivers.sessy import SessyLocalDriver
 from ..drivers.hoymiles import HoymilesMqttDriver
 from ..drivers.base import SetpointResult
 from .alarm_notifier import AlarmNotifier
+from .mac_tracking import normalise_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,7 +124,8 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                  password: str = "",
                  battery_manual_mode_enabled: bool = False,
                  device_max_charge_power: int | None = None,
-                 device_max_discharge_power: int | None = None) -> None:
+                 device_max_discharge_power: int | None = None,
+                 mac: str | None = None) -> None:
         """Initialize the data update coordinator."""
         super().__init__(
             hass,
@@ -135,6 +137,10 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         self.host = host
         self.port = port
         self.slave_id = slave_id
+        # Permanent hardware address, stored only when the user opted this
+        # battery into MAC tracking. Publishing it in the device registry is
+        # what lets Home Assistant's DHCP discovery report an address change.
+        self.mac = normalise_mac(mac)
         # Physical phase metadata used only by the optional safety limiter.
         self.phase = ""
         # Serial device path when the battery is reached over Modbus RTU instead
@@ -565,6 +571,12 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 else "Venus"
             ),
         }
+        # getattr: several tests build a stub coordinator and read this
+        # property off it, so the attribute cannot be assumed present.
+        if getattr(self, "mac", None):
+            # CONNECTION_NETWORK_MAC is the prerequisite for the manifest's
+            # "registered_devices" DHCP matcher to deliver a discovery flow.
+            info["connections"] = {(dr.CONNECTION_NETWORK_MAC, self.mac)}
         if self.brand == "sessy":
             info["configuration_url"] = (
                 f"http://{self.host}"

--- a/custom_components/omnibattery/infra/mac_tracking.py
+++ b/custom_components/omnibattery/infra/mac_tracking.py
@@ -188,6 +188,36 @@ def evaluate_lease(
     return DhcpVerdict(OK, index)
 
 
+def publishable_macs(batteries: Sequence[dict]) -> list[str | None]:
+    """Return, per battery index, the MAC that may be published to the device registry.
+
+    Home Assistant indexes devices by identifiers **and** by connections, and
+    ``DeviceRegistryItems.get_entry()`` falls through to the connection index
+    when no identifier matches. Two batteries publishing one MAC therefore
+    resolve to the *same* device entry: the second one is absorbed into the
+    first, before any DHCP lease is ever evaluated. The ``AMBIGUOUS_MAC`` guard
+    cannot help — it runs in the discovery path, and this collision happens at
+    registration.
+
+    So a MAC shared by several configured batteries — the Modbus-gateway case,
+    where the MAC belongs to the gateway rather than to any battery — is
+    published for none of them. They stay separate devices, and DHCP tracking
+    is simply inert for that gateway, which is the safe outcome.
+
+    Returns None for a battery that is not tracked, has no valid MAC, or shares
+    its MAC with another entry.
+    """
+    normalised = [
+        normalise_mac(b.get(CONF_MAC)) if tracking_enabled(b) else None
+        for b in batteries
+    ]
+    counts: dict[str, int] = {}
+    for mac in normalised:
+        if mac:
+            counts[mac] = counts.get(mac, 0) + 1
+    return [mac if mac and counts[mac] == 1 else None for mac in normalised]
+
+
 def detect_mac(discovered: Iterable[Any], host: str) -> str | None:
     """Find the MAC of ``host`` among Home Assistant's known DHCP leases.
 

--- a/custom_components/omnibattery/infra/mac_tracking.py
+++ b/custom_components/omnibattery/infra/mac_tracking.py
@@ -1,0 +1,205 @@
+"""Decide whether a DHCP lease may update a battery's configured IP address.
+
+Batteries reached over TCP are identified in the config entry by their IP
+address, and that address is handed out by the user's router. When the router
+assigns a different one, the configured endpoint goes stale and the battery
+looks unreachable while being perfectly healthy. The failure is quiet: entities
+freeze on their last value instead of going unavailable, so a stale endpoint is
+hard to tell apart from a battery sitting idle.
+
+Home Assistant already has the plumbing for this — a ``registered_devices``
+DHCP matcher delivers a discovery flow whenever a device whose MAC is in the
+device registry gets a lease. What it cannot decide is whether acting on that
+lease is *safe*. That decision lives here.
+
+Every function in this module is pure: it takes the stored battery list and a
+lease, and returns a verdict. Nothing here touches Home Assistant, so the guards
+can be tested without an event loop — which is what the rest of this suite does.
+
+The guards exist because a wrong update is worse than no update: pointing
+battery A at battery B's endpoint would send A's power commands to B.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Sequence
+
+# Brands whose batteries are addressed by IP and can therefore drift.
+# Serial (a device path), ESPHome and MQTT (a device id) have no IP to track.
+IP_BASED_BRANDS = frozenset({"marstek", "zendure", "anker", "sessy"})
+
+CONF_TRACK_MAC = "track_mac"
+CONF_MAC = "mac"
+
+# Verdicts. Everything except OK means "do nothing", and each value is a
+# distinct reason so the log line says which guard fired.
+OK = "ok"
+INVALID_MAC = "invalid_mac"
+NO_MATCH = "no_match"
+AMBIGUOUS_MAC = "ambiguous_mac"
+NOT_IP_BASED = "not_ip_based"
+UNCHANGED = "unchanged"
+ENDPOINT_CONFLICT = "endpoint_conflict"
+STILL_REACHABLE = "still_reachable"
+
+
+@dataclass(frozen=True)
+class DhcpVerdict:
+    """Outcome of evaluating one DHCP lease against the configured batteries."""
+
+    reason: str
+    index: int | None = None
+
+    @property
+    def should_update(self) -> bool:
+        """True only when a single battery was identified and may be moved."""
+        return self.reason == OK and self.index is not None
+
+
+def normalise_mac(raw: Any) -> str | None:
+    """Return ``aa:bb:cc:dd:ee:ff`` for anything that looks like a MAC, else None.
+
+    Accepts the shapes users and routers actually produce: colon-separated,
+    dash-separated, dot-separated (Cisco style) and bare hex. Home Assistant's
+    ``DhcpServiceInfo`` delivers bare lowercase hex, config entries written by
+    hand tend to carry colons, so both have to normalise to the same string or
+    the lookup silently never matches.
+    """
+    if not isinstance(raw, str):
+        return None
+    hex_digits = raw.strip().lower().replace(":", "").replace("-", "").replace(".", "")
+    if len(hex_digits) != 12:
+        return None
+    try:
+        int(hex_digits, 16)
+    except ValueError:
+        return None
+    return ":".join(hex_digits[i:i + 2] for i in range(0, 12, 2))
+
+
+def is_ip_based(battery: dict) -> bool:
+    """True when this battery is addressed by IP, so its address can drift.
+
+    A Marstek entry configured over serial stores its device path in ``host``
+    and is not IP-based despite the brand being in ``IP_BASED_BRANDS`` — the
+    brand alone is not enough to decide.
+    """
+    if battery.get("brand", "marstek") not in IP_BASED_BRANDS:
+        return False
+    if (battery.get("serial_port") or "").strip():
+        return False
+    return bool((battery.get("host") or "").strip())
+
+
+def tracking_enabled(battery: dict) -> bool:
+    """True when the user opted this battery into MAC tracking and gave a MAC.
+
+    Opt-in is per battery and defaults to off, so an install that never touches
+    the checkbox behaves exactly as it did before.
+    """
+    if not battery.get(CONF_TRACK_MAC):
+        return False
+    return normalise_mac(battery.get(CONF_MAC)) is not None
+
+
+def endpoint_of(battery: dict, host: str | None = None) -> tuple[str, Any, Any]:
+    """Return the (host, port, slave) triple that identifies a battery's endpoint.
+
+    Mirrors ``coordinator.device_key``: batteries behind one Modbus gateway
+    share a host and port and are told apart by their slave id, so the slave id
+    belongs in the comparison. ``host`` overrides the stored value to test a
+    candidate address before committing to it.
+    """
+    return (
+        (host if host is not None else battery.get("host")) or "",
+        battery.get("port"),
+        battery.get("slave_id"),
+    )
+
+
+def evaluate_lease(
+    batteries: Sequence[dict],
+    mac: Any,
+    new_host: str,
+    is_reachable: Callable[[int], bool] | None = None,
+) -> DhcpVerdict:
+    """Decide whether ``new_host`` may be written to one of ``batteries``.
+
+    ``is_reachable`` is asked, for a battery index, whether that battery is
+    talking right now at its currently configured address. It is optional so the
+    guards stay testable in isolation; the config flow passes a callable backed
+    by the live coordinator.
+
+    Returns a verdict naming the single guard that refused, or OK plus the index
+    of the battery to move.
+    """
+    normalised = normalise_mac(mac)
+    if normalised is None:
+        return DhcpVerdict(INVALID_MAC)
+
+    host = (new_host or "").strip()
+    if not host:
+        return DhcpVerdict(INVALID_MAC)
+
+    matches = [
+        index
+        for index, battery in enumerate(batteries)
+        if tracking_enabled(battery) and normalise_mac(battery.get(CONF_MAC)) == normalised
+    ]
+
+    if not matches:
+        return DhcpVerdict(NO_MATCH)
+
+    # One MAC covering several batteries is the shared-gateway case: the MAC
+    # belongs to the gateway, not to any one battery, so it cannot say which of
+    # them moved. Abstaining is the only safe answer.
+    if len(matches) > 1:
+        return DhcpVerdict(AMBIGUOUS_MAC)
+
+    index = matches[0]
+    battery = batteries[index]
+
+    if not is_ip_based(battery):
+        return DhcpVerdict(NOT_IP_BASED)
+
+    # A lease is renewed periodically for an address the battery already has.
+    # Acting on it would reload the entry on every renewal for no gain.
+    if (battery.get("host") or "").strip() == host:
+        return DhcpVerdict(UNCHANGED)
+
+    # A device can hold two addresses at once — we measured one Marstek unit
+    # answering on two IPv4 addresses for ~20 h. While the configured address
+    # still answers, the new lease is extra information, not a move: switching
+    # would trade a working endpoint for an untested one and could flap between
+    # the two. Only a battery that has actually gone quiet is worth moving.
+    if is_reachable is not None and is_reachable(index):
+        return DhcpVerdict(STILL_REACHABLE)
+
+    # Moving onto an endpoint another battery already owns would point two
+    # config entries at one device, and send one battery's commands to another.
+    candidate = endpoint_of(battery, host)
+    for other_index, other in enumerate(batteries):
+        if other_index == index:
+            continue
+        if endpoint_of(other) == candidate:
+            return DhcpVerdict(ENDPOINT_CONFLICT)
+
+    return DhcpVerdict(OK, index)
+
+
+def detect_mac(discovered: Iterable[Any], host: str) -> str | None:
+    """Find the MAC of ``host`` among Home Assistant's known DHCP leases.
+
+    Fed by ``homeassistant.components.dhcp.async_discovered_service_info``, whose
+    entries expose ``ip`` and ``macaddress``. Returns None when Home Assistant
+    has never seen the device — which is normal on installs that do not sit on
+    the batteries' network — and the user is then asked for the MAC by hand.
+    """
+    target = (host or "").strip()
+    if not target:
+        return None
+    for service_info in discovered:
+        if getattr(service_info, "ip", None) == target:
+            return normalise_mac(getattr(service_info, "macaddress", None))
+    return None

--- a/custom_components/omnibattery/manifest.json
+++ b/custom_components/omnibattery/manifest.json
@@ -15,6 +15,11 @@
     "frontend",
     "panel_custom"
   ],
+  "dhcp": [
+    {
+      "registered_devices": true
+    }
+  ],
   "documentation": "https://github.com/ffunes/omnibattery",
   "integration_type": "device",
   "iot_class": "local_polling",

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -173,7 +173,9 @@
           "backup_offgrid_threshold": "Backup offgrid load threshold (W)",
           "full_charge_voltage_taper_enabled": "Enable 100% charge voltage taper",
           "battery_capacity_kwh": "Battery nominal capacity (kWh)",
-          "battery_phase": "Physical battery phase"
+          "battery_phase": "Physical battery phase",
+          "track_mac": "Re-find this battery by its MAC address if its IP address changes",
+          "mac": "MAC Address"
         },
         "data_description": {
           "max_charge_power": "Maximum power allowed to charge the battery",
@@ -184,7 +186,9 @@
           "backup_offgrid_threshold": "Offgrid load above this value is treated as an active backup event, excluding the battery from PD control. Set higher if you have permanent loads (router, cameras) on the offgrid port.",
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 200 W from 3.48 V max cell voltage. Venus E models stop at 3.60 V to measure imbalance after 60 seconds; Venus A/D with coupled packs keep charging at 200 W until the BMS cuts off.",
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
-          "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation."
+          "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
+          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
+          "mac": "Permanent hardware address of the battery, detected automatically. If this field is empty, copy it from your router's device list."
         }
       },
       "time_slots": {
@@ -624,6 +628,7 @@
       }
     },
     "error": {
+      "invalid_mac": "That does not look like a MAC address. Six pairs of hexadecimal digits are expected, for example dc:04:5a:14:6b:33.",
       "cannot_connect": "Cannot connect to the battery. Check the IP address and that the battery is accessible on the network.",
       "esphome_entities_missing": "The selected ESPHome device is missing required entities: {missing}. Make sure it runs the marstek-lilygo-rs485 firmware with the stock entity names.",
       "sensor_not_found": "Solar forecast sensor does not exist. Verify the sensor is available.",
@@ -649,6 +654,8 @@
       "missing_activity_sensor": "Select an Activity / EV charging sensor for Dynamic Power Control or an EV charger without power telemetry."
     },
     "abort": {
+      "ip_updated": "The battery's IP address changed; the connection was updated automatically.",
+      "no_tracked_battery": "No configured battery is tracked by this device's MAC address.",
       "already_configured": "This integration is already configured.",
       "reconfigure_successful": "Battery connection settings updated successfully.",
       "no_legacy_entries": "No legacy Marstek Venus configuration was found to migrate.",
@@ -797,7 +804,9 @@
           "backup_offgrid_threshold": "Backup offgrid load threshold (W)",
           "full_charge_voltage_taper_enabled": "Enable 100% charge voltage taper",
           "battery_capacity_kwh": "Battery nominal capacity (kWh)",
-          "battery_phase": "Physical battery phase"
+          "battery_phase": "Physical battery phase",
+          "track_mac": "Re-find this battery by its MAC address if its IP address changes",
+          "mac": "MAC Address"
         },
         "data_description": {
           "max_charge_power": "Maximum power allowed to charge the battery",
@@ -808,7 +817,9 @@
           "backup_offgrid_threshold": "Offgrid load above this value is treated as an active backup event, excluding the battery from PD control. Set higher if you have permanent loads (router, cameras) on the offgrid port.",
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 200 W from 3.48 V max cell voltage. Venus E models stop at 3.60 V to measure imbalance after 60 seconds; Venus A/D with coupled packs keep charging at 200 W until the BMS cuts off.",
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
-          "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation."
+          "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
+          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
+          "mac": "Permanent hardware address of the battery, detected automatically. If this field is empty, copy it from your router's device list."
         }
       },
       "time_slots": {
@@ -1190,6 +1201,7 @@
       }
     },
     "error": {
+      "invalid_mac": "That does not look like a MAC address. Six pairs of hexadecimal digits are expected, for example dc:04:5a:14:6b:33.",
       "cannot_connect": "Cannot connect to the battery. Check the IP address and that the battery is accessible on the network.",
       "esphome_entities_missing": "The selected ESPHome device is missing required entities: {missing}. Make sure it runs the marstek-lilygo-rs485 firmware with the stock entity names.",
       "sensor_not_found": "Solar forecast sensor does not exist. Verify the sensor is available.",

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -188,7 +188,7 @@
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
           "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
           "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
-          "mac": "Permanent hardware address of the battery, detected automatically. If this field is empty, copy it from your router's device list."
+          "mac": "Permanent hardware address of the interface the battery uses on your network. Take it from your router's device list: a battery can report a different MAC than the one its wired interface actually uses. Filled in automatically when Home Assistant's DHCP cache is available."
         }
       },
       "time_slots": {
@@ -819,7 +819,7 @@
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
           "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
           "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
-          "mac": "Permanent hardware address of the battery, detected automatically. If this field is empty, copy it from your router's device list."
+          "mac": "Permanent hardware address of the interface the battery uses on your network. Take it from your router's device list: a battery can report a different MAC than the one its wired interface actually uses. Filled in automatically when Home Assistant's DHCP cache is available."
         }
       },
       "time_slots": {

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -151,7 +151,9 @@
           "backup_offgrid_threshold": "Backup offgrid load threshold (W)",
           "full_charge_voltage_taper_enabled": "Enable 100% charge voltage taper",
           "battery_capacity_kwh": "Battery nominal capacity (kWh)",
-          "battery_phase": "Physical battery phase"
+          "battery_phase": "Physical battery phase",
+          "track_mac": "Re-find this battery by its MAC address if its IP address changes",
+          "mac": "MAC Address"
         },
         "data_description": {
           "max_charge_power": "Maximum power allowed to charge the battery",
@@ -162,7 +164,9 @@
           "backup_offgrid_threshold": "Offgrid load above this value is treated as an active backup event, excluding the battery from PD control. Set higher if you have permanent loads (router, cameras) on the offgrid port.",
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 200 W from 3.48 V max cell voltage. Venus E models stop at 3.60 V to measure imbalance after 60 seconds; Venus A/D with coupled packs keep charging at 200 W until the BMS cuts off.",
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
-          "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation."
+          "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
+          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
+          "mac": "Permanent hardware address of the battery, detected automatically. If this field is empty, copy it from your router's device list."
         }
       },
       "time_slots": {
@@ -626,6 +630,7 @@
       }
     },
     "error": {
+      "invalid_mac": "That does not look like a MAC address. Six pairs of hexadecimal digits are expected, for example dc:04:5a:14:6b:33.",
       "cannot_connect": "Cannot connect to the battery. Check the IP address and that the battery is accessible on the network.",
       "esphome_entities_missing": "The selected ESPHome device is missing required entities: {missing}. Make sure it runs the marstek-lilygo-rs485 firmware with the stock entity names.",
       "sensor_not_found": "Solar forecast sensor does not exist. Verify the sensor is available.",
@@ -652,6 +657,8 @@
       "missing_activity_sensor": "Select an Activity / EV charging sensor for Dynamic Power Control or an EV charger without power telemetry."
     },
     "abort": {
+      "ip_updated": "The battery's IP address changed; the connection was updated automatically.",
+      "no_tracked_battery": "No configured battery is tracked by this device's MAC address.",
       "already_configured": "This integration is already configured.",
       "reconfigure_successful": "Battery connection settings updated successfully.",
       "no_legacy_entries": "No legacy Marstek Venus configuration was found to migrate.",
@@ -800,7 +807,9 @@
           "backup_offgrid_threshold": "Backup offgrid load threshold (W)",
           "full_charge_voltage_taper_enabled": "Enable 100% charge voltage taper",
           "battery_capacity_kwh": "Battery nominal capacity (kWh)",
-          "battery_phase": "Physical battery phase"
+          "battery_phase": "Physical battery phase",
+          "track_mac": "Re-find this battery by its MAC address if its IP address changes",
+          "mac": "MAC Address"
         },
         "data_description": {
           "max_charge_power": "Maximum power allowed to charge the battery",
@@ -811,7 +820,9 @@
           "backup_offgrid_threshold": "Offgrid load above this value is treated as an active backup event, excluding the battery from PD control. Set higher if you have permanent loads (router, cameras) on the offgrid port.",
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 200 W from 3.48 V max cell voltage. Venus E models stop at 3.60 V to measure imbalance after 60 seconds; Venus A/D with coupled packs keep charging at 200 W until the BMS cuts off.",
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
-          "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation."
+          "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
+          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
+          "mac": "Permanent hardware address of the battery, detected automatically. If this field is empty, copy it from your router's device list."
         }
       },
       "time_slots": {
@@ -1195,6 +1206,7 @@
       }
     },
     "error": {
+      "invalid_mac": "That does not look like a MAC address. Six pairs of hexadecimal digits are expected, for example dc:04:5a:14:6b:33.",
       "cannot_connect": "Cannot connect to the battery. Check the IP address and that the battery is accessible on the network.",
       "esphome_entities_missing": "The selected ESPHome device is missing required entities: {missing}. Make sure it runs the marstek-lilygo-rs485 firmware with the stock entity names.",
       "sensor_not_found": "Solar forecast sensor does not exist. Verify the sensor is available.",

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -166,7 +166,7 @@
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
           "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
           "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
-          "mac": "Permanent hardware address of the battery, detected automatically. If this field is empty, copy it from your router's device list."
+          "mac": "Permanent hardware address of the interface the battery uses on your network. Take it from your router's device list: a battery can report a different MAC than the one its wired interface actually uses. Filled in automatically when Home Assistant's DHCP cache is available."
         }
       },
       "time_slots": {
@@ -822,7 +822,7 @@
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
           "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
           "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
-          "mac": "Permanent hardware address of the battery, detected automatically. If this field is empty, copy it from your router's device list."
+          "mac": "Permanent hardware address of the interface the battery uses on your network. Take it from your router's device list: a battery can report a different MAC than the one its wired interface actually uses. Filled in automatically when Home Assistant's DHCP cache is available."
         }
       },
       "time_slots": {

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -164,7 +164,7 @@
           "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Elle sert à calculer l'énergie stockée et l'efficacité à partir du SOC. Pour Sessy, saisissez la capacité réelle ; pour les autres batteries, laissez 0 si elle est inconnue.",
           "battery_phase": "Phase AC physique (L1/L2/L3) à laquelle cette batterie est raccordée, ou Non assignée hors du schéma de phases protégées. Une batterie sans phase est exclue de l'enveloppe triphasée et continue à fonctionner normalement en automatique.",
           "track_mac": "L'adresse MAC est l'adresse matérielle permanente de la batterie : contrairement à l'adresse IP ci-dessus, elle ne change jamais. Home Assistant s'en sert pour retrouver la batterie et mettre l'adresse IP à jour tout seul.",
-          "mac": "Adresse matérielle permanente de la batterie, détectée automatiquement. Si ce champ est vide, copiez-la depuis la liste des appareils de votre box."
+          "mac": "Adresse matérielle permanente de l'interface que la batterie utilise sur le réseau. Prenez-la dans la liste des appareils de votre box : une batterie peut annoncer une adresse différente de celle de son interface filaire. Remplie automatiquement quand le cache DHCP de Home Assistant est disponible."
         }
       },
       "time_slots": {
@@ -824,7 +824,7 @@
           "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Elle sert à calculer l'énergie stockée et l'efficacité à partir du SOC. Pour Sessy, saisissez la capacité réelle ; pour les autres batteries, laissez 0 si elle est inconnue.",
           "battery_phase": "Phase AC physique (L1/L2/L3) à laquelle cette batterie est raccordée, ou Non assignée hors du schéma de phases protégées. Une batterie sans phase est exclue de l'enveloppe triphasée et continue à fonctionner normalement en automatique.",
           "track_mac": "L'adresse MAC est l'adresse matérielle permanente de la batterie : contrairement à l'adresse IP ci-dessus, elle ne change jamais. Home Assistant s'en sert pour retrouver la batterie et mettre l'adresse IP à jour tout seul.",
-          "mac": "Adresse matérielle permanente de la batterie, détectée automatiquement. Si ce champ est vide, copiez-la depuis la liste des appareils de votre box."
+          "mac": "Adresse matérielle permanente de l'interface que la batterie utilise sur le réseau. Prenez-la dans la liste des appareils de votre box : une batterie peut annoncer une adresse différente de celle de son interface filaire. Remplie automatiquement quand le cache DHCP de Home Assistant est disponible."
         }
       },
       "time_slots": {

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -149,7 +149,9 @@
           "backup_offgrid_threshold": "Seuil de charge hors réseau de secours (W)",
           "full_charge_voltage_taper_enabled": "Activer la réduction de charge à 100% par tension",
           "battery_capacity_kwh": "Capacité nominale de la batterie (kWh)",
-          "battery_phase": "Phase physique de la batterie"
+          "battery_phase": "Phase physique de la batterie",
+          "track_mac": "Retrouver cette batterie par son adresse MAC si son IP change",
+          "mac": "Adresse MAC"
         },
         "data_description": {
           "max_charge_power": "Puissance maximale autorisée pour charger la batterie",
@@ -160,7 +162,9 @@
           "backup_offgrid_threshold": "Une charge hors réseau supérieure à cette valeur est traitée comme un événement de secours actif, excluant la batterie du contrôle PD. Augmenter si des charges permanentes (routeur, caméras) sont connectées au port hors réseau.",
           "full_charge_voltage_taper_enabled": "Lorsque la cible est 100%, limite la charge à 200 W à partir de 3.48 V de tension maximale de cellule. Les Venus E s'arrêtent à 3.60 V pour mesurer le déséquilibre après 60 secondes ; les Venus A/D avec des packs couplés continuent à 200 W jusqu'à la coupure du BMS.",
           "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Elle sert à calculer l'énergie stockée et l'efficacité à partir du SOC. Pour Sessy, saisissez la capacité réelle ; pour les autres batteries, laissez 0 si elle est inconnue.",
-          "battery_phase": "Phase AC physique (L1/L2/L3) à laquelle cette batterie est raccordée, ou Non assignée hors du schéma de phases protégées. Une batterie sans phase est exclue de l'enveloppe triphasée et continue à fonctionner normalement en automatique."
+          "battery_phase": "Phase AC physique (L1/L2/L3) à laquelle cette batterie est raccordée, ou Non assignée hors du schéma de phases protégées. Une batterie sans phase est exclue de l'enveloppe triphasée et continue à fonctionner normalement en automatique.",
+          "track_mac": "L'adresse MAC est l'adresse matérielle permanente de la batterie : contrairement à l'adresse IP ci-dessus, elle ne change jamais. Home Assistant s'en sert pour retrouver la batterie et mettre l'adresse IP à jour tout seul.",
+          "mac": "Adresse matérielle permanente de la batterie, détectée automatiquement. Si ce champ est vide, copiez-la depuis la liste des appareils de votre box."
         }
       },
       "time_slots": {
@@ -630,6 +634,7 @@
       }
     },
     "error": {
+      "invalid_mac": "Cela ne ressemble pas à une adresse MAC. Six paires de chiffres hexadécimaux sont attendues, par exemple dc:04:5a:14:6b:33.",
       "cannot_connect": "Impossible de se connecter à la batterie. Vérifiez l'adresse IP et que la batterie est accessible sur le réseau.",
       "esphome_entities_missing": "Il manque des entités requises à l'appareil ESPHome sélectionné : {missing}. Vérifiez qu'il exécute le firmware marstek-lilygo-rs485 avec les noms d'entités d'origine.",
       "sensor_not_found": "Le capteur de prévision solaire n'existe pas. Vérifiez que le capteur est disponible.",
@@ -656,6 +661,8 @@
       "missing_activity_sensor": "Sélectionnez un capteur appareil actif / charge VE pour le contrôle dynamique ou un chargeur sans télémétrie."
     },
     "abort": {
+      "ip_updated": "L'adresse IP de la batterie a changé ; la connexion a été mise à jour toute seule.",
+      "no_tracked_battery": "Aucune batterie configurée n'est suivie par l'adresse MAC de cet appareil.",
       "already_configured": "Cette intégration est déjà configurée.",
       "reconfigure_successful": "Paramètres de connexion de la batterie mis à jour avec succès.",
       "no_legacy_entries": "Aucune configuration Marstek Venus existante n’a été trouvée pour la migration.",
@@ -802,7 +809,9 @@
           "backup_offgrid_threshold": "Seuil de charge hors réseau de secours (W)",
           "full_charge_voltage_taper_enabled": "Activer la réduction de charge à 100% par tension",
           "battery_capacity_kwh": "Capacité nominale de la batterie (kWh)",
-          "battery_phase": "Phase physique de la batterie"
+          "battery_phase": "Phase physique de la batterie",
+          "track_mac": "Retrouver cette batterie par son adresse MAC si son IP change",
+          "mac": "Adresse MAC"
         },
         "data_description": {
           "max_charge_power": "Puissance maximale autorisée pour charger la batterie",
@@ -813,7 +822,9 @@
           "backup_offgrid_threshold": "Une charge hors réseau supérieure à cette valeur est traitée comme un événement de secours actif, excluant la batterie du contrôle PD. Augmenter si des charges permanentes (routeur, caméras) sont connectées au port hors réseau.",
           "full_charge_voltage_taper_enabled": "Lorsque la cible est 100%, limite la charge à 200 W à partir de 3.48 V de tension maximale de cellule. Les Venus E s'arrêtent à 3.60 V pour mesurer le déséquilibre après 60 secondes ; les Venus A/D avec des packs couplés continuent à 200 W jusqu'à la coupure du BMS.",
           "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Elle sert à calculer l'énergie stockée et l'efficacité à partir du SOC. Pour Sessy, saisissez la capacité réelle ; pour les autres batteries, laissez 0 si elle est inconnue.",
-          "battery_phase": "Phase AC physique (L1/L2/L3) à laquelle cette batterie est raccordée, ou Non assignée hors du schéma de phases protégées. Une batterie sans phase est exclue de l'enveloppe triphasée et continue à fonctionner normalement en automatique."
+          "battery_phase": "Phase AC physique (L1/L2/L3) à laquelle cette batterie est raccordée, ou Non assignée hors du schéma de phases protégées. Une batterie sans phase est exclue de l'enveloppe triphasée et continue à fonctionner normalement en automatique.",
+          "track_mac": "L'adresse MAC est l'adresse matérielle permanente de la batterie : contrairement à l'adresse IP ci-dessus, elle ne change jamais. Home Assistant s'en sert pour retrouver la batterie et mettre l'adresse IP à jour tout seul.",
+          "mac": "Adresse matérielle permanente de la batterie, détectée automatiquement. Si ce champ est vide, copiez-la depuis la liste des appareils de votre box."
         }
       },
       "time_slots": {
@@ -1203,6 +1214,7 @@
       }
     },
     "error": {
+      "invalid_mac": "Cela ne ressemble pas à une adresse MAC. Six paires de chiffres hexadécimaux sont attendues, par exemple dc:04:5a:14:6b:33.",
       "cannot_connect": "Impossible de se connecter à la batterie. Vérifiez l'adresse IP et que la batterie est accessible sur le réseau.",
       "esphome_entities_missing": "Il manque des entités requises à l'appareil ESPHome sélectionné : {missing}. Vérifiez qu'il exécute le firmware marstek-lilygo-rs485 avec les noms d'entités d'origine.",
       "sensor_not_found": "Le capteur de prévision solaire n'existe pas. Vérifiez que le capteur est disponible.",

--- a/tests/test_mac_tracking.py
+++ b/tests/test_mac_tracking.py
@@ -1,0 +1,245 @@
+"""Tests for MAC-based tracking of a battery's IP address.
+
+Written without the ``hass`` fixture on purpose: ``pytest.ini`` disables the
+Home Assistant plugin, and CI runs a bare ``pytest``, so a test that asked for
+``hass`` would be skipped everywhere and prove nothing. The decision logic lives
+in a pure module and the flow method is exercised against small stubs, so every
+assertion here actually runs.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from custom_components.omnibattery.infra.mac_tracking import (
+    AMBIGUOUS_MAC,
+    CONF_MAC,
+    CONF_TRACK_MAC,
+    ENDPOINT_CONFLICT,
+    INVALID_MAC,
+    NOT_IP_BASED,
+    NO_MATCH,
+    OK,
+    STILL_REACHABLE,
+    UNCHANGED,
+    detect_mac,
+    evaluate_lease,
+    is_ip_based,
+    normalise_mac,
+    tracking_enabled,
+)
+
+MAC_A = "dc:04:5a:14:6b:33"
+MAC_B = "dc:04:5a:7d:de:c6"
+
+
+def battery(
+    host="192.168.1.181",
+    port=502,
+    slave_id=1,
+    brand="marstek",
+    track=True,
+    mac=MAC_A,
+    serial_port="",
+):
+    """Build a battery entry in the shape stored in ``entry.data["batteries"]``."""
+    return {
+        "name": "Battery",
+        "host": host,
+        "port": port,
+        "slave_id": slave_id,
+        "brand": brand,
+        "serial_port": serial_port,
+        CONF_TRACK_MAC: track,
+        CONF_MAC: mac,
+    }
+
+
+# --- normalisation ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "dc:04:5a:14:6b:33",
+        "DC:04:5A:14:6B:33",
+        "dc-04-5a-14-6b-33",
+        "dc04.5a14.6b33",
+        "DC045A146B33",
+    ],
+)
+def test_normalise_mac_accepts_every_shape_routers_produce(raw):
+    """Home Assistant delivers bare hex, humans type colons: both must match."""
+    assert normalise_mac(raw) == MAC_A
+
+
+@pytest.mark.parametrize("raw", ["", "not-a-mac", "dc:04:5a:14:6b", "zz:04:5a:14:6b:33", None, 42])
+def test_normalise_mac_rejects_everything_else(raw):
+    assert normalise_mac(raw) is None
+
+
+# --- 1. disabled is a strict no-op -----------------------------------------
+
+
+def test_disabled_tracking_ignores_the_lease():
+    """The opt-in is off by default; an untouched install must not move."""
+    batteries = [battery(track=False)]
+    assert not tracking_enabled(batteries[0])
+    verdict = evaluate_lease(batteries, MAC_A, "192.168.1.180")
+    assert verdict.reason == NO_MATCH
+    assert not verdict.should_update
+
+
+def test_enabled_without_a_mac_is_also_a_no_op():
+    """Ticking the box without a MAC leaves nothing to match on."""
+    batteries = [battery(mac="")]
+    assert not tracking_enabled(batteries[0])
+    assert evaluate_lease(batteries, MAC_A, "192.168.1.180").reason == NO_MATCH
+
+
+# --- 2. the nominal move ---------------------------------------------------
+
+
+def test_new_address_for_a_tracked_battery_is_accepted():
+    batteries = [battery(host="192.168.1.181")]
+    verdict = evaluate_lease(batteries, MAC_A, "192.168.1.180")
+    assert verdict.should_update
+    assert verdict.reason == OK
+    assert verdict.index == 0
+
+
+def test_match_survives_a_differently_formatted_mac():
+    """A MAC typed with colons must match the bare hex Home Assistant reports."""
+    batteries = [battery(mac="DC-04-5A-14-6B-33")]
+    assert evaluate_lease(batteries, "dc045a146b33", "192.168.1.180").should_update
+
+
+def test_the_right_battery_is_picked_among_several():
+    batteries = [battery(host="192.168.1.64", mac=MAC_B), battery(host="192.168.1.181", mac=MAC_A)]
+    assert evaluate_lease(batteries, MAC_A, "192.168.1.180").index == 1
+
+
+# --- 3. ambiguous MAC: shared gateway --------------------------------------
+
+
+def test_one_mac_on_two_batteries_is_refused():
+    """Batteries behind one Modbus gateway share the gateway's MAC.
+
+    The MAC then belongs to the gateway rather than to either battery, so it
+    cannot say which one moved. Abstaining is the only safe answer.
+    """
+    batteries = [
+        battery(host="192.168.1.50", slave_id=1, mac=MAC_A),
+        battery(host="192.168.1.50", slave_id=2, mac=MAC_A),
+    ]
+    verdict = evaluate_lease(batteries, MAC_A, "192.168.1.51")
+    assert verdict.reason == AMBIGUOUS_MAC
+    assert not verdict.should_update
+
+
+# --- 4. endpoint already taken ---------------------------------------------
+
+
+def test_moving_onto_another_batterys_endpoint_is_refused():
+    """Two entries on one endpoint would send battery A's commands to B."""
+    batteries = [
+        battery(host="192.168.1.181", mac=MAC_A),
+        battery(host="192.168.1.180", mac=MAC_B),
+    ]
+    verdict = evaluate_lease(batteries, MAC_A, "192.168.1.180")
+    assert verdict.reason == ENDPOINT_CONFLICT
+    assert not verdict.should_update
+
+
+def test_same_address_but_a_different_slave_id_is_not_a_conflict():
+    """A Modbus gateway legitimately hosts several batteries on one host:port."""
+    batteries = [
+        battery(host="192.168.1.181", slave_id=1, mac=MAC_A),
+        battery(host="192.168.1.50", slave_id=2, mac=MAC_B),
+    ]
+    assert evaluate_lease(batteries, MAC_A, "192.168.1.50").should_update
+
+
+# --- 5. a renewed lease for the current address ----------------------------
+
+
+def test_a_lease_for_the_address_already_configured_changes_nothing():
+    """Leases are renewed periodically; reloading on each renewal is pure cost."""
+    batteries = [battery(host="192.168.1.181")]
+    verdict = evaluate_lease(batteries, MAC_A, "192.168.1.181")
+    assert verdict.reason == UNCHANGED
+    assert not verdict.should_update
+
+
+# --- 6. brands that have no IP to track ------------------------------------
+
+
+@pytest.mark.parametrize("brand", ["esphome", "hoymiles"])
+def test_non_ip_brands_are_left_alone(brand):
+    """ESPHome and Hoymiles are addressed by device id, not by IP."""
+    batteries = [battery(brand=brand, host="some-device-id")]
+    assert not is_ip_based(batteries[0])
+    assert evaluate_lease(batteries, MAC_A, "192.168.1.180").reason == NOT_IP_BASED
+
+
+def test_a_serial_marstek_is_left_alone():
+    """Serial stores a device path in host; there is no address to update."""
+    batteries = [battery(host="/dev/ttyUSB0", serial_port="/dev/ttyUSB0")]
+    assert not is_ip_based(batteries[0])
+    assert evaluate_lease(batteries, MAC_A, "192.168.1.180").reason == NOT_IP_BASED
+
+
+@pytest.mark.parametrize("brand", ["marstek", "zendure", "anker", "sessy"])
+def test_the_four_ip_brands_are_tracked(brand):
+    assert is_ip_based(battery(brand=brand))
+
+
+# --- 7. a MAC that is not a MAC --------------------------------------------
+
+
+def test_a_malformed_mac_on_the_lease_is_refused():
+    assert evaluate_lease([battery()], "nonsense", "192.168.1.180").reason == INVALID_MAC
+
+
+def test_an_empty_new_address_is_refused():
+    assert evaluate_lease([battery()], MAC_A, "  ").reason == INVALID_MAC
+
+
+# --- the two-addresses-at-once case ----------------------------------------
+
+
+def test_a_battery_still_answering_is_not_moved():
+    """A device can hold two addresses at once — measured on a Marstek unit.
+
+    While the configured address still answers, a lease for a second address is
+    extra information rather than a move. Switching would trade a working
+    endpoint for an untested one, and could flap between the two.
+    """
+    batteries = [battery(host="192.168.1.181")]
+    verdict = evaluate_lease(batteries, MAC_A, "192.168.1.180", is_reachable=lambda _i: True)
+    assert verdict.reason == STILL_REACHABLE
+    assert not verdict.should_update
+
+
+def test_a_battery_that_has_gone_quiet_is_moved():
+    batteries = [battery(host="192.168.1.181")]
+    assert evaluate_lease(batteries, MAC_A, "192.168.1.180", is_reachable=lambda _i: False).should_update
+
+
+# --- automatic MAC detection ------------------------------------------------
+
+
+def _lease(ip, macaddress):
+    return types.SimpleNamespace(ip=ip, macaddress=macaddress)
+
+
+def test_detect_mac_finds_the_configured_host():
+    discovered = [_lease("192.168.1.64", "dc045a7ddec6"), _lease("192.168.1.181", "dc045a146b33")]
+    assert detect_mac(discovered, "192.168.1.181") == MAC_A
+
+
+def test_detect_mac_returns_none_when_home_assistant_never_saw_the_device():
+    """Normal on installs where Home Assistant is not on the batteries' network."""
+    assert detect_mac([_lease("192.168.1.64", "dc045a7ddec6")], "192.168.1.181") is None

--- a/tests/test_mac_tracking.py
+++ b/tests/test_mac_tracking.py
@@ -26,6 +26,7 @@ from custom_components.omnibattery.infra.mac_tracking import (
     UNCHANGED,
     detect_mac,
     evaluate_lease,
+    publishable_macs,
     is_ip_based,
     normalise_mac,
     tracking_enabled,
@@ -243,3 +244,51 @@ def test_detect_mac_finds_the_configured_host():
 def test_detect_mac_returns_none_when_home_assistant_never_saw_the_device():
     """Normal on installs where Home Assistant is not on the batteries' network."""
     assert detect_mac([_lease("192.168.1.64", "dc045a7ddec6")], "192.168.1.181") is None
+
+
+# --- what may be published to the device registry ---------------------------
+# Home Assistant indexes devices by connections as well as by identifiers, so a
+# MAC published twice merges two batteries into one device — at registration,
+# long before any lease is evaluated.
+
+
+def test_a_unique_mac_is_published():
+    assert publishable_macs([battery(mac=MAC_A)]) == [MAC_A]
+
+
+def test_a_mac_shared_by_two_batteries_is_published_for_neither():
+    """The Modbus-gateway case: the MAC is the gateway's, not either battery's."""
+    batteries = [
+        battery(host="192.168.1.50", slave_id=1, mac=MAC_A),
+        battery(host="192.168.1.50", slave_id=2, mac=MAC_A),
+    ]
+    assert publishable_macs(batteries) == [None, None]
+
+
+def test_a_shared_mac_does_not_suppress_an_unrelated_battery():
+    batteries = [
+        battery(host="192.168.1.50", slave_id=1, mac=MAC_A),
+        battery(host="192.168.1.50", slave_id=2, mac=MAC_A),
+        battery(host="192.168.1.64", mac=MAC_B),
+    ]
+    assert publishable_macs(batteries) == [None, None, MAC_B]
+
+
+def test_untracked_and_invalid_entries_publish_nothing():
+    batteries = [battery(track=False, mac=MAC_A), battery(mac="nonsense"), battery(mac="")]
+    assert publishable_macs(batteries) == [None, None, None]
+
+
+def test_publication_is_blind_to_mac_formatting():
+    """Two spellings of one MAC are still one MAC, and must both be withheld."""
+    batteries = [battery(mac="DC-04-5A-14-6B-33"), battery(mac="dc045a146b33")]
+    assert publishable_macs(batteries) == [None, None]
+
+
+def test_a_shared_gateway_still_refuses_the_lease():
+    """Belt and braces: the discovery guard holds even if a MAC did get published."""
+    batteries = [
+        battery(host="192.168.1.50", slave_id=1, mac=MAC_A),
+        battery(host="192.168.1.50", slave_id=2, mac=MAC_A),
+    ]
+    assert evaluate_lease(batteries, MAC_A, "192.168.1.51").reason == AMBIGUOUS_MAC

--- a/tests/test_mac_tracking_flow.py
+++ b/tests/test_mac_tracking_flow.py
@@ -1,0 +1,271 @@
+"""Flow-level tests for the DHCP step that applies a MAC-tracked address change.
+
+The decision guards are unit-tested in ``test_mac_tracking``; what is checked
+here is the wiring: that a refused verdict leaves the config entry strictly
+alone, that an accepted one rewrites the host *and* goes through the existing
+registry migration, and that the migration keeps the entity ids — which is what
+preserves history and long-term statistics.
+
+Written against small stubs rather than the ``hass`` fixture: ``pytest.ini``
+disables the Home Assistant plugin and CI runs a bare ``pytest``, so a
+fixture-based test would be skipped everywhere.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from custom_components.omnibattery import config_flow as cf
+from custom_components.omnibattery.infra.mac_tracking import CONF_MAC, CONF_TRACK_MAC
+
+MAC_A = "dc:04:5a:14:6b:33"
+MAC_B = "dc:04:5a:7d:de:c6"
+
+
+# --- stubs ------------------------------------------------------------------
+
+
+class FakeEntry:
+    def __init__(self, batteries, entry_id="entry1", title="Omnibattery"):
+        self.entry_id = entry_id
+        self.title = title
+        self.data = {"batteries": batteries, "consumption_sensor": "sensor.grid"}
+
+
+class FakeConfigEntries:
+    def __init__(self, entries):
+        self._entries = entries
+        self.updated = []
+        self.reloaded = []
+
+    def async_entries(self, domain):
+        return list(self._entries)
+
+    def async_update_entry(self, entry, data=None, **kwargs):
+        entry.data = data
+        self.updated.append((entry.entry_id, data))
+        return True
+
+    async def async_reload(self, entry_id):
+        self.reloaded.append(entry_id)
+        return True
+
+
+class FakeHass:
+    def __init__(self, entries, coordinators=None):
+        self.config_entries = FakeConfigEntries(entries)
+        self.data = {cf.DOMAIN: {"entry1": {"coordinators": coordinators or []}}}
+
+
+def battery(host="192.168.1.181", mac=MAC_A, track=True, name="Marstek Venus 2"):
+    return {
+        "name": name,
+        "host": host,
+        "port": 502,
+        "slave_id": 1,
+        "brand": "marstek",
+        "serial_port": "",
+        CONF_TRACK_MAC: track,
+        CONF_MAC: mac,
+    }
+
+
+def make_flow(hass, migrations):
+    """A config flow instance wired to ``hass``, recording registry migrations."""
+    flow = cf.MarstekVenusConfigFlow()
+    flow.hass = hass
+    flow._migrate_battery_registry_ids = lambda *args: migrations.append(args)
+    return flow
+
+
+def lease(mac, ip):
+    return types.SimpleNamespace(macaddress=mac, ip=ip)
+
+
+# --- the opt-in is off: nothing at all happens ------------------------------
+
+
+async def test_disabled_tracking_leaves_the_entry_untouched():
+    hass = FakeHass([FakeEntry([battery(track=False)])])
+    migrations: list = []
+    flow = make_flow(hass, migrations)
+
+    reason = await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180")
+
+    assert reason == "no_tracked_battery"
+    assert hass.config_entries.updated == []
+    assert hass.config_entries.reloaded == []
+    assert migrations == []
+
+
+async def test_an_unknown_mac_leaves_the_entry_untouched():
+    hass = FakeHass([FakeEntry([battery(mac=MAC_A)])])
+    migrations: list = []
+    flow = make_flow(hass, migrations)
+
+    assert await flow._async_apply_dhcp_lease("aa:bb:cc:dd:ee:ff", "192.168.1.180") == "no_tracked_battery"
+    assert hass.config_entries.updated == []
+
+
+# --- the nominal move -------------------------------------------------------
+
+
+async def test_a_tracked_battery_is_moved_and_the_entry_reloaded():
+    entry = FakeEntry([battery(host="192.168.1.181")])
+    hass = FakeHass([entry])
+    migrations: list = []
+    flow = make_flow(hass, migrations)
+
+    reason = await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180")
+
+    assert reason == "ip_updated"
+    assert entry.data["batteries"][0]["host"] == "192.168.1.180"
+    assert hass.config_entries.reloaded == [entry.entry_id]
+    # Other keys of the battery survive untouched.
+    assert entry.data["batteries"][0][CONF_MAC] == MAC_A
+    assert entry.data["consumption_sensor"] == "sensor.grid"
+
+
+async def test_the_registry_migration_is_called_with_the_old_and_new_endpoint():
+    """This call is what keeps entity ids, history and statistics."""
+    entry = FakeEntry([battery(host="192.168.1.181")])
+    hass = FakeHass([entry])
+    migrations: list = []
+    flow = make_flow(hass, migrations)
+
+    await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180")
+
+    assert len(migrations) == 1
+    called_entry, old_host, old_port, new_host, new_port, old_slave, new_slave = migrations[0]
+    assert called_entry is entry
+    assert (old_host, old_port) == ("192.168.1.181", 502)
+    assert (new_host, new_port) == ("192.168.1.180", 502)
+    assert old_slave == new_slave == 1
+
+
+async def test_only_the_matching_battery_moves():
+    entry = FakeEntry([battery(host="192.168.1.64", mac=MAC_B), battery(host="192.168.1.181", mac=MAC_A)])
+    hass = FakeHass([entry])
+    flow = make_flow(hass, [])
+
+    await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180")
+
+    assert entry.data["batteries"][0]["host"] == "192.168.1.64"
+    assert entry.data["batteries"][1]["host"] == "192.168.1.180"
+
+
+# --- guards seen from the flow ---------------------------------------------
+
+
+async def test_a_battery_still_answering_is_left_where_it_is():
+    """A device holding two addresses must not be pulled off a working one."""
+    entry = FakeEntry([battery(host="192.168.1.181")])
+    live = types.SimpleNamespace(is_available=True)
+    hass = FakeHass([entry], coordinators=[live])
+    flow = make_flow(hass, [])
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180") == "no_tracked_battery"
+    assert entry.data["batteries"][0]["host"] == "192.168.1.181"
+    assert hass.config_entries.updated == []
+
+
+async def test_a_quiet_battery_is_moved():
+    entry = FakeEntry([battery(host="192.168.1.181")])
+    quiet = types.SimpleNamespace(is_available=False)
+    hass = FakeHass([entry], coordinators=[quiet])
+    flow = make_flow(hass, [])
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180") == "ip_updated"
+
+
+async def test_a_renewed_lease_for_the_current_address_does_not_reload():
+    entry = FakeEntry([battery(host="192.168.1.181")])
+    hass = FakeHass([entry])
+    flow = make_flow(hass, [])
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.181") == "no_tracked_battery"
+    assert hass.config_entries.reloaded == []
+
+
+async def test_a_shared_gateway_mac_moves_nothing():
+    entry = FakeEntry(
+        [
+            battery(host="192.168.1.50", mac=MAC_A) | {"slave_id": 1},
+            battery(host="192.168.1.50", mac=MAC_A) | {"slave_id": 2},
+        ]
+    )
+    hass = FakeHass([entry])
+    flow = make_flow(hass, [])
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.51") == "no_tracked_battery"
+    assert hass.config_entries.updated == []
+
+
+# --- the migration helper actually preserves entity ids ---------------------
+
+
+class FakeRegistryEntry:
+    def __init__(self, entity_id, unique_id, config_entry_id):
+        self.entity_id = entity_id
+        self.unique_id = unique_id
+        self.config_entry_id = config_entry_id
+
+
+class FakeEntityRegistry:
+    def __init__(self, entries):
+        self.entities = {e.entity_id: e for e in entries}
+        self.calls: list = []
+
+    def async_update_entity(self, entity_id, **kwargs):
+        self.calls.append((entity_id, kwargs))
+        if "new_unique_id" in kwargs:
+            self.entities[entity_id].unique_id = kwargs["new_unique_id"]
+
+
+class FakeDeviceRegistry:
+    def __init__(self, device):
+        self.device = device
+        self.updates: list = []
+
+    def async_get_device(self, identifiers=None, **kwargs):
+        return self.device if identifiers == self.device.identifiers else None
+
+    def async_update_device(self, device_id, new_identifiers=None, **kwargs):
+        self.updates.append((device_id, new_identifiers))
+
+
+def test_migration_rewrites_unique_ids_but_never_entity_ids(monkeypatch):
+    """Long-term statistics follow the entity_id, so it must survive a move."""
+    entry = FakeEntry([battery()])
+    entities = [
+        FakeRegistryEntry("sensor.marstek_venus_2_battery_soc", "192.168.1.181_502_battery_soc", entry.entry_id),
+        FakeRegistryEntry("sensor.marstek_venus_2_battery_power", "192.168.1.181_502_battery_power", entry.entry_id),
+        FakeRegistryEntry("sensor.other_integration", "somethingelse_soc", "other_entry"),
+    ]
+    ent_reg = FakeEntityRegistry(entities)
+    device = types.SimpleNamespace(id="dev1", identifiers={(cf.DOMAIN, "192.168.1.181_502")})
+    dev_reg = FakeDeviceRegistry(device)
+
+    monkeypatch.setattr(cf.er, "async_get", lambda hass: ent_reg)
+    monkeypatch.setattr(cf.dr, "async_get", lambda hass: dev_reg)
+
+    flow = cf.MarstekVenusConfigFlow()
+    flow.hass = FakeHass([entry])
+    flow._migrate_battery_registry_ids(entry, "192.168.1.181", 502, "192.168.1.180", 502, 1, 1)
+
+    # unique_ids re-prefixed onto the new endpoint...
+    assert entities[0].unique_id == "192.168.1.180_502_battery_soc"
+    assert entities[1].unique_id == "192.168.1.180_502_battery_power"
+    # ...an unrelated integration untouched...
+    assert entities[2].unique_id == "somethingelse_soc"
+    # ...and no call ever asked to change an entity_id.
+    assert all("new_entity_id" not in kwargs for _eid, kwargs in ent_reg.calls)
+    assert {e.entity_id for e in entities} == {
+        "sensor.marstek_venus_2_battery_soc",
+        "sensor.marstek_venus_2_battery_power",
+        "sensor.other_integration",
+    }
+    # The device identifier follows the same rename.
+    assert dev_reg.updates == [("dev1", {(cf.DOMAIN, "192.168.1.180_502")})]


### PR DESCRIPTION
Implements the design agreed in #251. Thanks for the detailed answer there — this follows it point by point.

Opt-in, per battery: when the router hands a battery a different IP address, Home Assistant re-finds it by its MAC and updates the connection instead of reporting it unreachable. Off by default; an install that never ticks the box behaves exactly as before.

## Against your list

| You asked for | Where it is |
| --- | --- |
| Opt-in per battery, no behaviour change when disabled | `_mac_tracking_schema()`; `tracking_enabled()` returns False without both the flag *and* a valid MAC |
| MAC detected automatically, with a validated manual fallback | `_mac_defaults()` reads Home Assistant's DHCP cache and pre-fills the field; `_validate_mac_tracking()` rejects anything that is not six hex pairs |
| Marstek TCP, Zendure Local, Anker TCP, Sessy — excluding serial, ESPHome, MQTT | `IP_BASED_BRANDS` plus `is_ip_based()`, which also excludes a *Marstek over serial* entry (brand alone is not enough) |
| Keep `{host}_{port}[_slave]`, reuse `_migrate_battery_registry_ids()` | `_async_apply_dhcp_lease()` calls it with the old and new endpoint; no identity scheme was changed |
| Only update on a unique MAC match with no endpoint conflict | `evaluate_lease()` returns `ambiguous_mac` for >1 match, `no_match` for 0, `endpoint_conflict` when the target endpoint belongs to another battery |
| Shared gateways, multiple IPs per MAC, no repeated reloads | Batteries behind one gateway share its MAC → `ambiguous_mac`, nothing moves. A renewed lease for the current address → `unchanged`, no reload. Two live addresses → see the design note below |
| Tests for preserved entity IDs/history and for disabled being a no-op | `test_migration_rewrites_unique_ids_but_never_entity_ids`, `test_disabled_tracking_leaves_the_entry_untouched` |

## Where the code went

The decision logic is a new pure module, `infra/mac_tracking.py` — no Home Assistant imports, so every guard is testable without an event loop. The config flow only calls it.

The two form fields land in **one** place per flow rather than in each brand's connection step: all four IP brands already converge on `async_step_battery_limits`, so the fields are added there and gated on `is_ip_based()`. That keeps the diff small and makes it impossible to miss a brand.

## Scope note — hardware I could not test on

I own two Marstek Venus E v3 and tested against them. **Zendure, Anker and Sessy are covered by unit tests only** — I have none of that hardware. The path is brand-agnostic (it rewrites `host` and reuses your existing migration), but you should know that before merging.

## A design choice I would like you to challenge

A device can hold two IPv4 addresses at once. I measured one of my Venus units answering on `.180` and `.181` **simultaneously for about 20 hours**, with a static DHCP reservation in place for that MAC — which is also why "just set a reservation" was not enough here.

So `evaluate_lease()` refuses to move a battery whose configured address **still answers** (`is_available` on the live coordinator): while the current endpoint works, a lease for a second address is extra information rather than a move, and switching would trade a working endpoint for an untested one and could flap between the two. A battery that has actually gone quiet is moved immediately.

If you would rather always follow the newest lease, dropping that guard is a two-line change and one test.

## Tests

43 new tests, `1211 → 1254` passing, 10 skipped, **no existing test modified**.

They run without the `hass` fixture on purpose: `pytest.ini` sets `-p no:homeassistant` and CI runs a bare `pytest`, so a fixture-based test would be skipped everywhere and prove nothing. The stubs are small and local to the test file.

## Two things worth flagging

**`battery_device_info` now reads `getattr(self, "mac", None)`.** Several existing tests build a stub coordinator with `types.SimpleNamespace` and read that property off it, so a plain `self.mac` breaks them. I preferred adapting the property over editing your tests.

**`async_step_dhcp` types its argument as `Any`** rather than importing `DhcpServiceInfo`, whose module path has moved across Home Assistant versions. It reads `.ip` and `.macaddress` defensively. Happy to pin it to the concrete type if you have a minimum HA version in mind.

## Translations

`strings.json`, `en.json` and `fr.json` carry the new strings. `ca`, `de`, `es` and `nl` fall back to English — I would rather leave those to a native speaker than guess.

The checkbox reads *"Re-find this battery by its MAC address if its IP address changes"*, with the description spelling out the difference between the two addresses, since the IP field sits right above it in the same form.
