### PR TITLE
Preserve runtime-only fields when the options flow rebuilds records

### DIFF
--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -898,10 +898,14 @@ def _finalize_slot(
 ) -> dict:
     """Merge step A and optional step B into the persisted slot shape.
 
-    ``existing`` is the stored slot this one replaces, when there is one. Keys
-    written at runtime rather than through the form (the per-slot enable
-    switch) are carried over from it, so re-saving the flow does not reset
-    them to their defaults.
+    ``existing`` is the stored slot occupying this position, when there is one.
+    Every stored key the form does not emit — today that is ``enabled``, written
+    by the per-slot enable switch — is carried over from it, so re-saving the
+    flow does not reset it to its default.
+
+    The carry-over only happens when the form still describes the same schedule.
+    Editing a slot into a different window replaces it, and a replacement must
+    not inherit a disabled state that has no form field to reveal it.
     """
     soc_on = bool(step_a.get("soc_override_enabled", False))
     power_on = bool(step_a.get("power_override_enabled", False))
@@ -934,7 +938,11 @@ def _finalize_slot(
         "battery_limits": battery_limits,
         "mode": step_a.get("mode", DEFAULT_SLOT_MODE),
     }
-    merged = {**(existing or {}), **slot}
+    identity = ("start_time", "end_time", "days", "battery_scope")
+    replaces_same_slot = bool(existing) and all(
+        existing.get(key) == slot[key] for key in identity
+    )
+    merged = {**existing, **slot} if replaces_same_slot else dict(slot)
     merged.setdefault("enabled", True)
     return merged
 
@@ -3950,10 +3958,15 @@ class OptionsFlowHandler(OptionsFlow):
             # The Enabled switch and the Exclusion % slider write straight into
             # the stored record and have no field on this form. Lay the form
             # result over the stored device so those keys survive a re-save.
+            # Only do that while the form still describes the same device:
+            # replacing the device at this position must not inherit a disabled
+            # state the user cannot see here, let alone change.
             stored = self.config_entry.data.get("excluded_devices", [])
             index = len(self.excluded_devices)
-            if index < len(stored):
-                excluded_device = {**stored[index], **excluded_device}
+            previous = stored[index] if index < len(stored) else {}
+            previous_id = previous.get("power_sensor") or previous.get("activity_sensor")
+            if previous_id and previous_id == (power_sensor or activity_sensor):
+                excluded_device = {**previous, **excluded_device}
             self.excluded_devices.append(excluded_device)
 
             # Check if user wants to add more devices (max 4)

--- a/custom_components/omnibattery/config_flow.py
+++ b/custom_components/omnibattery/config_flow.py
@@ -893,8 +893,16 @@ def _parse_step_b_battery_limits(step_b: dict | None) -> dict[str, dict]:
     return out
 
 
-def _finalize_slot(step_a: dict, step_b: dict | None) -> dict:
-    """Merge step A and optional step B into the persisted slot shape."""
+def _finalize_slot(
+    step_a: dict, step_b: dict | None, existing: dict | None = None
+) -> dict:
+    """Merge step A and optional step B into the persisted slot shape.
+
+    ``existing`` is the stored slot this one replaces, when there is one. Keys
+    written at runtime rather than through the form (the per-slot enable
+    switch) are carried over from it, so re-saving the flow does not reset
+    them to their defaults.
+    """
     soc_on = bool(step_a.get("soc_override_enabled", False))
     power_on = bool(step_a.get("power_override_enabled", False))
     parsed = _parse_step_b_battery_limits(step_b) if (soc_on or power_on) else {}
@@ -914,11 +922,10 @@ def _finalize_slot(step_a: dict, step_b: dict | None) -> dict:
                 entry["max_discharge_power_w"] = limits["max_discharge_power_w"]
         if entry:
             battery_limits[b_key] = entry
