### PR TITLE
fix(config_flow): require the candidate address to answer before following a lease

### DIFF
--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -2806,9 +2806,11 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
 
         Reached through the ``registered_devices`` matcher in the manifest, which
         fires for any device whose MAC sits in the device registry. All this step
-        does is turn the lease into a verdict and act on it; every guard lives in
-        ``infra.mac_tracking`` so it can be tested without a running Home
-        Assistant. It always aborts — there is no user-facing flow here.
+        does is turn the lease into a verdict and act on it; the decision guards
+        live in ``infra.mac_tracking`` so they can be tested without a running
+        Home Assistant, and the one guard that needs the network — the candidate
+        has to answer as the battery — runs here. It always aborts; there is no
+        user-facing flow.
         """
         reason = await self._async_apply_dhcp_lease(
             getattr(discovery_info, "macaddress", None),

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -38,6 +38,7 @@ from homeassistant.helpers.selector import (
 )
 
 from .infra.mac_tracking import (
+    CANDIDATE_SILENT,
     CONF_MAC,
     CONF_TRACK_MAC,
     detect_mac,
@@ -1021,14 +1022,21 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         slave_id: int = DEFAULT_SLAVE_ID,
         brand: str = "marstek",
         serial_port: str | None = None,
+        username: str = "",
+        password: str = "",
     ) -> bool:
-        """Test connection to a battery."""
+        """Test connection to a battery.
+
+        ``username`` and ``password`` are only read for Sessy, whose local API
+        can require authentication: probing it with empty credentials returns a
+        refusal that is indistinguishable from an absent device (#289).
+        """
         if brand == "zendure":
             _LOGGER.info("Probing Zendure device at %s:%s", host, port)
             result, _ = await ZendureLocalDriver.probe(host, port)
         elif brand == "sessy":
             _LOGGER.info("Probing Sessy device at %s:%s", host, port)
-            result = await SessyLocalDriver.probe(host, port)
+            result = await SessyLocalDriver.probe(host, port, username, password)
         elif brand == "anker":
             _LOGGER.info("Probing Anker Solarbank at %s:%s slave %s", host, port, slave_id)
             result, _ = await AnkerModbusDriver.probe(host, port, slave_id)
@@ -2808,6 +2816,14 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         )
         return self.async_abort(reason=reason)
 
+    def _dhcp_coordinator(self, entry: ConfigEntry, index: int):
+        """Return the live coordinator of battery *index*, or None if there is none."""
+        data = (self.hass.data.get(DOMAIN) or {}).get(entry.entry_id) or {}
+        coordinators = data.get("coordinators") or []
+        if index >= len(coordinators):
+            return None
+        return coordinators[index]
+
     def _dhcp_reachability_probe(self, entry: ConfigEntry):
         """Return a callable answering whether battery *index* still responds.
 
@@ -2816,13 +2832,59 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         """
 
         def _is_reachable(index: int) -> bool:
-            data = (self.hass.data.get(DOMAIN) or {}).get(entry.entry_id) or {}
-            coordinators = data.get("coordinators") or []
-            if index >= len(coordinators):
-                return False
-            return bool(getattr(coordinators[index], "is_available", False))
+            coordinator = self._dhcp_coordinator(entry, index)
+            return bool(getattr(coordinator, "is_available", False))
 
         return _is_reachable
+
+    async def _async_probe_battery_endpoint(self, battery: dict, host: str) -> bool:
+        """Open a connection to ``host`` using this battery's stored settings."""
+        return await self._test_connection(
+            host,
+            battery.get(CONF_PORT),
+            battery.get(CONF_BATTERY_VERSION, DEFAULT_VERSION),
+            battery.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID),
+            brand=battery.get("brand", "marstek"),
+            username=battery.get(CONF_USERNAME, ""),
+            password=battery.get(CONF_PASSWORD, ""),
+        )
+
+    async def _async_probe_candidate(
+        self, entry: ConfigEntry, index: int, battery: dict, host: str
+    ) -> bool:
+        """Require the candidate address to answer before moving a battery onto it.
+
+        A matching MAC only proves that *something* at ``host`` carries the
+        battery's hardware address. A Wi-Fi-to-LAN bridge or a powerline adapter
+        answers for everything behind it, so one MAC can cover both the battery
+        and the bridge's own management address (#289): the lease alone cannot
+        say which one arrived. Talking to the candidate is what tells them apart.
+
+        It also makes the move symmetric with ``STILL_REACHABLE``. That guard
+        refuses to leave an endpoint that answers; without this one, the same
+        code would happily arrive on an endpoint that never did.
+
+        The battery's own coordinator is closed first: a v3 Marstek accepts a
+        single Modbus TCP connection at a time, and ``is_available`` being False
+        does not prove its socket was released. On failure the previous
+        connection is restored, so a lease that leads nowhere leaves the battery
+        exactly as it was. On success it is left closed on purpose, because the
+        entry is reloaded immediately after and rebuilds it on the new address.
+        """
+        coordinator = self._dhcp_coordinator(entry, index)
+        if coordinator is None:
+            return await self._async_probe_battery_endpoint(battery, host)
+
+        async with coordinator.lock:
+            await coordinator.driver.close()
+            # Same settle margins as the options-flow probe: the device needs a
+            # moment to release the slot before it accepts the next connection.
+            await asyncio.sleep(0.5)
+            answered = await self._async_probe_battery_endpoint(battery, host)
+            if not answered:
+                await asyncio.sleep(0.3)
+                await coordinator.driver.connect()
+            return answered
 
     async def _async_apply_dhcp_lease(self, mac: Any, host: str) -> str:
         """Move a battery onto ``host`` when exactly one may safely be moved.
@@ -2830,6 +2892,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
         Returns the abort reason, which doubles as the log line: every refusal
         names the single guard that fired.
         """
