### PR TITLE
fix: clear the slow grid-sensor repair when cadence recovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **The slow grid-sensor warning stayed after the sensor recovered**: a transient stall of three intervals raised the Repairs warning, and nothing could clear it until the integration or Home Assistant restarted, so the warning kept describing a fast meter as slow. Twenty consecutive fast intervals now clear it during the same run, and a sensor that slows down again raises it once more. Clearing deliberately needs a longer streak than raising, so a sensor hovering around the ten-second threshold does not churn the repair. A warning left over from an earlier run now also needs that longer streak, so it disappears about twenty publications into the new run instead of three.
+
 ## [1.3.0] - 2026-08-14
 
 ### Added

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -182,6 +182,7 @@ from .const import (
     SLOW_SENSOR_WARNING_INTERVAL_S,
     MAX_SENSOR_STALE_S,
     SLOW_SENSOR_WARN_INTERVALS,
+    SLOW_SENSOR_RECOVERY_INTERVALS,
     FORECAST_DATA_ISSUE_DELAY_S,
     HOT_PATH_READBACK_MAX_LATENCY_S,
     DISCHARGE_ENGAGE_GRACE_S,
@@ -546,9 +547,9 @@ class ChargeDischargeController:
         self._max_sensor_stale_s = MAX_SENSOR_STALE_S
         self._control_lock = asyncio.Lock()     # serialize control cycle across timer + sensor-event triggers
         self._grid_at_min_soc_last_ts = None     # last accumulation timestamp for grid-at-min-soc kWh integration
-        self._slow_sensor_issue_created = False  # at most one Repairs creation per controller run
+        self._slow_sensor_issue_created = False  # slow-sensor repair currently raised
         self._slow_sensor_intervals = 0         # consecutive slow sensor intervals
-        self._fast_sensor_intervals = 0         # startup fast intervals used to clear an old repair
+        self._fast_sensor_intervals = 0         # consecutive fast intervals used to clear the repair
 
         # Normal high-SOC charge protection. These must exist before the first
         # capacity calculation because _battery_power_limit() reads them.
@@ -5710,7 +5711,7 @@ class ChargeDischargeController:
         return self._observe_sensor_cadence(report_time)
 
     def _check_sensor_cadence(self, sensor_elapsed_s):
-        """Raise one repair per run when the main sensor cadence is slow.
+        """Raise a repair while the main sensor cadence is slow, clear it when it recovers.
 
         Slow sensors remain supported up to the stale tolerance. The repair is
         guidance about control quality, not a rejection of the sensor. Only positive,
@@ -5722,9 +5723,16 @@ class ChargeDischargeController:
         timestamp is not advanced while the sensor reads unavailable, so the first sample
         after any downtime measures the whole gap.
 
-        Once created, the issue is left untouched for the rest of this controller run.
-        On the next integration/Home Assistant restart, sustained fast updates clear a
-        persisted issue. This prevents create/delete churn and repeated log messages.
+        The repair describes the sensor as it behaves now, so a cadence that recovers
+        must clear it: SLOW_SENSOR_RECOVERY_INTERVALS consecutive fast intervals delete
+        the issue, whether it was created in this run or persisted from an earlier one.
+        Creating needs only SLOW_SENSOR_WARN_INTERVALS, so the asymmetry is the
+        hysteresis that keeps a sensor hovering around the threshold from churning
+        create/delete. Each transition acts once per streak.
+
+        A repair persisted from an earlier run is cleared by the same recovery streak,
+        so it survives roughly SLOW_SENSOR_RECOVERY_INTERVALS publications into a new
+        run before disappearing.
         """
         if sensor_elapsed_s is None or sensor_elapsed_s <= 0:
             return
@@ -5733,10 +5741,8 @@ class ChargeDischargeController:
         if sensor_elapsed_s < SLOW_SENSOR_WARNING_INTERVAL_S:
             self._slow_sensor_intervals = 0
             self._fast_sensor_intervals += 1
-            if (
-                self._fast_sensor_intervals == SLOW_SENSOR_WARN_INTERVALS
-                and not self._slow_sensor_issue_created
-            ):
+            if self._fast_sensor_intervals == SLOW_SENSOR_RECOVERY_INTERVALS:
+                self._slow_sensor_issue_created = False
                 ir.async_delete_issue(self.hass, DOMAIN, issue_id)
             return
 

--- a/custom_components/omnibattery/const/integration_const.py
+++ b/custom_components/omnibattery/const/integration_const.py
@@ -325,10 +325,17 @@ SLOW_SENSOR_WARNING_INTERVAL_S = 10.0
 # shorten the promised tolerance.
 MAX_SENSOR_STALE_S = 65.0
 
-# Consecutive real main-sensor intervals at the same cadence class before creating
-# or clearing the slow-sensor repair. Debouncing prevents a single outage/restart
-# gap from flagging an otherwise fast sensor.
+# Consecutive slow main-sensor intervals before the slow-sensor repair is raised.
+# Debouncing prevents a single outage/restart gap from flagging an otherwise fast
+# sensor. Clearing uses SLOW_SENSOR_RECOVERY_INTERVALS instead.
 SLOW_SENSOR_WARN_INTERVALS = 3
+
+# Consecutive fast intervals before an existing slow-sensor repair is cleared.
+# Deliberately much longer than SLOW_SENSOR_WARN_INTERVALS: clearing is the
+# hysteresis side, and a sensor hovering around the threshold would otherwise
+# create and delete the repair over and over. At a 3 s meter this is about a
+# minute of sustained fast cadence.
+SLOW_SENSOR_RECOVERY_INTERVALS = 20
 
 # How often the dynamic-pricing handler re-parses the price sensor purely to
 # refresh _price_data_status for the health check. The parse itself is cheap but

--- a/tests/test_pd_deadlock_min_soc.py
+++ b/tests/test_pd_deadlock_min_soc.py
@@ -38,6 +38,7 @@ from custom_components.omnibattery import ChargeDischargeController
 from custom_components.omnibattery.const import (
     MAX_SENSOR_STALE_S,
     PD_ZERO_CROSS_MIN_HOLD_S,
+    SLOW_SENSOR_RECOVERY_INTERVALS,
     SLOW_SENSOR_WARN_INTERVALS,
 )
 
@@ -177,7 +178,7 @@ def test_unchanged_four_second_reports_do_not_create_slow_sensor_repair(monkeypa
     created, deleted = _capture_repairs(monkeypatch)
     first_report = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
-    for report_number in range(6):
+    for report_number in range(SLOW_SENSOR_RECOVERY_INTERVALS + 1):
         report_time = first_report + timedelta(seconds=4 * report_number)
         state = State(
             "sensor.grid_power",
@@ -221,7 +222,7 @@ def test_identical_publications_are_fresh_health_but_not_new_control_samples(mon
     first_report = datetime(2026, 1, 1, tzinfo=timezone.utc)
     ctrl.previous_power = -700.0
 
-    for report_number in range(6):
+    for report_number in range(SLOW_SENSOR_RECOVERY_INTERVALS + 1):
         report_time = first_report + timedelta(seconds=4 * report_number)
         state = State(
             "sensor.grid_power",
@@ -391,22 +392,65 @@ def test_slow_warning_threshold_is_independent_of_stale_tolerance(caplog, monkey
     assert caplog.text == ""
 
 
-def test_created_repair_is_not_cleared_or_recreated_during_same_run(monkeypatch):
+def test_repair_clears_when_cadence_recovers_in_the_same_run(monkeypatch):
+    """A transient stall must not leave a permanent warning about a fast sensor."""
+    ctrl = _cadence_ctrl()
+    created, deleted = _capture_repairs(monkeypatch)
+
+    for _ in range(SLOW_SENSOR_WARN_INTERVALS):
+        _cadence(ctrl, 12.0)
+    assert len(created) == 1
+
+    for _ in range(SLOW_SENSOR_RECOVERY_INTERVALS):
+        _cadence(ctrl, 3.0)
+
+    assert len(deleted) == 1
+    assert deleted[0][0][2] == "slow_main_sensor_test-entry"
+    assert ctrl._slow_sensor_issue_created is False
+
+
+def test_short_fast_streak_does_not_clear_the_repair(monkeypatch):
+    """Clearing needs the full recovery streak; that asymmetry is the hysteresis."""
     ctrl = _cadence_ctrl()
     created, deleted = _capture_repairs(monkeypatch)
 
     for _ in range(SLOW_SENSOR_WARN_INTERVALS):
         _cadence(ctrl, 60.0)
-    for _ in range(SLOW_SENSOR_WARN_INTERVALS + 3):
+    for _ in range(SLOW_SENSOR_RECOVERY_INTERVALS - 1):
         _cadence(ctrl, 2.0)
 
     assert len(created) == 1
+    assert deleted == []
+    assert ctrl._slow_sensor_issue_created is True
+
+
+def test_repair_is_recreated_when_the_sensor_slows_down_again(monkeypatch):
+    ctrl = _cadence_ctrl()
+    created, deleted = _capture_repairs(monkeypatch)
+
+    for _ in range(SLOW_SENSOR_WARN_INTERVALS):
+        _cadence(ctrl, 60.0)
+    for _ in range(SLOW_SENSOR_RECOVERY_INTERVALS):
+        _cadence(ctrl, 2.0)
     for _ in range(SLOW_SENSOR_WARN_INTERVALS):
         _cadence(ctrl, 60.0)
 
-    assert deleted == []
-    assert len(created) == 1
+    assert len(created) == 2
+    assert len(deleted) == 1
     assert ctrl._slow_sensor_issue_created is True
+
+
+def test_sustained_fast_cadence_clears_and_deletes_only_once(monkeypatch):
+    ctrl = _cadence_ctrl()
+    created, deleted = _capture_repairs(monkeypatch)
+
+    for _ in range(SLOW_SENSOR_WARN_INTERVALS):
+        _cadence(ctrl, 60.0)
+    for _ in range(SLOW_SENSOR_RECOVERY_INTERVALS * 3):
+        _cadence(ctrl, 2.0)
+
+    assert len(created) == 1
+    assert len(deleted) == 1
 
 
 def test_publications_are_counted_while_control_loop_is_busy(monkeypatch):
@@ -443,7 +487,7 @@ def test_persisted_repair_clears_after_fast_startup_cadence(monkeypatch):
     ctrl = _cadence_ctrl()
     created, deleted = _capture_repairs(monkeypatch)
 
-    for _ in range(SLOW_SENSOR_WARN_INTERVALS):
+    for _ in range(SLOW_SENSOR_RECOVERY_INTERVALS):
         _cadence(ctrl, 2.0)
 
     assert created == []


### PR DESCRIPTION
My grid sensor got flagged as slow at 06:51 this morning. Hours later the repair
was still up, still saying "about 12 seconds", while the meter had been
publishing every three seconds the whole time. I measured the chain before
blaming the code: dsmr-reader writes a reading every 3.0 s, the MQTT publish came
in at 3.05 s over a 20 s sample, and the sensor age in Home Assistant was 1.85 s.

The cause is in `_check_sensor_cadence`. Three intervals above ten seconds raise
the repair and set `_slow_sensor_issue_created`, but the clearing branch is gated
on `not self._slow_sensor_issue_created`. So once it fires, only a restart of the
integration or of Home Assistant gets rid of it, no matter how fast the sensor
runs afterwards. A short stall leaves a warning that describes the sensor as it
was, not as it is.

This makes clearing independent of how the issue got there: after
`SLOW_SENSOR_RECOVERY_INTERVALS` (20) consecutive fast intervals it is deleted and
the flag reset, and a sensor that slows down again raises it once more. Raising
still takes three intervals. I kept that difference on purpose, because it is what
stops a sensor sitting right at the ten second mark from creating and deleting the
repair endlessly, which is why the one-way flag existed in the first place.

One side effect worth knowing: a repair left over from an earlier run now needs
the same twenty intervals instead of three, so roughly a minute on a fast meter.

Tests cover clearing on recovery, not clearing on a short fast streak, re-raising
when the sensor slows again, and deleting only once during a long fast streak. The
existing debounce, outage gap, watchdog and busy-loop tests are untouched. Full
suite: 1294 passed, 10 skipped.