-    return {
+    slot = {
         "start_time": step_a["start_time"],
         "end_time": step_a["end_time"],
         "days": step_a["days"],
-        "enabled": True,
         "battery_scope": step_a.get("battery_scope", SLOT_BATTERY_SCOPE_ALL),
         "allow_charge": bool(step_a.get("allow_charge", False)),
         "allow_discharge": bool(step_a.get("allow_discharge", True)),
@@ -927,6 +934,9 @@ def _finalize_slot(step_a: dict, step_b: dict | None) -> dict:
         "battery_limits": battery_limits,
         "mode": step_a.get("mode", DEFAULT_SLOT_MODE),
     }
+    merged = {**(existing or {}), **slot}
+    merged.setdefault("enabled", True)
+    return merged
 
 
 
@@ -3833,7 +3843,11 @@ class OptionsFlowHandler(OptionsFlow):
         """Persist the pending slot and advance the flow."""
         if self._pending_slot_step_a is None:
             return await self.async_step_add_time_slot()
-        slot = _finalize_slot(self._pending_slot_step_a, step_b)
+        slot = _finalize_slot(
+            self._pending_slot_step_a,
+            step_b,
+            self._options_slot_defaults(len(self.time_slots)),
+        )
         self.time_slots.append(slot)
         self._pending_slot_step_a = None
         if len(self.time_slots) < MAX_TIME_SLOTS:
@@ -3933,6 +3947,13 @@ class OptionsFlowHandler(OptionsFlow):
                 "cover_home_when_active": user_input.get("cover_home_when_active", False),
                 "ev_charger_no_telemetry": ev_no_telemetry,
             }
+            # The Enabled switch and the Exclusion % slider write straight into
+            # the stored record and have no field on this form. Lay the form
+            # result over the stored device so those keys survive a re-save.
+            stored = self.config_entry.data.get("excluded_devices", [])
+            index = len(self.excluded_devices)
+            if index < len(stored):
+                excluded_device = {**stored[index], **excluded_device}
             self.excluded_devices.append(excluded_device)
 
             # Check if user wants to add more devices (max 4)

--- a/tests/test_excluded_device_config_flow.py
+++ b/tests/test_excluded_device_config_flow.py
@@ -205,3 +205,57 @@ async def test_options_flow_keeps_fields_that_have_no_form_field():
 
     assert flow.excluded_devices[0]["enabled"] is False
     assert flow.excluded_devices[0]["exclusion_pct"] == 60
+
+
+async def test_options_flow_does_not_hand_runtime_fields_to_a_replacement():
+    """Swapping the device at a position must not inherit its disabled state."""
+    entry = SimpleNamespace(
+        entry_id="replacement-entry",
+        data={
+            "excluded_devices": [
+                {
+                    "power_sensor": "sensor.wallbox_power",
+                    "enabled": False,
+                    "exclusion_pct": 60,
+                }
+            ]
+        },
+    )
+    flow = _options_flow(entry)
+
+    await flow.async_step_add_excluded_device(
+        {"power_sensor": "sensor.heat_pump_power"}
+    )
+
+    assert flow.excluded_devices[0]["power_sensor"] == "sensor.heat_pump_power"
+    assert flow.excluded_devices[0].get("enabled", True) is True
+    assert "exclusion_pct" not in flow.excluded_devices[0]
+
+
+async def test_options_flow_keeps_runtime_fields_when_only_activity_sensor_is_added():
+    """The device is unchanged, so its Enabled state must survive the edit."""
+    entry = SimpleNamespace(
+        entry_id="activity-entry",
+        data={
+            "excluded_devices": [
+                {
+                    "power_sensor": "sensor.wallbox_power",
+                    "enabled": False,
+                    "exclusion_pct": 60,
+                }
+            ]
+        },
+    )
+    flow = _options_flow(entry)
+
+    await flow.async_step_add_excluded_device(
+        {
+            "power_sensor": "sensor.wallbox_power",
+            "activity_sensor": "binary_sensor.ev_charging",
+            "dynamic_power_control": True,
+        }
+    )
+
+    assert flow.excluded_devices[0]["activity_sensor"] == "binary_sensor.ev_charging"
+    assert flow.excluded_devices[0]["enabled"] is False
+    assert flow.excluded_devices[0]["exclusion_pct"] == 60

--- a/tests/test_excluded_device_config_flow.py
+++ b/tests/test_excluded_device_config_flow.py
@@ -181,3 +181,27 @@ async def test_no_telemetry_device_requires_an_activity_or_legacy_sensor():
 
     assert result["errors"] == {"activity_sensor": "missing_activity_sensor"}
     assert flow.excluded_devices == []
+
+
+async def test_options_flow_keeps_fields_that_have_no_form_field():
+    """Re-saving must not reset the Enabled switch or the Exclusion % slider."""
+    entry = SimpleNamespace(
+        entry_id="runtime-entry",
+        data={
+            "excluded_devices": [
+                {
+                    "power_sensor": "sensor.wallbox_power",
+                    "enabled": False,
+                    "exclusion_pct": 60,
+                }
+            ]
+        },
+    )
+    flow = _options_flow(entry)
+
+    await flow.async_step_add_excluded_device(
+        {"power_sensor": "sensor.wallbox_power"}
+    )
+
+    assert flow.excluded_devices[0]["enabled"] is False
+    assert flow.excluded_devices[0]["exclusion_pct"] == 60