+        refusal = "no_tracked_battery"
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             batteries = [dict(b) for b in entry.data.get("batteries", [])]
             verdict = evaluate_lease(
@@ -2844,6 +2907,19 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
                 continue
 
             battery = batteries[verdict.index]
+
+            # Last guard, and the only one that needs the network: the address
+            # has to answer as this battery before anything is written.
+            if not await self._async_probe_candidate(
+                entry, verdict.index, battery, host
+            ):
+                _LOGGER.debug(
+                    "DHCP lease %s -> %s not applied to %s: %s",
+                    mac, host, entry.title, CANDIDATE_SILENT,
+                )
+                refusal = CANDIDATE_SILENT
+                continue
+
             old_host = battery.get(CONF_HOST) or ""
             port = battery.get(CONF_PORT)
             slave = battery.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID)
@@ -2863,7 +2939,7 @@ class MarstekVenusConfigFlow(LegacyDomainMigrationMixin, ConfigFlow, domain=DOMA
             )
             await self.hass.config_entries.async_reload(entry.entry_id)
             return "ip_updated"
-        return "no_tracked_battery"
+        return refusal
 
 
 class OptionsFlowHandler(OptionsFlow):

--- a/custom_components/omnibattery/infra/mac_tracking.py
+++ b/custom_components/omnibattery/infra/mac_tracking.py
@@ -43,6 +43,11 @@ UNCHANGED = "unchanged"
 ENDPOINT_CONFLICT = "endpoint_conflict"
 STILL_REACHABLE = "still_reachable"
 
+# Decided by the flow rather than by ``evaluate_lease``: answering it means
+# talking to the candidate address, and everything in this module is pure.
+# It belongs here anyway, with the other reasons, so one place lists them all.
+CANDIDATE_SILENT = "candidate_silent"
+
 
 @dataclass(frozen=True)
 class DhcpVerdict:

--- a/custom_components/omnibattery/strings.json
+++ b/custom_components/omnibattery/strings.json
@@ -193,7 +193,7 @@
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 200 W from 3.48 V max cell voltage. Venus E models stop at 3.60 V to measure imbalance after 60 seconds; Venus A/D with coupled packs keep charging at 200 W until the BMS cuts off.",
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
           "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
-          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
+          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself. Behind a Wi-Fi-to-LAN bridge or a powerline adapter the address you see is the adapter's own, shared with everything behind it, so tracking only works while a single battery sits behind that adapter.",
           "mac": "Permanent hardware address of the interface the battery uses on your network. Take it from your router's device list: a battery can report a different MAC than the one its wired interface actually uses. Filled in automatically when Home Assistant's DHCP cache is available."
         }
       },
