### PR TITLE
Two coordinator defects in device-reported values

### DIFF
--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -64,6 +64,121 @@ def _normalise_power_limit(value) -> int:
         return 0
 
 
+def _stamp_native_daily_reset_dates(coordinator) -> None:
+    """Date-stamp daily energy values a device counts for itself.
+
+    The system totals refuse to add up unless every battery's daily figure is
+    marked as belonging to today — a guard against summing one battery's fresh
+    value with another's from before midnight. Only the derived counter stamps
+    that mark, because until now every driver needed one.
+
+    A driver whose device keeps its own daily counters never gets that sensor,
+    so it never carried the mark, and one such battery in a fleet zeroed the
+    system totals outright: 10.3 kWh charged on one battery and 3.97 on the
+    other, with the overview reading 0.00.
+
+    The poll happening today does not make the *value* today's. A device keeps
+    its own midnight, and for a few minutes either side of ours its counter
+    still holds yesterday's accumulation. Marking that as today let the system
+    aggregate add a battery's fresh 0.00 to another's stale 14.13 and latch the
+    sum: the aggregate refuses same-day decreases, so the wrong figure stood
+    until the real total grew past it — all day, in the observed case.
+
+    So the mark waits for evidence that the device's own counter has turned,
+    which is the value dropping below what was last seen. Until then the
+    previous day's mark stays and the aggregate treats the sum as incomplete,
+    which is the honest answer: better no total than a wrong one that sticks.
+
+    A counter last seen at zero carries nothing stale, so it needs no such
+    evidence. This assumes the device does reset daily — the capability that
+    gates this function is the claim that it does.
+    """
+    if not getattr(coordinator.capabilities, "has_daily_energy_counters", False):
+        return
+    if not coordinator.data:
+        return
+    today = dt_util.now().date().isoformat()
+    seen = getattr(coordinator, "_native_daily_seen", None)
+    if seen is None:
+        seen = {}
+        coordinator._native_daily_seen = seen
+
+    for key in ("total_daily_charging_energy", "total_daily_discharging_energy"):
+        value = coordinator.data.get(key)
+        if value is None:
+            continue
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            continue
+
+        previous = seen.get(key)
+        if previous is None:
+            # Nothing to compare against — first sight, or a restart. The
+            # counter is whatever the device says it is now.
+            stamp = today
+        else:
+            previous_date, previous_value = previous
+            if previous_date == today or previous_value <= 0 or value < previous_value:
+                stamp = today
+            else:
+                # Our day has turned, the device's has not. Leave the old mark.
+                stamp = previous_date
+
+        seen[key] = (stamp, value)
+        coordinator.data[f"{key}_reset_date"] = stamp
+
+
+def _sync_device_reported_limits(coordinator) -> None:
+    """Adopt the power ceilings the device reports, ignoring a zero.
+
+    A reported ceiling of zero is not a limit, it is a missing answer. A
+    Marstek came back from a restart with both power registers reading 0,
+    and adopting that shut the battery out of every allocation: it could
+    neither charge nor discharge, and nothing would ever write those
+    registers again, because the controller had stopped addressing a
+    battery it believed could do nothing. The last good figure stands
+    instead, and the mismatch is worth a line in the log.
+    """
+    for key in ("max_charge_power", "max_discharge_power"):
+        if key in coordinator.data and not coordinator.data[key]:
+            _LOGGER.warning(
+                "[%s] Device reports %s = 0; keeping the last known ceiling. "
+                "The battery may have lost its limits on a restart — writing "
+                "the corresponding number entity restores them.",
+                coordinator.name, key,
+            )
+    if coordinator.data.get("max_charge_power"):
+        device_cap = int(coordinator.data["max_charge_power"])
+        # Soft-max drivers (Zendure telemetry, Anker read-only sensor) and
+        # Venus E v2/v3 report the physical/device ceiling. Writable
+        # register drivers report the user's configured ceiling instead.
+        if coordinator.needs_software_max_charge or coordinator.needs_software_power_cap:
+            coordinator.device_max_charge_power = device_cap
+        else:
+            coordinator.configured_max_charge_power = device_cap
+        # Keep the legacy alias synchronized for lightweight coordinator
+        # doubles that do not have the normalized backing fields.
+        if not hasattr(coordinator, "_configured_max_charge_power"):
+            coordinator.max_charge_power = (
+                min(device_cap, getattr(coordinator, "user_max_charge_power", device_cap))
+                if coordinator.needs_software_max_charge or coordinator.needs_software_power_cap
+                else device_cap
+            )
+    if coordinator.data.get("max_discharge_power"):
+        device_cap = int(coordinator.data["max_discharge_power"])
+        if coordinator.needs_software_max_discharge or coordinator.needs_software_power_cap:
+            coordinator.device_max_discharge_power = device_cap
+        else:
+            coordinator.configured_max_discharge_power = device_cap
+        if not hasattr(coordinator, "_configured_max_discharge_power"):
+            coordinator.max_discharge_power = (
+                min(device_cap, getattr(coordinator, "user_max_discharge_power", device_cap))
+                if coordinator.needs_software_max_discharge or coordinator.needs_software_power_cap
+                else device_cap
+            )
+
+
 def group_scan_interval_s(
     group_keys: tuple[str, ...],
     nominal_interval_s: float,
@@ -1386,35 +1501,8 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         # coordinator.min_soc stays at the construction default across restarts.
         if "min_soc" in self.data:
             self.min_soc = int(self.data["min_soc"])
-        if "max_charge_power" in self.data:
-            device_cap = int(self.data["max_charge_power"])
-            # Soft-max drivers (Zendure telemetry, Anker read-only sensor) and
-            # Venus E v2/v3 report the physical/device ceiling. Writable
-            # register drivers report the user's configured ceiling instead.
-            if self.needs_software_max_charge or self.needs_software_power_cap:
-                self.device_max_charge_power = device_cap
-            else:
-                self.configured_max_charge_power = device_cap
-            # Keep the legacy alias synchronized for lightweight coordinator
-            # doubles that do not have the normalized backing fields.
-            if not hasattr(self, "_configured_max_charge_power"):
-                self.max_charge_power = (
-                    min(device_cap, getattr(self, "user_max_charge_power", device_cap))
-                    if self.needs_software_max_charge or self.needs_software_power_cap
-                    else device_cap
-                )
-        if "max_discharge_power" in self.data:
-            device_cap = int(self.data["max_discharge_power"])
-            if self.needs_software_max_discharge or self.needs_software_power_cap:
-                self.device_max_discharge_power = device_cap
-            else:
-                self.configured_max_discharge_power = device_cap
-            if not hasattr(self, "_configured_max_discharge_power"):
-                self.max_discharge_power = (
-                    min(device_cap, getattr(self, "user_max_discharge_power", device_cap))
-                    if self.needs_software_max_discharge or self.needs_software_power_cap
-                    else device_cap
-                )
+        _sync_device_reported_limits(self)
+        _stamp_native_daily_reset_dates(self)
 
         if updated_data:
             _LOGGER.debug(

--- a/tests/test_coordinator_device_reports.py
+++ b/tests/test_coordinator_device_reports.py
@@ -1,0 +1,195 @@
+"""What the coordinator makes of the figures a device reports.
+
+A Marstek Venus came back from a restart with registers 44002 and 44003 both
+reading 0. The coordinator adopted them as the configured ceiling, which shut
+the battery out of every allocation — it could neither charge nor discharge, and
+nothing would ever write those registers again, because the controller had
+stopped addressing a battery it believed could do nothing.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.omnibattery.infra.coordinator import (
+    MarstekVenusDataUpdateCoordinator,
+    _sync_device_reported_limits,
+)
+
+
+class _Coordinator:
+    """The narrow slice of the coordinator this sync touches."""
+
+    def __init__(self, data):
+        self.name = "Omnibattery Marstek Venus"
+        self.data = data
+        self.needs_software_max_charge = False
+        self.needs_software_max_discharge = False
+        self.needs_software_power_cap = False
+        self._configured_max_charge_power = 2500
+        self._configured_max_discharge_power = 2500
+        self._device_max_charge_power = 2500
+        self._device_max_discharge_power = 2500
+        self._effective_max_charge_power = 2500
+        self._effective_max_discharge_power = 2500
+        self.min_soc = 10
+        self.max_soc = 100
+
+    configured_max_charge_power = MarstekVenusDataUpdateCoordinator.configured_max_charge_power
+    configured_max_discharge_power = MarstekVenusDataUpdateCoordinator.configured_max_discharge_power
+    device_max_charge_power = MarstekVenusDataUpdateCoordinator.device_max_charge_power
+    device_max_discharge_power = MarstekVenusDataUpdateCoordinator.device_max_discharge_power
+    _recompute_effective_power_limits = (
+        MarstekVenusDataUpdateCoordinator._recompute_effective_power_limits
+    )
+
+
+def _sync(data):
+    coordinator = _Coordinator(data)
+    _sync_device_reported_limits(coordinator)
+    return coordinator
+
+
+def test_a_reported_ceiling_of_zero_is_not_adopted():
+    """The exact state after the restart: both registers reading 0."""
+    coordinator = _sync({"max_charge_power": 0, "max_discharge_power": 0})
+    assert coordinator._effective_max_charge_power == 2500
+    assert coordinator._effective_max_discharge_power == 2500
+
+
+def test_a_real_ceiling_is_still_adopted():
+    coordinator = _sync({"max_charge_power": 1500, "max_discharge_power": 800})
+    assert coordinator._effective_max_charge_power == 1500
+    assert coordinator._effective_max_discharge_power == 800
+
+
+def test_one_register_answering_does_not_drag_the_other_down():
+    coordinator = _sync({"max_charge_power": 0, "max_discharge_power": 1200})
+    assert coordinator._effective_max_charge_power == 2500
+    assert coordinator._effective_max_discharge_power == 1200
+
+
+def test_the_mismatch_is_logged_rather_than_swallowed(caplog):
+    """Silence here cost a day of a battery sitting idle in the sun."""
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        _sync({"max_charge_power": 0})
+    assert "max_charge_power = 0" in caplog.text
+    assert "restarts" in caplog.text or "restart" in caplog.text
+
+
+# ----------------------------------------------------------------------
+# daily totals across mixed fleets
+#
+# The system totals refuse to add up unless every battery's daily figure is
+# marked as belonging to today — a guard against summing one battery's fresh
+# value with another's from before midnight. Only the derived counter stamps
+# that mark, because until the Huawei driver arrived every brand needed one.
+#
+# A battery whose device counts for itself never got that sensor, so it never
+# carried the mark, and one of them in a fleet zeroed the totals outright: 10.3
+# kWh charged on one battery and 3.97 on the other, the overview reading 0.00.
+# ----------------------------------------------------------------------
+from types import SimpleNamespace
+
+from custom_components.omnibattery.infra.coordinator import (
+    _stamp_native_daily_reset_dates,
+)
+
+
+def _native(data, has_daily=True):
+    coordinator = SimpleNamespace(
+        data=data, capabilities=SimpleNamespace(has_daily_energy_counters=has_daily)
+    )
+    _stamp_native_daily_reset_dates(coordinator)
+    return coordinator.data
+
+
+def test_a_device_counted_daily_value_is_marked_as_todays():
+    from homeassistant.util import dt as dt_util
+
+    today = dt_util.now().date().isoformat()
+    data = _native({"total_daily_charging_energy": 10.3,
+                    "total_daily_discharging_energy": 4.42})
+    assert data["total_daily_charging_energy_reset_date"] == today
+    assert data["total_daily_discharging_energy_reset_date"] == today
+
+
+def test_a_driver_with_a_derived_counter_is_left_alone():
+    """It stamps its own mark, and overwriting it would defeat the guard."""
+    data = _native({"total_daily_charging_energy": 3.97}, has_daily=False)
+    assert "total_daily_charging_energy_reset_date" not in data
+
+
+def test_a_value_that_did_not_arrive_gets_no_mark():
+    data = _native({"total_daily_discharging_energy": 4.42})
+    assert "total_daily_charging_energy_reset_date" not in data
+    assert "total_daily_discharging_energy_reset_date" in data
+
+
+def test_zero_is_a_value_and_gets_marked():
+    """Before the first charge of the day the figure is legitimately zero."""
+    data = _native({"total_daily_charging_energy": 0.0})
+    assert "total_daily_charging_energy_reset_date" in data
+
+
+# --- The device keeps its own midnight ---------------------------------
+#
+# Stamping every poll with today's date said the value was today's when it was
+# not. Just after local midnight the Huawei's own counter still held 14.13 kWh
+# while the Marstek had reset to 0.00; the aggregate accepted 14.18 as a
+# complete sum and latched it, and because it refuses same-day decreases the
+# figure stood untouched all day while the real total climbed to 6.17.
+
+def _stamping(has_daily=True):
+    """A coordinator that keeps its state across polls, as the real one does."""
+    coordinator = SimpleNamespace(
+        data={}, capabilities=SimpleNamespace(has_daily_energy_counters=has_daily)
+    )
+
+    def poll(value, today):
+        coordinator.data = {"total_daily_charging_energy": value}
+        import custom_components.omnibattery.infra.coordinator as mod
+        real_now = mod.dt_util.now
+        mod.dt_util.now = lambda: SimpleNamespace(date=lambda: SimpleNamespace(
+            isoformat=lambda: today))
+        try:
+            _stamp_native_daily_reset_dates(coordinator)
+        finally:
+            mod.dt_util.now = real_now
+        return coordinator.data.get("total_daily_charging_energy_reset_date")
+
+    return poll
+
+
+def test_a_stale_counter_keeps_yesterdays_mark_until_it_turns():
+    poll = _stamping()
+    assert poll(14.13, "2026-08-27") == "2026-08-27"
+    # Our midnight passes; the device's has not. The value has not moved.
+    assert poll(14.13, "2026-08-28") == "2026-08-27"
+    assert poll(14.13, "2026-08-28") == "2026-08-27"
+    # The device's counter turns over.
+    assert poll(0.0, "2026-08-28") == "2026-08-28"
+    # And keeps the new day's mark as it climbs again.
+    assert poll(2.0, "2026-08-28") == "2026-08-28"
+
+
+def test_a_counter_left_at_zero_needs_no_evidence():
+    """Nothing stale to carry, so waiting would strand the sum at nothing."""
+    poll = _stamping()
+    assert poll(0.0, "2026-08-27") == "2026-08-27"
+    assert poll(0.0, "2026-08-28") == "2026-08-28"
+    assert poll(1.4, "2026-08-28") == "2026-08-28"
+
+
+def test_first_sight_is_taken_at_face_value():
+    """A restart mid-day has nothing to compare against."""
+    poll = _stamping()
+    assert poll(9.9, "2026-08-28") == "2026-08-28"
+
+
+def test_a_same_day_climb_is_never_held_back():
+    poll = _stamping()
+    assert poll(1.0, "2026-08-28") == "2026-08-28"
+    assert poll(4.5, "2026-08-28") == "2026-08-28"
+    assert poll(6.17, "2026-08-28") == "2026-08-28"


### PR DESCRIPTION
Split out of #335 as you asked. Two coordinator fixes, one file plus its tests, no control-layer code and no dependency on the rest of that PR.

### A reported ceiling of zero is a missing answer, not a limit

A Marstek came back from a restart with both power registers reading 0. Adopting that shut the battery out of every allocation — it could neither charge nor discharge — and nothing would ever write those registers again, because the controller had stopped addressing a battery it believed could do nothing. Only a manual write to the number entity brought it back.

The last known ceiling now stands when the device reports 0, and the mismatch gets a warning that says which entity restores it.

### The daily reset stamp

The system totals refuse to add up unless every battery's daily figure is marked as belonging to today — a guard against summing one battery's fresh value with another's from before midnight. Only the derived counter stamped that mark, because until now every driver needed one. A driver whose device keeps its own daily counters never gets that sensor, so it never carried the mark, and one such battery in a fleet zeroed the system totals outright: **10.3 kWh charged on one battery and 3.97 on the other, with the overview reading 0.00.**

Stamping every poll as today was the obvious fix, and I shipped it first. It was wrong. A device keeps its own midnight, and for a few minutes either side of ours its counter still holds yesterday's accumulation. Marking that as today let the aggregate add a battery's fresh 0.00 to another's stale 14.13 and latch the sum — the aggregate refuses same-day decreases, so the wrong figure stood until the real total grew past it, which on the observed day was never.

The mark now waits for evidence that the device's own counter has turned: the value dropping below what was last seen. Until then the previous day's mark stays and the aggregate treats the sum as incomplete. Better no total than a wrong one that sticks.

A counter last seen at zero carries nothing stale, so it needs no such evidence. The function is gated on `has_daily_energy_counters`, which is itself the claim that the device resets daily.

### Tests

12 new tests in `tests/test_coordinator_device_reports.py` — the zero-ceiling cases for soft-max and writable-register drivers, and four midnight-transition cases that keep state across polls: our midnight before the device's, the device's counter turning, a counter last seen at zero, and a restart with no history.

### One thing you should know about the base

`tests/test_charge_delay.py::test_balance_needs_charge_unlocks_low_forecast` fails on current `release/v1.4.0` before this branch touches anything:

```
assert ctrl._charge_delay_status["unlock_reason"] == "low_forecast"
AssertionError: assert 'energy_balance' == 'low_forecast'
```

I verified it by stashing this change and running the test on the clean base. Not mine, and not fixed here — flagging it rather than folding an unrelated fix into a PR you want small.

Full suite on this branch: 1930 passed, 10 skipped, that one pre-existing failure.