--- a/tests/test_time_slot_power_limits.py
+++ b/tests/test_time_slot_power_limits.py
@@ -1,6 +1,9 @@
 """Regression tests for time-slot power override selector limits."""
 
-from custom_components.omnibattery.config_flow import _build_slot_step_b_schema
+from custom_components.omnibattery.config_flow import (
+    _build_slot_step_b_schema,
+    _finalize_slot,
+)
 from custom_components.omnibattery.const import SLOT_BATTERY_SCOPE_ALL
 
 
@@ -77,3 +80,28 @@ def test_time_slot_power_override_keeps_marstek_version_envelope():
         "battery_1__max_charge_power_w": 2500,
         "battery_1__max_discharge_power_w": 2500,
     }
+
+
+def test_finalize_slot_keeps_disabled_state_of_the_slot_it_replaces():
+    """The per-slot enable switch has no form field, so it must be carried over."""
+    step_a = {
+        "start_time": "23:00",
+        "end_time": "07:00",
+        "days": ["mon"],
+        "battery_scope": SLOT_BATTERY_SCOPE_ALL,
+    }
+
+    slot = _finalize_slot(step_a, None, {"enabled": False})
+
+    assert slot["enabled"] is False
+
+
+def test_finalize_slot_defaults_to_enabled_for_a_brand_new_slot():
+    step_a = {
+        "start_time": "23:00",
+        "end_time": "07:00",
+        "days": ["mon"],
+        "battery_scope": SLOT_BATTERY_SCOPE_ALL,
+    }
+
+    assert _finalize_slot(step_a, None)["enabled"] is True

--- a/tests/test_time_slot_power_limits.py
+++ b/tests/test_time_slot_power_limits.py
@@ -91,7 +91,7 @@ def test_finalize_slot_keeps_disabled_state_of_the_slot_it_replaces():
         "battery_scope": SLOT_BATTERY_SCOPE_ALL,
     }
 
-    slot = _finalize_slot(step_a, None, {"enabled": False})
+    slot = _finalize_slot(step_a, None, {**step_a, "enabled": False})
 
     assert slot["enabled"] is False
 
@@ -105,3 +105,22 @@ def test_finalize_slot_defaults_to_enabled_for_a_brand_new_slot():
     }
 
     assert _finalize_slot(step_a, None)["enabled"] is True
+
+
+def test_finalize_slot_does_not_hand_disabled_state_to_a_different_window():
+    """Editing a slot into another window replaces it, so it starts enabled."""
+    step_a = {
+        "start_time": "11:00",
+        "end_time": "15:00",
+        "days": ["mon"],
+        "battery_scope": SLOT_BATTERY_SCOPE_ALL,
+    }
+    stored = {
+        "start_time": "23:00",
+        "end_time": "07:00",
+        "days": ["mon"],
+        "battery_scope": SLOT_BATTERY_SCOPE_ALL,
+        "enabled": False,
+    }
+
+    assert _finalize_slot(step_a, None, stored)["enabled"] is True


### PR DESCRIPTION
The options flow rebuilds excluded devices and time slots from form fields only, so keys that have no form field are dropped and fall back to their defaults on save.

Two are written at runtime and lost this way: `enabled` (`switch.py:1096`) and `exclusion_pct` (`number.py:861`). Click through Configure → excluded_devices without changing anything and every device you disabled is enabled again, with `Exclusion %` back at 100. Time slots have the same problem: `_finalize_slot()` hardcoded `"enabled": True`.

I hit this on a live system: re-saving to add an `activity_sensor` re-enabled an excluded device I had deliberately switched off, with no warning.

This lays the form result over the stored record instead of replacing it, and takes a slot's enabled state from the slot it replaces.

The carry-over is deliberately conditional. Position alone is not enough to identify a record: if you replace the device at a position, inheriting its `enabled: False` would be worse than the reset this fixes, because neither key has a form field to reveal or change it. So a stored record is only carried forward while the form still describes the same thing — the same power (or activity) sensor for an excluded device, the same window, days and battery scope for a time slot. Replacements start from the defaults, as they do today.

Four regression tests cover both paths in both directions: re-saving keeps the runtime keys, replacing does not inherit them. They fail on `main` and pass here. Full suite: 1297 passed, 10 skipped.