@@ -662,6 +662,7 @@
     },
     "abort": {
       "ip_updated": "The battery's IP address changed; the connection was updated automatically.",
+      "candidate_silent": "A new IP address was announced for this battery, but nothing answered there; the connection was left unchanged.",
       "no_tracked_battery": "No configured battery is tracked by this device's MAC address.",
       "already_configured": "This integration is already configured.",
       "reconfigure_successful": "Battery connection settings updated successfully.",
@@ -827,7 +828,7 @@
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 200 W from 3.48 V max cell voltage. Venus E models stop at 3.60 V to measure imbalance after 60 seconds; Venus A/D with coupled packs keep charging at 200 W until the BMS cuts off.",
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
           "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
-          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
+          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself. Behind a Wi-Fi-to-LAN bridge or a powerline adapter the address you see is the adapter's own, shared with everything behind it, so tracking only works while a single battery sits behind that adapter.",
           "mac": "Permanent hardware address of the interface the battery uses on your network. Take it from your router's device list: a battery can report a different MAC than the one its wired interface actually uses. Filled in automatically when Home Assistant's DHCP cache is available."
         }
       },

--- a/custom_components/omnibattery/translations/en.json
+++ b/custom_components/omnibattery/translations/en.json
@@ -171,7 +171,7 @@
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 200 W from 3.48 V max cell voltage. Venus E models stop at 3.60 V to measure imbalance after 60 seconds; Venus A/D with coupled packs keep charging at 200 W until the BMS cuts off.",
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
           "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
-          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
+          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself. Behind a Wi-Fi-to-LAN bridge or a powerline adapter the address you see is the adapter's own, shared with everything behind it, so tracking only works while a single battery sits behind that adapter.",
           "mac": "Permanent hardware address of the interface the battery uses on your network. Take it from your router's device list: a battery can report a different MAC than the one its wired interface actually uses. Filled in automatically when Home Assistant's DHCP cache is available."
         }
       },
@@ -665,6 +665,7 @@
     },
     "abort": {
       "ip_updated": "The battery's IP address changed; the connection was updated automatically.",
+      "candidate_silent": "A new IP address was announced for this battery, but nothing answered there; the connection was left unchanged.",
       "no_tracked_battery": "No configured battery is tracked by this device's MAC address.",
       "already_configured": "This integration is already configured.",
       "reconfigure_successful": "Battery connection settings updated successfully.",
@@ -830,7 +831,7 @@
           "full_charge_voltage_taper_enabled": "When the target is 100%, limit charge to 200 W from 3.48 V max cell voltage. Venus E models stop at 3.60 V to measure imbalance after 60 seconds; Venus A/D with coupled packs keep charging at 200 W until the BMS cuts off.",
           "battery_capacity_kwh": "Nominal usable capacity of the battery pack. Used to calculate stored energy and efficiency from SOC. Sessy requires its actual capacity; for other batteries, leave at 0 if unknown.",
           "battery_phase": "Physical AC phase (L1/L2/L3) where this battery is wired, or Unassigned when it is outside the protected phase layout. An unassigned battery is outside the three-phase envelope and continues normal automatic operation.",
-          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself.",
+          "track_mac": "The MAC address is the battery's permanent hardware address: unlike the IP address above, it never changes. Home Assistant uses it to find the battery again and update the IP address by itself. Behind a Wi-Fi-to-LAN bridge or a powerline adapter the address you see is the adapter's own, shared with everything behind it, so tracking only works while a single battery sits behind that adapter.",
           "mac": "Permanent hardware address of the interface the battery uses on your network. Take it from your router's device list: a battery can report a different MAC than the one its wired interface actually uses. Filled in automatically when Home Assistant's DHCP cache is available."
         }
       },

--- a/custom_components/omnibattery/translations/fr.json
+++ b/custom_components/omnibattery/translations/fr.json
@@ -169,7 +169,7 @@
           "full_charge_voltage_taper_enabled": "Lorsque la cible est 100%, limite la charge à 200 W à partir de 3.48 V de tension maximale de cellule. Les Venus E s'arrêtent à 3.60 V pour mesurer le déséquilibre après 60 secondes ; les Venus A/D avec des packs couplés continuent à 200 W jusqu'à la coupure du BMS.",
           "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Elle sert à calculer l'énergie stockée et l'efficacité à partir du SOC. Pour Sessy, saisissez la capacité réelle ; pour les autres batteries, laissez 0 si elle est inconnue.",
           "battery_phase": "Phase AC physique (L1/L2/L3) à laquelle cette batterie est raccordée, ou Non assignée hors du schéma de phases protégées. Une batterie sans phase est exclue de l'enveloppe triphasée et continue à fonctionner normalement en automatique.",
-          "track_mac": "L'adresse MAC est l'adresse matérielle permanente de la batterie : contrairement à l'adresse IP ci-dessus, elle ne change jamais. Home Assistant s'en sert pour retrouver la batterie et mettre l'adresse IP à jour tout seul.",
+          "track_mac": "L'adresse MAC est l'adresse matérielle permanente de la batterie : contrairement à l'adresse IP ci-dessus, elle ne change jamais. Home Assistant s'en sert pour retrouver la batterie et mettre l'adresse IP à jour tout seul. Derrière un pont Wi-Fi vers Ethernet ou un adaptateur CPL, l'adresse visible est celle de l'adaptateur et couvre tout ce qui est derrière : le suivi ne fonctionne alors que si une seule batterie s'y trouve.",
           "mac": "Adresse matérielle permanente de l'interface que la batterie utilise sur le réseau. Prenez-la dans la liste des appareils de votre box : une batterie peut annoncer une adresse différente de celle de son interface filaire. Remplie automatiquement quand le cache DHCP de Home Assistant est disponible."
         }
       },
@@ -669,6 +669,7 @@
     },
     "abort": {
       "ip_updated": "L'adresse IP de la batterie a changé ; la connexion a été mise à jour toute seule.",
+      "candidate_silent": "Une nouvelle adresse IP a été annoncée pour cette batterie, mais rien n'y a répondu ; la connexion n'a pas été modifiée.",
       "no_tracked_battery": "Aucune batterie configurée n'est suivie par l'adresse MAC de cet appareil.",
       "already_configured": "Cette intégration est déjà configurée.",
       "reconfigure_successful": "Paramètres de connexion de la batterie mis à jour avec succès.",
@@ -832,7 +833,7 @@
           "full_charge_voltage_taper_enabled": "Lorsque la cible est 100%, limite la charge à 200 W à partir de 3.48 V de tension maximale de cellule. Les Venus E s'arrêtent à 3.60 V pour mesurer le déséquilibre après 60 secondes ; les Venus A/D avec des packs couplés continuent à 200 W jusqu'à la coupure du BMS.",
           "battery_capacity_kwh": "Capacité utilisable nominale du pack de batteries. Elle sert à calculer l'énergie stockée et l'efficacité à partir du SOC. Pour Sessy, saisissez la capacité réelle ; pour les autres batteries, laissez 0 si elle est inconnue.",
           "battery_phase": "Phase AC physique (L1/L2/L3) à laquelle cette batterie est raccordée, ou Non assignée hors du schéma de phases protégées. Une batterie sans phase est exclue de l'enveloppe triphasée et continue à fonctionner normalement en automatique.",
-          "track_mac": "L'adresse MAC est l'adresse matérielle permanente de la batterie : contrairement à l'adresse IP ci-dessus, elle ne change jamais. Home Assistant s'en sert pour retrouver la batterie et mettre l'adresse IP à jour tout seul.",
+          "track_mac": "L'adresse MAC est l'adresse matérielle permanente de la batterie : contrairement à l'adresse IP ci-dessus, elle ne change jamais. Home Assistant s'en sert pour retrouver la batterie et mettre l'adresse IP à jour tout seul. Derrière un pont Wi-Fi vers Ethernet ou un adaptateur CPL, l'adresse visible est celle de l'adaptateur et couvre tout ce qui est derrière : le suivi ne fonctionne alors que si une seule batterie s'y trouve.",
           "mac": "Adresse matérielle permanente de l'interface que la batterie utilise sur le réseau. Prenez-la dans la liste des appareils de votre box : une batterie peut annoncer une adresse différente de celle de son interface filaire. Remplie automatiquement quand le cache DHCP de Home Assistant est disponible."
         }
       },

--- a/tests/test_mac_tracking_flow.py
+++ b/tests/test_mac_tracking_flow.py
@@ -13,6 +13,7 @@ fixture-based test would be skipped everywhere.
 
 from __future__ import annotations
 
+import asyncio
 import types
 
 import pytest
@@ -72,11 +73,32 @@ def battery(host="192.168.1.181", mac=MAC_A, track=True, name="Marstek Venus 2")
     }
 
 
-def make_flow(hass, migrations):
-    """A config flow instance wired to ``hass``, recording registry migrations."""
+def make_flow(hass, migrations, candidate_answers=True):
+    """A config flow instance wired to ``hass``, recording registry migrations.
+
+    The candidate probe is stubbed by default: these tests are about which
+    verdict the flow acts on, and a real probe would reach for the network. The
+    probe itself is exercised further down against fake drivers.
+    """
     flow = cf.MarstekVenusConfigFlow()
     flow.hass = hass
     flow._migrate_battery_registry_ids = lambda *args: migrations.append(args)
+
+    async def _probe(entry, index, battery, host):
+        return candidate_answers
+
+    flow._async_probe_candidate = _probe
+    return flow
+
+
+
+def make_flow_probing_for_real(hass, migrations=None):
+    """Same, but keeping the real candidate probe, aimed at stubbed drivers."""
+    flow = cf.MarstekVenusConfigFlow()
+    flow.hass = hass
+    flow._migrate_battery_registry_ids = lambda *args: (
+        migrations.append(args) if migrations is not None else None
+    )
     return flow
 
 
@@ -201,6 +223,159 @@ async def test_a_shared_gateway_mac_moves_nothing():
 
     assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.51") == "no_tracked_battery"
     assert hass.config_entries.updated == []
+
+
+# --- the candidate address has to answer ------------------------------------
+
+
+class FakeDriver:
+    """Records the close/connect sequence a probe puts the coordinator through."""
+
+    def __init__(self):
+        self.calls: list[str] = []
+
+    async def close(self):
+        self.calls.append("close")
+
+    async def connect(self):
+        self.calls.append("connect")
+        return True
+
+
+class FakeCoordinator:
+    def __init__(self, available=False):
+        self.is_available = available
+        self.lock = asyncio.Lock()
+        self.driver = FakeDriver()
+
+
+@pytest.fixture
+def no_settle_delay(monkeypatch):
+    """Skip the settle margins; they exist for the device, not for the test."""
+
+    async def _instant(_seconds):
+        return None
+
+    monkeypatch.setattr(cf.asyncio, "sleep", _instant)
+
+
+def patch_probe(monkeypatch, driver_name, result, calls):
+    """Replace one driver's probe, recording what it was asked."""
+
+    async def _probe(*args, **kwargs):
+        calls.append((args, kwargs))
+        return result
+
+    monkeypatch.setattr(getattr(cf, driver_name), "probe", _probe)
+
+
+async def test_a_candidate_that_answers_is_adopted(monkeypatch, no_settle_delay):
+    """The nominal case: something is there, and it speaks the battery's protocol."""
+    entry = FakeEntry([battery(host="192.168.1.181")])
+    hass = FakeHass([entry])
+    migrations: list = []
+    calls: list = []
+    patch_probe(monkeypatch, "MarstekModbusDriver", True, calls)
+
+    flow = make_flow_probing_for_real(hass, migrations)
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180") == "ip_updated"
+    assert entry.data["batteries"][0]["host"] == "192.168.1.180"
+    # Probed at the candidate address, not the one already configured.
+    assert calls[0][0][0] == "192.168.1.180"
+
+
+async def test_a_silent_candidate_changes_nothing(monkeypatch, no_settle_delay):
+    """A MAC can cover a bridge and the battery behind it; only one answers."""
+    entry = FakeEntry([battery(host="192.168.1.181")])
+    hass = FakeHass([entry])
+    migrations: list = []
+    patch_probe(monkeypatch, "MarstekModbusDriver", False, [])
+
+    flow = make_flow_probing_for_real(hass, migrations)
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180") == "candidate_silent"
+    assert entry.data["batteries"][0]["host"] == "192.168.1.181"
+    assert migrations == []
+    assert hass.config_entries.updated == []
+    assert hass.config_entries.reloaded == []
+
+
+async def test_the_connection_is_restored_when_the_candidate_stays_silent(
+    monkeypatch, no_settle_delay
+):
+    """The slot is freed to probe; a failed probe must give it back."""
+    entry = FakeEntry([battery(host="192.168.1.181")])
+    coordinator = FakeCoordinator(available=False)
+    hass = FakeHass([entry], coordinators=[coordinator])
+    patch_probe(monkeypatch, "MarstekModbusDriver", False, [])
+    flow = make_flow_probing_for_real(hass)
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180") == "candidate_silent"
+    assert coordinator.driver.calls == ["close", "connect"]
+    assert not coordinator.lock.locked()
+
+
+async def test_a_successful_probe_leaves_the_reload_to_rebuild_the_connection(
+    monkeypatch, no_settle_delay
+):
+    """Reconnecting to the old address would be pointless: the reload follows."""
+    entry = FakeEntry([battery(host="192.168.1.181")])
+    coordinator = FakeCoordinator(available=False)
+    hass = FakeHass([entry], coordinators=[coordinator])
+    patch_probe(monkeypatch, "MarstekModbusDriver", True, [])
+    flow = make_flow_probing_for_real(hass)
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180") == "ip_updated"
+    assert coordinator.driver.calls == ["close"]
+    assert hass.config_entries.reloaded == [entry.entry_id]
+
+
+async def test_sessy_is_probed_with_its_stored_credentials(monkeypatch, no_settle_delay):
+    """Sessy refuses an unauthenticated probe, which reads exactly like an absent device."""
+    sessy = battery(host="192.168.1.181") | {
+        "brand": "sessy",
+        "port": 80,
+        "username": "sessy-user",
+        "password": "sessy-pass",
+    }
+    entry = FakeEntry([sessy])
+    hass = FakeHass([entry])
+    calls: list = []
+    patch_probe(monkeypatch, "SessyLocalDriver", True, calls)
+    flow = make_flow_probing_for_real(hass)
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180") == "ip_updated"
+    assert calls[0][0] == ("192.168.1.180", 80, "sessy-user", "sessy-pass")
+
+
+@pytest.mark.parametrize(
+    "brand,driver_name,tuple_result",
+    [
+        ("marstek", "MarstekModbusDriver", False),
+        ("zendure", "ZendureLocalDriver", True),
+        ("anker", "AnkerModbusDriver", True),
+        ("sessy", "SessyLocalDriver", False),
+    ],
+)
+async def test_every_ip_based_brand_is_probed_through_its_own_driver(
+    monkeypatch, no_settle_delay, brand, driver_name, tuple_result
+):
+    """The four brands that can drift are the four brands that must be probed."""
+    entry = FakeEntry([battery(host="192.168.1.181") | {"brand": brand}])
+    hass = FakeHass([entry])
+    calls: list = []
+
+    async def _probe(*args, **kwargs):
+        calls.append((args, kwargs))
+        return (True, None) if tuple_result else True
+
+    monkeypatch.setattr(getattr(cf, driver_name), "probe", _probe)
+    flow = make_flow_probing_for_real(hass)
+
+    assert await flow._async_apply_dhcp_lease(MAC_A, "192.168.1.180") == "ip_updated"
+    assert len(calls) == 1
+    assert calls[0][0][0] == "192.168.1.180"
 
 
 # --- the migration helper actually preserves entity ids ---------------------


### PR DESCRIPTION
Refs #289. Targets `release/v1.4.0`, as agreed there.

A tracked battery is now moved onto a new address only after that address has answered as the battery. Everything else about the feature is unchanged.

### Why

A matching MAC proves that something at the leased address carries the battery's hardware address, not that it is the battery. Behind a Wi-Fi-to-LAN bridge or a powerline adapter, one MAC covers the adapter and everything behind it, so the lease can just as well be the adapter's own management address. That is the case reported in #279.

It also removes an asymmetry in the existing guards: `STILL_REACHABLE` refuses to leave an endpoint that answers, while nothing stopped the same code from arriving on an endpoint that never did.

### What changed

Following your five points:

1. `evaluate_lease()` is untouched and still pure. The probe runs in `_async_apply_dhcp_lease()` after the `OK` verdict and before any registry or config-entry write.
2. A candidate that does not answer is skipped with the `candidate_silent` reason, and the next lease is evaluated from scratch. No retry.
3. Close-then-probe on the coordinator of the matched battery, by index rather than by host: the existing options-flow helper looks the coordinator up by the address being probed, which is the new one here. The previous connection is restored when the probe fails. On success it is left closed on purpose, since the reload that follows rebuilds it on the new address.
4. Sessy is probed with its stored credentials. Rather than bypassing the helper, `MarstekVenusConfigFlow._test_connection()` gained optional `username` and `password`, defaulting to empty, so its Sessy branch stops being unauthenticated for every caller.
5. Tests cover a successful probe, a silent candidate leaving the entry strictly alone, close-and-restore on failure, close-without-reconnect on success, Sessy credentials reaching the driver, and each of the four IP-based brands going through its own driver.

The MAC field help text now mentions bridges and powerline adapters, in English and French.

### Two choices you may want to redirect

The close-then-probe sequence applies to all four brands rather than to Marstek alone, including the settle margins copied from the options-flow probe. One code path is easier to review than a brand switch, and the delay lands in a background discovery flow where the battery is already silent. Restricting it to Marstek is a two-line change.

A refused lease names `candidate_silent` at debug level like the other refusals, and the probe itself already logs `Failed to connect` at error level, so the event is visible in a default log. If you would rather have the refusal itself at info, say the word.

### Verification

Full suite green locally: 1392 passed, 10 skipped.

Same hardware caveat as #254: I only own Marstek units, so Zendure, Anker and Sessy are covered by unit tests alone.
