### PR TITLE
Huawei: release instead of commanding while the strings are lit

### DIFF
--- a/custom_components/omnibattery/drivers/huawei.py
+++ b/custom_components/omnibattery/drivers/huawei.py
@@ -112,6 +112,13 @@ _PV_LIT_VOLTAGE_V = 100.0
 # below 100 V, so if a second installation disagrees, these numbers are where
 # to look first rather than the logic around them.
 _PV_HARVEST_THRESHOLD_W = 150.0
+# A band either side of it, because the dawn ramp crawls across the threshold
+# rather than stepping over it. Measured 2 September on a cloudless morning:
+# twenty minutes wobbling between 123 W and 214 W around the 150 W mark, with
+# irradiance rising smoothly throughout — so the wobble is the array, not the
+# weather. A bare comparison would flip the gate on every one of those, and
+# each flip costs a write the inverter answers by derating.
+_PV_HARVEST_HYSTERESIS_W = 50.0
 # How often a held verdict is re-checked by letting go for a moment. The cost
 # is a slice of command time each interval; the alternative is missing sunrise.
 _PV_PROBE_INTERVAL_S = 120.0
@@ -1015,7 +1022,11 @@ class HuaweiSolarDriver(BatteryDriver):
             # No reading is not evidence either way; the last verdict stands.
             return
 
-        if float(harvest) > _PV_HARVEST_THRESHOLD_W:
+        # Latching, with the band above on the way in and below on the way out.
+        threshold = _PV_HARVEST_THRESHOLD_W + (
+            -_PV_HARVEST_HYSTERESIS_W if self._pv_lit else _PV_HARVEST_HYSTERESIS_W
+        )
+        if float(harvest) > threshold:
             self._pv_lit = True
             self._pv_verdict_monotonic = now
             self._pv_probe_until = 0.0

--- a/custom_components/omnibattery/drivers/huawei.py
+++ b/custom_components/omnibattery/drivers/huawei.py
@@ -106,6 +106,11 @@ _PV_LIT_VOLTAGE_V = 100.0
 # while the strings already stand near 300 V — time the battery is needlessly
 # refused. Set low deliberately: too high curtails a roof that is genuinely
 # producing, too low only costs availability.
+#
+# Both this and the voltage threshold above come from a single installation —
+# one ~374 V array on a SUN2000-8K. A smaller string can genuinely produce
+# below 100 V, so if a second installation disagrees, these numbers are where
+# to look first rather than the logic around them.
 _PV_HARVEST_THRESHOLD_W = 150.0
 # How often a held verdict is re-checked by letting go for a moment. The cost
 # is a slice of command time each interval; the alternative is missing sunrise.
@@ -1158,6 +1163,16 @@ class HuaweiSolarDriver(BatteryDriver):
             # cycle, so they must keep being polled even with their entities off.
             "inverter_max_power", "inverter_ac_power", "battery_power",
             "charging_cutoff_capacity", "discharging_cutoff_capacity",
+            # Inputs of the PV gate (see _update_pv_gate). Without these the
+            # gate cannot form a verdict at all: the harvest reads as absent, so
+            # the verdict stays at its initial "not lit" and the driver commands
+            # through full sun — the failure the gate exists to prevent, put
+            # back by an entity toggle. Solar Power is user-facing, and the
+            # string voltages are enabled_by_default False and only arrive
+            # dragged along by mppt{n}_power, so there are two switches between
+            # this gate and its evidence.
+            "solar_power",
+            *(f"pv{index}_voltage" for index in range(1, _MAX_PV_STRINGS + 1)),
         })
 
     # --- concrete methods the coordinator calls without isinstance guards ----

--- a/custom_components/omnibattery/drivers/huawei.py
+++ b/custom_components/omnibattery/drivers/huawei.py
@@ -100,6 +100,23 @@ _TARGET_MODE_TIME = 0
 # clock. Measured on the reference installation: 374 V under sun, 0 V at night.
 _PV_LIT_VOLTAGE_V = 100.0
 
+# Voltage alone cannot tell a bright morning from a dim one, so it is paired
+# with harvested power (32064). Measured across three dawns on the reference
+# installation, the array sits below this for 45-50 minutes after first light
+# while the strings already stand near 300 V — time the battery is needlessly
+# refused. Set low deliberately: too high curtails a roof that is genuinely
+# producing, too low only costs availability.
+_PV_HARVEST_THRESHOLD_W = 150.0
+# How often a held verdict is re-checked by letting go for a moment. The cost
+# is a slice of command time each interval; the alternative is missing sunrise.
+_PV_PROBE_INTERVAL_S = 120.0
+# How long a release must stand before the reading means anything. The tracker
+# recovered in 6 s when measured (288 W to 5054 W); this leaves margin.
+_PV_PROBE_SETTLE_S = 15.0
+# When to give up on a probe whose release never reached the hardware. Longer
+# than the settle plus _MIN_WRITE_INTERVAL_S, which throttles the release write.
+_PV_PROBE_WINDOW_S = 45.0
+
 # Slave ids worth trying when scanning. 1 is the factory default for a direct
 # connection; the rest are what dongles and energy managers hand out. Kept short
 # because each one costs a connection, and the inverter needs 1.5 s of silence
@@ -422,8 +439,14 @@ class HuaweiSolarDriver(BatteryDriver):
         # Which pack slots are populated, learned from the packs that answer.
         # Empty until one has, so a failed read never hides a pack that exists.
         self._packs: set[int] = set()
-        # Strings lit but not harvested — see read_telemetry.
+        # Whether the roof is producing enough to leave the inverter alone.
+        # See _update_pv_gate for why that takes two signals rather than one.
         self._pv_lit = False
+        self._strings_lit = False
+        # Monotonic deadline of a probe in progress, 0.0 when none is.
+        self._pv_probe_until = 0.0
+        # When the verdict last came from a reading this driver could trust.
+        self._pv_verdict_monotonic = 0.0
         self._serial: Optional[str] = None
         # Last command actually written, so the deadband can compare against what
         # the hardware was told rather than against what it currently delivers.
@@ -664,16 +687,8 @@ class HuaweiSolarDriver(BatteryDriver):
         if storage is not None:
             self._storage_model = _STORAGE_MODELS.get(int(storage)) or self._storage_model
 
-        # Is there light on the panels? See _pv_lit for why that decides whether
-        # this driver may command anything at all.
-        voltages = [
-            snapshot.get(f"pv{index}_voltage")
-            for index in range(1, self._pv_strings + 1)
-        ]
-        if any(volts is not None for volts in voltages):
-            self._pv_lit = any(
-                volts is not None and volts > _PV_LIT_VOLTAGE_V for volts in voltages
-            )
+        # Whether this driver may command at all. See _update_pv_gate.
+        self._update_pv_gate(snapshot)
 
         for index in (1, 2, 3):
             if snapshot.get(f"pack{index}_serial_number") or snapshot.get(
@@ -768,7 +783,7 @@ class HuaweiSolarDriver(BatteryDriver):
             min(self._ceiling("charge"), int(net_power_w)),
         )
 
-        if applied != 0 and self._pv_lit:
+        if applied != 0 and self._hands_off():
             # A forcible command on this hybrid is not a request but a ceiling:
             # the inverter produces exactly what the command asks for and
             # curtails the rest of the roof. Measured with a 315 W charge
@@ -935,6 +950,103 @@ class HuaweiSolarDriver(BatteryDriver):
             battery_power_w=int(battery_power) if battery_power is not None else None,
             applied=echo,
         )
+
+    def _hands_off(self) -> bool:
+        """Whether the inverter is to be left to its own regulation right now."""
+        return self._pv_lit or bool(self._pv_probe_until)
+
+    def _update_pv_gate(self, snapshot: dict) -> None:
+        """Decide whether the roof is producing enough to leave alone.
+
+        Two signals, and neither is sufficient by itself.
+
+        **String voltage says whether it is day**, and it survives our own
+        commands: a forcible discharge holds the tracker down and the panels
+        sit at open-circuit voltage — 374 V at 0.00 A — so voltage still reads
+        daylight. What it cannot do is tell a bright morning from a dim one. An
+        overcast dawn stands near 300 V while the array makes 50 W, and
+        refusing to command there costs the house a discharge it needs, for
+        nothing. Measured across three dawns on the reference installation,
+        that band runs 45-50 minutes.
+
+        **Harvested power says how much there is to lose**, and is the quantity
+        that actually matters — but a low reading is only honest while this
+        driver is released. Once a command stands, the production it suppresses
+        is our own artefact, and gating on it would read a curtailed roof as
+        darkness, keep commanding, and keep the roof curtailed. That is the
+        failure the voltage test was introduced to stop: a discharge commanded
+        at 04:32 against a dark sky, still standing at 09:22.
+
+        A *high* reading is a different matter. Our command can only ever push
+        this number down, never up, so production above the threshold is
+        decisive whatever the driver is doing — that is what hands control back
+        at sunrise without waiting for anything.
+
+        A low reading while commanding is the one ambiguous case, and the only
+        one that needs a probe: let go, wait for the tracker to find its own
+        maximum, and read again. A probe costs seconds of curtailment. Not
+        probing costs a day of it.
+        """
+        now = asyncio.get_running_loop().time()
+
+        voltages = [
+            snapshot.get(f"pv{index}_voltage")
+            for index in range(1, self._pv_strings + 1)
+        ]
+        if any(volts is not None for volts in voltages):
+            self._strings_lit = any(
+                volts is not None and volts > _PV_LIT_VOLTAGE_V for volts in voltages
+            )
+
+        if not self._strings_lit:
+            # Night needs no second opinion, and nothing is being curtailed.
+            self._pv_lit = False
+            self._pv_probe_until = 0.0
+            self._pv_verdict_monotonic = now
+            return
+
+        harvest = snapshot.get("solar_power")
+        if harvest is None:
+            # No reading is not evidence either way; the last verdict stands.
+            return
+
+        if float(harvest) > _PV_HARVEST_THRESHOLD_W:
+            self._pv_lit = True
+            self._pv_verdict_monotonic = now
+            self._pv_probe_until = 0.0
+            return
+
+        released = (
+            self._last_written_w in (None, 0)
+            and now - self._last_write_monotonic >= _PV_PROBE_SETTLE_S
+        )
+        if released:
+            # Nothing of ours is holding the tracker down, so a low reading is
+            # the roof's own answer and the battery is ours to command.
+            self._pv_lit = False
+            self._pv_verdict_monotonic = now
+            self._pv_probe_until = 0.0
+            return
+
+        if self._pv_probe_until:
+            if now >= self._pv_probe_until:
+                # The release never reached the hardware — the write was
+                # refused, or something else is commanding this battery.
+                # Stop pretending to measure and wait out the interval.
+                _LOGGER.debug(
+                    "Huawei driver: PV probe expired without a usable reading"
+                )
+                self._pv_probe_until = 0.0
+                self._pv_verdict_monotonic = now
+            return
+
+        if now - self._pv_verdict_monotonic >= _PV_PROBE_INTERVAL_S:
+            _LOGGER.info(
+                "Huawei driver: releasing briefly to re-read the roof — %.0fW "
+                "reported while commanding is not evidence of darkness",
+                float(harvest),
+            )
+            self._pv_probe_until = now + _PV_PROBE_WINDOW_S
 
     def _should_write(self, applied: int) -> bool:
         """Whether this set-point is worth four Modbus writes and a 10 s ramp."""

--- a/custom_components/omnibattery/drivers/huawei.py
+++ b/custom_components/omnibattery/drivers/huawei.py
@@ -1125,7 +1125,21 @@ class HuaweiSolarDriver(BatteryDriver):
         The subtraction deliberately excludes this battery's own contribution:
         the ceiling has to describe what PV occupies, not what the battery is
         currently doing, or the limit would chase its own output and oscillate.
+
+        Zero while the PV gate is closed, which is the honest answer and not a
+        special case. The allocator hands out shares against this limit and
+        then believes the battery was served; leaving the static envelope in
+        place would have it allocate a discharge that ``apply_setpoint`` is
+        about to refuse, so the fleet under-delivers and no other battery picks
+        up the slack. Saying zero up front moves that share to a battery that
+        can actually deliver it.
+
+        There is no charge equivalent — the allocator has no comparable seam on
+        that side, so a refused charge is still invisible to it. See §13.9 of
+        the driver assessment.
         """
+        if self._hands_off():
+            return 0
         ceiling = data.get("inverter_max_power")
         ac_power = data.get("inverter_ac_power")
         battery_power = data.get("battery_power")

--- a/custom_components/omnibattery/drivers/huawei.py
+++ b/custom_components/omnibattery/drivers/huawei.py
@@ -459,6 +459,9 @@ class HuaweiSolarDriver(BatteryDriver):
         self._pv_probe_until = 0.0
         # When the verdict last came from a reading this driver could trust.
         self._pv_verdict_monotonic = 0.0
+        # Last harvest this driver had reason to believe, in watts. None when
+        # the standing command makes the reading its own artefact.
+        self._pv_harvest_w: Optional[float] = None
         self._serial: Optional[str] = None
         # Last command actually written, so the deadband can compare against what
         # the hardware was told rather than against what it currently delivers.
@@ -795,7 +798,7 @@ class HuaweiSolarDriver(BatteryDriver):
             min(self._ceiling("charge"), int(net_power_w)),
         )
 
-        if applied != 0 and self._hands_off():
+        if self._refuses(applied):
             # A forcible command on this hybrid is not a request but a ceiling:
             # the inverter produces exactly what the command asks for and
             # curtails the rest of the roof. Measured with a 315 W charge
@@ -963,9 +966,51 @@ class HuaweiSolarDriver(BatteryDriver):
             applied=echo,
         )
 
-    def _hands_off(self) -> bool:
-        """Whether the inverter is to be left to its own regulation right now."""
+    def _gate_closed(self) -> bool:
+        """Whether the roof is producing enough to be worth protecting."""
         return self._pv_lit or bool(self._pv_probe_until)
+
+    def _refuses(self, applied: int) -> bool:
+        """Whether the gate refuses this particular command.
+
+        **Discharge is refused outright.** A forcible discharge serves the
+        house from the battery and leaves the tracker down entirely — 374 V at
+        0.00 A — so the whole roof is lost for as long as it stands. There is
+        nothing to weigh.
+
+        **Charge is refused only where it would bind.** A forcible command is a
+        ceiling on production, and a ceiling above what the array can reach is
+        not a constraint at all. Measured 2 September on a cloudless morning,
+        with an irradiance sensor and a separate array as controls:
+
+        * 400 W commanded against 1839 W of harvest produced **363 W** — the
+          roof cut to a fifth while irradiance held, recovering to 1936 W seven
+          seconds after the release;
+        * 3000 W commanded against 1936 W produced **2020 W**, tracking the sun
+          as if nothing had been sent.
+
+        So a charge at or above the harvest costs nothing — and that is the one
+        charge worth having, the cheap-price slot in the middle of a lit day,
+        which a symmetric gate refuses for no gain.
+
+        The rule is self-stabilising, which is what makes it safe to compare
+        against a harvest read while commanding: an allowed charge is never a
+        binding cap, so the reading stays true MPP exactly while this driver is
+        commanding; and a refused charge is never sent, so it cannot suppress
+        the evidence that refused it. The one way out of that is the sun rising
+        to meet a standing command, which :meth:`_update_pv_gate` detects by
+        refusing to believe a harvest that has converged on it.
+        """
+        if applied == 0 or not self._gate_closed():
+            return False
+        if applied < 0:
+            return True
+        if self._pv_harvest_w is None:
+            # No harvest this driver can believe. Refuse, as the symmetric gate
+            # always did — a wrong "allow" curtails the roof, a wrong "refuse"
+            # only costs a charge.
+            return True
+        return applied < self._pv_harvest_w
 
     def _update_pv_gate(self, snapshot: dict) -> None:
         """Decide whether the roof is producing enough to leave alone.
@@ -1012,6 +1057,7 @@ class HuaweiSolarDriver(BatteryDriver):
 
         if not self._strings_lit:
             # Night needs no second opinion, and nothing is being curtailed.
+            self._pv_harvest_w = 0.0
             self._pv_lit = False
             self._pv_probe_until = 0.0
             self._pv_verdict_monotonic = now
@@ -1021,6 +1067,29 @@ class HuaweiSolarDriver(BatteryDriver):
         if harvest is None:
             # No reading is not evidence either way; the last verdict stands.
             return
+
+        # Whether the reading can be believed depends on what this driver has
+        # standing. Nothing: it is the roof's own answer. A charge clear of the
+        # harvest: the ceiling is never reached, so the tracker is still at its
+        # own maximum — that is what lets an allowed charge keep its evidence
+        # alive. A charge the harvest has converged on, or any discharge: the
+        # number is our own doing and means nothing.
+        #
+        # This governs the *value*, not the verdict. A high reading still says
+        # the roof is producing whatever this driver is doing, because a command
+        # can only push it down — but a floor is not a maximum, and only a
+        # maximum is safe to compare a charge against.
+        standing = self._last_written_w or 0
+        if standing == 0:
+            trustworthy = now - self._last_write_monotonic >= _PV_PROBE_SETTLE_S
+        elif standing > 0:
+            trustworthy = standing > float(harvest) + _PV_HARVEST_HYSTERESIS_W
+        else:
+            trustworthy = False
+        # Refusing to guess is what makes the sun rising past a standing charge
+        # self-correcting: the charge is refused on the next cycle, the release
+        # restores a true reading, and the decision is retaken against it.
+        self._pv_harvest_w = float(harvest) if trustworthy else None
 
         # Latching, with the band above on the way in and below on the way out.
         threshold = _PV_HARVEST_THRESHOLD_W + (
@@ -1032,13 +1101,9 @@ class HuaweiSolarDriver(BatteryDriver):
             self._pv_probe_until = 0.0
             return
 
-        released = (
-            self._last_written_w in (None, 0)
-            and now - self._last_write_monotonic >= _PV_PROBE_SETTLE_S
-        )
-        if released:
-            # Nothing of ours is holding the tracker down, so a low reading is
-            # the roof's own answer and the battery is ours to command.
+        if trustworthy:
+            # A low reading this driver can believe is the roof's own answer,
+            # and the battery is ours to command.
             self._pv_lit = False
             self._pv_verdict_monotonic = now
             self._pv_probe_until = 0.0
@@ -1149,7 +1214,7 @@ class HuaweiSolarDriver(BatteryDriver):
         that side, so a refused charge is still invisible to it. See §13.9 of
         the driver assessment.
         """
-        if self._hands_off():
+        if self._refuses(-1):
             return 0
         ceiling = data.get("inverter_max_power")
         ac_power = data.get("inverter_ac_power")

--- a/custom_components/omnibattery/drivers/huawei.py
+++ b/custom_components/omnibattery/drivers/huawei.py
@@ -95,6 +95,11 @@ _REG_CHARGE_CUTOFF = 47081             # u16, tenths of a percent
 _REG_DISCHARGE_CUTOFF = 47082          # u16, tenths of a percent
 _TARGET_MODE_TIME = 0
 
+# A string carries voltage when there is light on it and collapses in the dark,
+# which makes it a reliable daylight signal needing no forecast, sun elevation or
+# clock. Measured on the reference installation: 374 V under sun, 0 V at night.
+_PV_LIT_VOLTAGE_V = 100.0
+
 # Slave ids worth trying when scanning. 1 is the factory default for a direct
 # connection; the rest are what dongles and energy managers hand out. Kept short
 # because each one costs a connection, and the inverter needs 1.5 s of silence
@@ -417,6 +422,8 @@ class HuaweiSolarDriver(BatteryDriver):
         # Which pack slots are populated, learned from the packs that answer.
         # Empty until one has, so a failed read never hides a pack that exists.
         self._packs: set[int] = set()
+        # Strings lit but not harvested — see read_telemetry.
+        self._pv_lit = False
         self._serial: Optional[str] = None
         # Last command actually written, so the deadband can compare against what
         # the hardware was told rather than against what it currently delivers.
@@ -657,6 +664,17 @@ class HuaweiSolarDriver(BatteryDriver):
         if storage is not None:
             self._storage_model = _STORAGE_MODELS.get(int(storage)) or self._storage_model
 
+        # Is there light on the panels? See _pv_lit for why that decides whether
+        # this driver may command anything at all.
+        voltages = [
+            snapshot.get(f"pv{index}_voltage")
+            for index in range(1, self._pv_strings + 1)
+        ]
+        if any(volts is not None for volts in voltages):
+            self._pv_lit = any(
+                volts is not None and volts > _PV_LIT_VOLTAGE_V for volts in voltages
+            )
+
         for index in (1, 2, 3):
             if snapshot.get(f"pack{index}_serial_number") or snapshot.get(
                 f"pack{index}_firmware_version"
@@ -749,6 +767,24 @@ class HuaweiSolarDriver(BatteryDriver):
             -self._ceiling("discharge"),
             min(self._ceiling("charge"), int(net_power_w)),
         )
+
+        if applied != 0 and self._pv_lit:
+            # A forcible command on this hybrid is not a request but a ceiling:
+            # the inverter produces exactly what the command asks for and
+            # curtails the rest of the roof. Measured with a 315 W charge
+            # standing: 288 W harvested, and 5054 W six seconds after it ended.
+            # A discharge does the same, holding the tracker down entirely.
+            #
+            # So while there is light on the panels this driver commands
+            # nothing. The inverter's own regulation harvests everything and
+            # runs the battery from it, which is what the release hands back to.
+            _LOGGER.info(
+                "Huawei driver: releasing instead of commanding %dW — a forcible "
+                "command caps this inverter's own production while the sun is on "
+                "the panels",
+                applied,
+            )
+            applied = 0
 
         if not self._should_write(applied):
             # Nothing was sent, so report what is actually in force rather than

--- a/site-docs/reference/driver-assessment-huawei.md
+++ b/site-docs/reference/driver-assessment-huawei.md
@@ -414,15 +414,46 @@ real deficit — which is what asks for discharge. The command goes on justifyin
 itself and survives sunrise: commanded at 04:32 against a genuinely dark sky,
 still standing at 09:22.
 
-**So while there is light on the panels, this driver commands nothing.** It
-releases instead and leaves the inverter to its own regulation, which harvests
+**So while the roof is producing, this driver commands nothing.** It releases
+instead and leaves the inverter to its own regulation, which harvests
 everything and runs the battery from it. That is not a workaround: on a
-DC-coupled hybrid the inverter is the better controller during daylight, because
-it is the only party that knows what the array could be making.
+DC-coupled hybrid the inverter is the better controller during daylight,
+because it is the only party that knows what the array could be making.
 
-The daylight test comes from the strings themselves — a string carries voltage
-when there is light on it and collapses in the dark — so no forecast, sun
-elevation or clock is involved.
+#### What "producing" means, and why it takes two signals
+
+The first test was string voltage alone — a string carries voltage in light and
+collapses in the dark, so no forecast, sun elevation or clock is involved. It
+survives our own commands, which is exactly why it was chosen: under a forcible
+discharge the panels sit at open-circuit voltage and still read daylight.
+
+What it cannot do is tell a bright morning from a dim one. An overcast dawn
+stands near 300 V while the array makes 50 W, and refusing to command there
+costs the house a discharge it needs, for nothing. Measured across three dawns
+on the reference installation, from the first non-zero watt to a sustained
+150 W:
+
+| Dawn | First harvest | Sustained >150 W | Band |
+|---|---|---|---|
+| 30.08 | 06:55 | 07:45 | 50 min |
+| 31.08 | 06:15 | 07:00 | 45 min |
+| 01.09 | 06:48 | 07:38 | 50 min |
+
+So harvested power (32064) is the second signal — with one asymmetry that makes
+it usable at all. A *low* reading proves nothing while a command stands,
+because the production it suppresses is the command's own doing; gating on it
+would read a curtailed roof as darkness, keep commanding, and keep the roof
+curtailed. A *high* reading is decisive whatever the driver is doing, since a
+command can only ever push that number down. That asymmetry is what hands
+control back at sunrise without waiting for anything.
+
+The remaining case — commanding, strings lit, roof quiet — is genuinely
+ambiguous, and is resolved by letting go for a moment and reading again. The
+release is throttled like any other write, so a probe costs the settle window
+plus the ramp interval, about 20 s in every 120 s. Sunrise is worth more.
+
+The threshold is set low on purpose. Too high curtails a roof that is genuinely
+producing; too low only costs availability in the dim band.
 
 What this costs is real and belongs in the decision: **a Huawei battery is only
 under Omnibattery's control after dark.** During the day it follows its own

--- a/site-docs/reference/driver-assessment-huawei.md
+++ b/site-docs/reference/driver-assessment-huawei.md
@@ -429,15 +429,33 @@ discharge the panels sit at open-circuit voltage and still read daylight.
 
 What it cannot do is tell a bright morning from a dim one. An overcast dawn
 stands near 300 V while the array makes 50 W, and refusing to command there
-costs the house a discharge it needs, for nothing. Measured across three dawns
-on the reference installation, from the first non-zero watt to a sustained
-150 W:
+costs the house a discharge it needs, for nothing.
 
-| Dawn | First harvest | Sustained >150 W | Band |
-|---|---|---|---|
-| 30.08 | 06:55 | 07:45 | 50 min |
-| 31.08 | 06:15 | 07:00 | 45 min |
-| 01.09 | 06:48 | 07:38 | 50 min |
+The first three dawns below were measured from the first non-zero watt, because
+string voltage was not being recorded on the reference installation at the time.
+They are therefore a **lower bound**. The fourth is measured from the quantity
+the gate actually uses — the strings crossing 100 V — and the band is roughly
+double:
+
+| Dawn | Gate closes | Sustained >150 W | Band | Measured from |
+|---|---|---|---|---|
+| 30.08 | 06:55 | 07:45 | 50 min | first watt (lower bound) |
+| 31.08 | 06:15 | 07:00 | 45 min | first watt (lower bound) |
+| 01.09 | 06:48 | 07:38 | 50 min | first watt (lower bound) |
+| **02.09** | **06:12:56** | **07:50** | **97 min** | **100 V on the strings** |
+
+On 2 September the strings jumped from 0 V to 123.8 V in a single poll at
+06:12:56 — the inverter waking, not a gradual rise — which is 23 minutes before
+sunrise at 06:36. The array made 1 W or less until 07:12 and did not hold above
+150 W until 07:50.
+
+That the roof genuinely had nothing to give is worth establishing rather than
+assuming, because a forcible discharge was standing for part of that window and
+would suppress production by itself. An irradiance sensor independent of the
+inverter settles it: 5 lx at 06:21, 98 lx at 06:42, 250 lx at 07:10. There was
+no production to curtail. It also confirms the morning was cloudless — the
+reading climbed smoothly from 1486 lx to 1955 lx across the crossing with no
+dips — so 97 minutes is the *clear-sky* band, and an overcast dawn is longer.
 
 So harvested power (32064) is the second signal — with one asymmetry that makes
 it usable at all. A *low* reading proves nothing while a command stands,
@@ -454,6 +472,13 @@ plus the ramp interval, about 20 s in every 120 s. Sunrise is worth more.
 
 The threshold is set low on purpose. Too high curtails a roof that is genuinely
 producing; too low only costs availability in the dim band.
+
+It also carries a band either side, because the ramp crawls across the threshold
+rather than stepping over it: on 2 September the harvest spent twenty minutes
+wobbling between 123 W and 214 W around the 150 W mark while irradiance rose
+smoothly throughout. A bare comparison would flip the gate on every one of
+those, and each flip costs a write that this inverter answers by derating the
+array — the fault the gate exists to avoid, reintroduced by the gate itself.
 
 What this costs is real and belongs in the decision: **a Huawei battery is only
 under Omnibattery's control after dark.** During the day it follows its own

--- a/site-docs/reference/driver-assessment-huawei.md
+++ b/site-docs/reference/driver-assessment-huawei.md
@@ -480,10 +480,53 @@ smoothly throughout. A bare comparison would flip the gate on every one of
 those, and each flip costs a write that this inverter answers by derating the
 array — the fault the gate exists to avoid, reintroduced by the gate itself.
 
-What this costs is real and belongs in the decision: **a Huawei battery is only
-under Omnibattery's control after dark.** During the day it follows its own
-energy manager. An installation whose second battery is AC-coupled still gets
-full control of that one, which is where the surplus can be steered.
+#### Charge is refused only where it binds
+
+A forcible command is a *ceiling* on production, and a ceiling above what the
+array can reach is not a constraint at all. Measured 2 September on a cloudless
+morning, with an irradiance sensor and a separate array on the same roof as
+controls — both moved by about 1 % while the hybrid moved by a factor of five:
+
+| | Roof DC | Irradiance | Separate array |
+|---|---|---|---|
+| Uncommanded | 1839 W | 15 809 lx | 394 W |
+| **Charge 400 W** | **363 W** | 15 707 lx | 401 W |
+| Released, +7 s | 1936 W | 15 733 lx | 403 W |
+| **Charge 3000 W** | **2020 W** | 16 278 lx | 407 W |
+
+A command below the harvest becomes the production ceiling exactly. A command
+above it costs nothing — and that is the one charge worth having, the cheap
+half-hour in the middle of a lit day, which a symmetric gate refuses for no
+gain. So charge is refused only when it would bind; discharge stays refused
+outright, because it holds the tracker down whatever its size.
+
+That comparison is safe to make against a harvest read while commanding,
+because an allowed charge is never a binding cap and a refused charge is never
+sent. The one way out is the sun rising to meet a standing command, and the
+driver handles it by declining to believe a harvest that has converged on what
+it asked for.
+
+#### The limit: a self-curtailing inverter reads as darkness
+
+The harvest only means "what the roof can make" while something wants the
+power. PV has three destinations — house, battery, grid — so with the battery
+full and export capped, production must equal house load; curtailment *is* how
+any inverter limits output. If that load sits under the threshold, the array
+reports under 150 W in full sun and this gate opens.
+
+Neither signal can separate that from real darkness: the voltage is up either
+way, and releasing changes nothing because the inverter goes on curtailing
+whether commanded or not. It is stated here rather than guarded against,
+because it needs an export limit, a battery that fills, *and* a base load under
+150 W at the same time, and the third is demanding in a house with a hybrid and
+a battery in it. Guarding on state of charge instead would buy back the dawn
+refusal for a full battery, which is the larger of the two faults.
+
+What this costs is real and belongs in the decision: **a Huawei battery is
+under Omnibattery's control after dark, and during the day only for a charge it
+would not curtail.** Otherwise it follows its own energy manager. An
+installation whose second battery is AC-coupled still gets full control of that
+one, which is where the surplus can be steered.
 
 ### 13.9 A second battery is household load to the hybrid's manager
 
@@ -550,7 +593,8 @@ Firmware tested:    inverter V200R024C00SPC110, storage V200R025C00SPC103
 Documentation:      Solar Inverter Modbus Interface Definitions v05
 
 Verdict: SUITABLE WITH LIMITATIONS
-         Control is available after dark only (§13.8)
+         Discharge is available after dark only; charge also in
+         daylight, but only above what the roof is making (§13.8)
 
 Blocking items:
 - Real SOC:        N — register 37004, verified

--- a/site-docs/reference/driver-assessment-huawei.md
+++ b/site-docs/reference/driver-assessment-huawei.md
@@ -182,10 +182,15 @@ charge cutoff on the inverter and the discharge cutoff on the battery, so
 resolving against the configured battery device alone finds one and misses the
 other. The driver searches the whole config entry.
 
-**Watchdog.** Every command carries a duration (10 minutes as issued). If Home
-Assistant dies without unloading, the inverter drops the command by itself and
-returns to its own regulation. This is why a duration is sent rather than an
-open-ended command.
+**Watchdog — do not rely on it.** Every command carries a duration (10 minutes
+as issued), and the register still reads 10 while a command stands. On the
+reference installation a forcible discharge written at 04:32 was still in force
+at 09:22, five hours later, with the integration disabled for the last of them.
+Whatever the duration governs, it did not release this. The release has to be
+written, and it has to go out over the same path the command did: releasing
+through the `huawei_solar` service while writing registers directly addresses a
+device that does not exist on that path, and the failure is silent because
+shutdown suppresses the warning.
 
 ## 6. Feature degradation matrix
 
@@ -214,7 +219,9 @@ misbehaving first and a test second:
 - The dynamic discharge limit ignores the battery's own contribution.
 - No read group may hold a single key.
 - The inverter's AC total is not published as the battery's AC port.
-- Every form schema survives the serialisation the frontend needs (§13.8).
+- Every form schema survives the serialisation the frontend needs (§13.10).
+- Nothing is commanded at all while the strings carry voltage.
+- Shutdown clears the registers over the path the commands took.
 - An unpopulated pack slot produces no entities at all.
 - A battery device belonging to a different inverter is refused.
 - The limits form allows more than the battery reports today.
@@ -390,7 +397,65 @@ padding, so the pack 1 firmware string decodes to nothing, and the battery
 flapped in and out of the pool every three seconds all day. Groups are now one
 per cadence rather than one per block.
 
-### 13.8 A form schema must survive serialisation
+### 13.8 A forcible command caps the inverter's own production
+
+The worst fault this driver has caused, and the one most specific to a hybrid.
+
+**A forcible command is not a request but a ceiling.** The inverter produces
+exactly what it was told and curtails the rest of the roof. Caught in the act
+with a 315 W charge standing: 288 W harvested from an array that made 5054 W six
+seconds after the command ended, while a separate balcony array on the same roof
+held steady throughout — so not weather.
+
+A discharge is worse still. It serves the house from the battery and leaves the
+MPPT tracker down entirely, so the panels sit at open-circuit voltage drawing
+nothing: 374 V at 0.00 A. And with the roof producing nothing, the meter shows a
+real deficit — which is what asks for discharge. The command goes on justifying
+itself and survives sunrise: commanded at 04:32 against a genuinely dark sky,
+still standing at 09:22.
+
+**So while there is light on the panels, this driver commands nothing.** It
+releases instead and leaves the inverter to its own regulation, which harvests
+everything and runs the battery from it. That is not a workaround: on a
+DC-coupled hybrid the inverter is the better controller during daylight, because
+it is the only party that knows what the array could be making.
+
+The daylight test comes from the strings themselves — a string carries voltage
+when there is light on it and collapses in the dark — so no forecast, sun
+elevation or clock is involved.
+
+What this costs is real and belongs in the decision: **a Huawei battery is only
+under Omnibattery's control after dark.** During the day it follows its own
+energy manager. An installation whose second battery is AC-coupled still gets
+full control of that one, which is where the surplus can be steered.
+
+### 13.9 A second battery is household load to the hybrid's manager
+
+Anything drawing power behind the same meter reads as consumption to the
+inverter's energy manager, and a second battery is no exception. That cuts both
+ways, and both matter.
+
+It is what leaves any control at all during daylight. The hybrid cannot be
+commanded while the sun is on the panels (§13.8), so it would be easy to assume
+this integration can only stand aside until dark. It cannot command the hybrid —
+but on an installation with a second, AC-coupled battery it can command that
+one, and the manager has no way to refuse: it sees load and covers it. A command
+to the AC battery is a decision that takes effect, not a preference that gets
+overruled.
+
+It is also the hazard. Whatever is asked for gets covered — from the sun when it
+is there, and **from the hybrid's own battery when it is not**. A charge command
+larger than the real surplus therefore pumps one battery into the other through
+two conversions, while the meter sits at zero and nothing looks wrong. Observed
+with no such bound in place: 1391 W of PV over a 529 W house, one battery taking
+in 1110 W while the other gave up 205 W, the meter reading 3 W.
+
+The bound that prevents it is the *uncovered* surplus — what the meter would
+read if every battery stopped — rather than the fleet's charging capacity. That
+belongs to the control layer rather than to this driver, and is noted here
+because the hybrid is what makes it necessary.
+
+### 13.10 A form schema must survive serialisation
 
 Home Assistant hands the frontend a *serialised* copy of every form schema, and
 not every voluptuous construct has a serialised form. A `vol.Any` in the
@@ -411,6 +476,7 @@ Firmware tested:    inverter V200R024C00SPC110, storage V200R025C00SPC103
 Documentation:      Solar Inverter Modbus Interface Definitions v05
 
 Verdict: SUITABLE WITH LIMITATIONS
+         Control is available after dark only (§13.8)
 
 Blocking items:
 - Real SOC:        N — register 37004, verified

--- a/site-docs/reference/driver-assessment-huawei.md
+++ b/site-docs/reference/driver-assessment-huawei.md
@@ -486,6 +486,24 @@ read if every battery stopped — rather than the fleet's charging capacity. Tha
 belongs to the control layer rather than to this driver, and is noted here
 because the hybrid is what makes it necessary.
 
+#### The allocator has one seam, and only on the discharge side
+
+When the PV gate closes, a discharge asked of this battery is refused. The
+allocator does not learn that from the refusal itself: it has already handed
+out this battery's share and treats it as served, so the fleet under-delivers
+and nothing picks up the slack.
+
+`dynamic_discharge_limit_w` is the seam that fixes it, because the allocator
+reads it before deciding. Reporting zero while the gate is closed moves the
+share to a battery that can deliver it, and needs no control-layer change.
+
+**There is no charge equivalent.** Nothing narrows what the allocator believes
+this battery will accept, so a charge refused by the gate is still invisible to
+it — the surplus is allocated here, declined, and goes to the grid. On a
+DC-coupled hybrid that loss is smaller than it sounds, since the inverter is
+charging the battery from the strings anyway, but it is a real gap and it
+belongs to the control layer rather than to this driver.
+
 ### 13.10 A form schema must survive serialisation
 
 Home Assistant hands the frontend a *serialised* copy of every form schema, and

--- a/tests/test_huawei_driver.py
+++ b/tests/test_huawei_driver.py
@@ -2102,9 +2102,32 @@ async def test_an_overcast_dawn_does_not_block_the_battery():
 
 @pytest.mark.asyncio
 async def test_the_threshold_is_on_harvest_not_on_voltage():
-    driver = _driver(_fake_client(_dim_blocks(watts=151)))
+    driver = _driver(_fake_client(_dim_blocks(watts=201)))
     await driver.read_telemetry()
     assert driver._pv_lit is True
+
+
+@pytest.mark.asyncio
+async def test_the_dawn_ramp_does_not_flip_the_gate_on_every_wobble():
+    """Measured 2 September: twenty minutes between 123 W and 214 W around the
+    threshold, with irradiance rising smoothly — the array, not the weather."""
+    driver = _driver(_fake_client(_dim_blocks(watts=123)))
+    await driver.read_telemetry()
+    assert driver._pv_lit is False
+
+    for watts, expected in ((176, False), (214, True), (152, True), (123, True)):
+        driver._client.async_read_holding_block = AsyncMock(
+            side_effect=lambda start, count, w=watts: _dim_blocks(watts=w).get(start)
+        )
+        await driver.read_telemetry()
+        assert driver._pv_lit is expected, f"{watts} W gave {driver._pv_lit}"
+
+    # Clear of the band on the way out, and it lets go.
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _dim_blocks(watts=99).get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_lit is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_huawei_driver.py
+++ b/tests/test_huawei_driver.py
@@ -2729,3 +2729,121 @@ async def test_after_dark_the_full_envelope_is_offered():
         {"inverter_max_power": 8800, "inverter_ac_power": 0, "battery_power": 0}
     ) == 8800
 
+
+# ----------------------------------------------------------------------
+# A forcible command is a ceiling on production, so a ceiling the array never
+# reaches is not a constraint. Measured 2 September against an irradiance
+# sensor and a separate array: 400 W against 1839 W of harvest produced 363 W,
+# recovering to 1936 W seven seconds after the release; 3000 W against 1936 W
+# produced 2020 W, tracking the sun as if nothing had been sent.
+#
+# Discharge has no such nuance — it holds the tracker down entirely.
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_a_charge_clear_of_the_harvest_is_allowed():
+    """The cheap midday slot, which a symmetric gate refused for no gain."""
+    driver = _driver(_fake_client(_lit_blocks(watts=1839)), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
+    assert driver._pv_harvest_w == 1839
+    assert (await driver.apply_setpoint(3000, read_back=False)).net_power_w == 3000
+
+
+@pytest.mark.asyncio
+async def test_a_charge_under_the_harvest_is_refused():
+    """400 W commanded against 1839 W cut the array to 363 W."""
+    driver = _driver(_fake_client(_lit_blocks(watts=1839)), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(400, read_back=False)).net_power_w == 0
+
+
+@pytest.mark.asyncio
+async def test_discharge_stays_refused_however_large():
+    """374 V at 0.00 A: the tracker is down whatever the number was."""
+    driver = _driver(_fake_client(_lit_blocks(watts=1839)), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(-6000, read_back=False)).net_power_w == 0
+    assert (await driver.apply_setpoint(-100, read_back=False)).net_power_w == 0
+
+
+@pytest.mark.asyncio
+async def test_the_sun_rising_to_meet_a_standing_charge_takes_it_back():
+    """An allowed charge keeps its own evidence alive only while it is clear of
+    the harvest. Once the two converge the reading is the command's own doing,
+    and believing it would pin the array just under what it could make."""
+    driver = _driver(_fake_client(_lit_blocks(watts=1839)), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(2000, read_back=False)).net_power_w == 2000
+    assert driver._last_written_w == 2000
+
+    # The sun rises to meet it: the reading is no longer evidence of anything.
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks(watts=1990).get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_harvest_w is None
+    driver._last_write_monotonic -= _MIN_WRITE_INTERVAL_S + 1
+    assert (await driver.apply_setpoint(2000, read_back=False)).net_power_w == 0
+
+    # Released, the roof reports what it can really make, and the same command
+    # is now plainly a cap.
+    driver._last_write_monotonic -= _PV_PROBE_SETTLE_S + 1
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks(watts=2500).get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_harvest_w == 2500
+    assert (await driver.apply_setpoint(2000, read_back=False)).net_power_w == 0
+
+
+@pytest.mark.asyncio
+async def test_after_dark_both_directions_are_commanded():
+    driver = _driver(_fake_client(_dark_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(3000, read_back=False)).net_power_w == 3000
+    driver._last_write_monotonic -= _MIN_WRITE_INTERVAL_S + 1
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == -2000
+
+
+# ----------------------------------------------------------------------
+# The allocator hands out shares against dynamic_discharge_limit_w before it
+# decides, so a hybrid that is about to refuse must say so there. Otherwise the
+# fleet allocates a discharge this battery declines, believes it was served,
+# and no other battery picks up the slack.
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_a_hands_off_huawei_yields_its_share_in_a_mixed_fleet():
+    from custom_components.omnibattery import _apply_driver_dynamic_limit
+
+    huawei = _driver(_fake_client(_lit_blocks(watts=1839)), hass=_hass_with_services())
+    await huawei.read_telemetry()
+    assert huawei._pv_lit is True
+
+    hybrid = MagicMock(
+        name="hybrid",
+        driver=huawei,
+        data={"inverter_max_power": 8800, "inverter_ac_power": 1839,
+              "battery_power": 0},
+    )
+    # The AC battery beside it: no dynamic limiter at all, so its envelope
+    # stands whatever the sun is doing.
+    ac_battery = MagicMock(name="ac", driver=MagicMock(spec=[]), data={})
+
+    assert _apply_driver_dynamic_limit(hybrid, 7000) == 0
+    assert _apply_driver_dynamic_limit(ac_battery, 2500) == 2500
+
+
+@pytest.mark.asyncio
+async def test_after_dark_the_hybrid_takes_its_share_back():
+    from custom_components.omnibattery import _apply_driver_dynamic_limit
+
+    huawei = _driver(_fake_client(_dark_blocks()), hass=_hass_with_services())
+    await huawei.read_telemetry()
+    hybrid = MagicMock(
+        name="hybrid",
+        driver=huawei,
+        data={"inverter_max_power": 8800, "inverter_ac_power": 0,
+              "battery_power": 0},
+    )
+    assert _apply_driver_dynamic_limit(hybrid, 7000) == 7000
+

--- a/tests/test_huawei_driver.py
+++ b/tests/test_huawei_driver.py
@@ -2654,3 +2654,55 @@ async def test_a_dim_dawn_is_still_read_with_the_entities_disabled():
     assert driver._pv_lit is False
     assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == -2000
 
+
+# ----------------------------------------------------------------------
+# The allocator hands out shares against dynamic_discharge_limit_w and then
+# believes the battery was served. A discharge the gate is about to refuse
+# must therefore not be allocated here in the first place.
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_a_closed_gate_takes_the_battery_out_of_the_allocation():
+    driver = _driver(_fake_client(_lit_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
+    assert driver.dynamic_discharge_limit_w(
+        {"inverter_max_power": 8800, "inverter_ac_power": 5000, "battery_power": 0}
+    ) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_dim_dawn_leaves_the_allocation_alone():
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert driver._pv_lit is False
+    assert driver.dynamic_discharge_limit_w(
+        {"inverter_max_power": 8800, "inverter_ac_power": 200, "battery_power": 0}
+    ) == 8600
+
+
+@pytest.mark.asyncio
+async def test_a_probe_also_takes_the_battery_out_of_the_allocation():
+    """While probing the driver lets go, so it cannot serve a share either."""
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    await driver.apply_setpoint(-2000, read_back=False)
+    driver._pv_verdict_monotonic -= _PV_PROBE_INTERVAL_S + 1
+    driver._last_write_monotonic -= _MIN_WRITE_INTERVAL_S + 1
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks(watts=0).get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_probe_until > 0.0
+    assert driver.dynamic_discharge_limit_w(
+        {"inverter_max_power": 8800, "inverter_ac_power": 200, "battery_power": 0}
+    ) == 0
+
+
+@pytest.mark.asyncio
+async def test_after_dark_the_full_envelope_is_offered():
+    driver = _driver(_fake_client(_dark_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert driver.dynamic_discharge_limit_w(
+        {"inverter_max_power": 8800, "inverter_ac_power": 0, "battery_power": 0}
+    ) == 8800
+

--- a/tests/test_huawei_driver.py
+++ b/tests/test_huawei_driver.py
@@ -2616,3 +2616,41 @@ def test_the_proxy_hint_still_reaches_the_user():
         description = strings[section]["step"]["battery_connection_huawei"]["description"]
         assert "{proxy_url}" in description, section
     assert _MODBUS_PROXY_URL.startswith("https://")
+
+
+# ----------------------------------------------------------------------
+# The gate is only as good as its inputs. The coordinator stops polling any
+# key whose entity is disabled unless the driver declares it a control
+# dependency, and Solar Power is a user-facing toggle — so without the
+# declaration a single switch in the entity list puts the 04:32-to-09:22
+# failure back, in full sun and with no warning.
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_the_gate_inputs_are_declared_control_dependencies():
+    keys = HuaweiSolarDriver.control_dependency_keys.fget(None)
+    assert "solar_power" in keys
+    for index in range(1, 5):
+        assert f"pv{index}_voltage" in keys
+
+
+@pytest.mark.asyncio
+async def test_the_gate_still_closes_when_its_entities_are_disabled():
+    """What the coordinator asks for once the user disables Solar Power and
+    MPPT Power: the declared dependencies are fetched anyway."""
+    driver = _driver(_fake_client(_lit_blocks()), hass=_hass_with_services())
+    declared = HuaweiSolarDriver.control_dependency_keys.fget(None)
+    await driver.read_telemetry(sorted(declared))
+    assert driver._strings_lit is True
+    assert driver._pv_lit is True
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+
+
+@pytest.mark.asyncio
+async def test_a_dim_dawn_is_still_read_with_the_entities_disabled():
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    declared = HuaweiSolarDriver.control_dependency_keys.fget(None)
+    await driver.read_telemetry(sorted(declared))
+    assert driver._strings_lit is True
+    assert driver._pv_lit is False
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == -2000
+

--- a/tests/test_huawei_driver.py
+++ b/tests/test_huawei_driver.py
@@ -17,6 +17,10 @@ from custom_components.omnibattery.drivers import DriverCapabilities
 from custom_components.omnibattery.drivers.huawei import (
     SENSOR_DEFINITIONS,
     HuaweiSolarDriver,
+    _MIN_WRITE_INTERVAL_S,
+    _PV_PROBE_INTERVAL_S,
+    _PV_PROBE_SETTLE_S,
+    _PV_PROBE_WINDOW_S,
 )
 from custom_components.omnibattery.infra.huawei_modbus_client import (
     decode_i16,
@@ -1989,14 +1993,28 @@ def test_the_grid_sensor_is_named_in_every_language():
 # So while there is light on the panels this driver commands nothing at all and
 # leaves the inverter to its own regulation, which harvests everything.
 # ----------------------------------------------------------------------
-def _lit_blocks():
-    """Strings under load on a sunny morning: 374 V."""
-    return {**_LIVE_BLOCKS, 32016: [3741, 1141, 3757, 1143]}
+def _pv_block(watts):
+    """Register 32064 with a given DC total, AC output left as it was."""
+    return [(watts >> 16) & 0xFFFF, watts & 0xFFFF] + [0] * 14 + [0, 758]
+
+
+def _lit_blocks(watts=5054):
+    """Strings under load on a sunny morning: 374 V, and a roof worth keeping."""
+    return {
+        **_LIVE_BLOCKS,
+        32016: [3741, 1141, 3757, 1143],
+        32064: _pv_block(watts),
+    }
+
+
+def _dim_blocks(watts=50):
+    """An overcast dawn: the strings are up, the array makes almost nothing."""
+    return {**_LIVE_BLOCKS, 32016: [3001, 17, 2987, 16], 32064: _pv_block(watts)}
 
 
 def _dark_blocks():
     """After sunset the voltage collapses with the light."""
-    return {**_LIVE_BLOCKS, 32016: [0, 0, 0, 0]}
+    return {**_LIVE_BLOCKS, 32016: [0, 0, 0, 0], 32064: _pv_block(0)}
 
 
 @pytest.mark.asyncio
@@ -2017,7 +2035,9 @@ async def test_darkness_is_read_the_same_way():
 @pytest.mark.asyncio
 async def test_a_string_at_voltage_but_idle_still_counts_as_lit():
     """The state a held command leaves behind — 374 V at 0.00 A."""
-    driver = _driver(_fake_client({**_LIVE_BLOCKS, 32016: [3741, 0, 3757, 0]}))
+    driver = _driver(_fake_client({
+        **_LIVE_BLOCKS, 32016: [3741, 0, 3757, 0], 32064: _pv_block(5054),
+    }))
     await driver.read_telemetry()
     assert driver._pv_lit is True
 
@@ -2058,6 +2078,209 @@ async def test_sunrise_hands_control_over_without_a_restart():
     await driver.read_telemetry()
     driver._last_write_monotonic = 0.0
     assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+
+
+# ----------------------------------------------------------------------
+# Voltage alone cannot tell a bright morning from a dim one. Measured across
+# three dawns on the reference installation, the array stays under 150 W for
+# 45-50 minutes after first light while the strings already carry ~300 V —
+# time the battery was refused for nothing.
+#
+# Harvested power closes that hole, but only carefully: while a command stands
+# the production it suppresses is our own artefact, so a low reading proves
+# nothing. A high one still does, which is what hands control back at sunrise.
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_an_overcast_dawn_does_not_block_the_battery():
+    """300 V on the strings, 50 W off the roof: nothing worth curtailing."""
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert driver._strings_lit is True
+    assert driver._pv_lit is False
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == -2000
+
+
+@pytest.mark.asyncio
+async def test_the_threshold_is_on_harvest_not_on_voltage():
+    driver = _driver(_fake_client(_dim_blocks(watts=151)))
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
+
+
+@pytest.mark.asyncio
+async def test_production_while_commanding_is_believed_at_once():
+    """Our own command can only push this number down, never up."""
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    await driver.apply_setpoint(-2000, read_back=False)
+    assert driver._last_written_w == -2000
+
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks().get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
+    # The release still waits out the ramp throttle; see the test below.
+    driver._last_write_monotonic -= _MIN_WRITE_INTERVAL_S + 1
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+
+
+@pytest.mark.asyncio
+async def test_the_release_waits_out_the_ramp_throttle():
+    """A verdict change does not jump the queue: rewriting mid-ramp achieves
+    nothing, so the hand-back is reported as the command still in force."""
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    await driver.apply_setpoint(-2000, read_back=False)
+
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks().get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
+    held = await driver.apply_setpoint(-2000, read_back=False)
+    assert held.net_power_w == -2000
+    assert held.confirmed is False
+
+
+@pytest.mark.asyncio
+async def test_a_quiet_roof_while_commanding_is_not_read_as_darkness():
+    """The 04:32 to 09:22 failure: a held discharge suppresses its own evidence."""
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    await driver.apply_setpoint(-2000, read_back=False)
+
+    # The tracker is now down, so the roof reports nothing whatever the sky does.
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks(watts=0).get(start)
+    )
+    verdict_at = driver._pv_verdict_monotonic
+    await driver.read_telemetry()
+    # No fresh verdict was taken from a reading this driver caused.
+    assert driver._pv_verdict_monotonic == verdict_at
+    assert driver._pv_probe_until == 0.0
+
+
+@pytest.mark.asyncio
+async def test_the_verdict_is_rechecked_by_letting_go():
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    await driver.apply_setpoint(-2000, read_back=False)
+
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks(watts=0).get(start)
+    )
+    # Age the verdict past the probe interval, and past the ramp throttle so
+    # the release can actually be written.
+    driver._pv_verdict_monotonic -= _PV_PROBE_INTERVAL_S + 1
+    driver._last_write_monotonic -= _MIN_WRITE_INTERVAL_S + 1
+    await driver.read_telemetry()
+    assert driver._pv_probe_until > 0.0
+    # While the probe runs the driver lets go, whatever it is asked for.
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+
+
+@pytest.mark.asyncio
+async def test_a_probe_that_finds_sun_keeps_the_battery_released():
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    await driver.apply_setpoint(-2000, read_back=False)
+
+    driver._pv_verdict_monotonic -= _PV_PROBE_INTERVAL_S + 1
+    driver._last_write_monotonic -= _MIN_WRITE_INTERVAL_S + 1
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks(watts=0).get(start)
+    )
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+
+    # Released long enough for the tracker to recover, and it has.
+    driver._last_write_monotonic -= _PV_PROBE_SETTLE_S + 1
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks().get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
+    assert driver._pv_probe_until == 0.0
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+
+
+@pytest.mark.asyncio
+async def test_a_probe_that_finds_nothing_returns_the_battery():
+    """The dim-dawn case: let go, see 50 W, take the battery back."""
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    await driver.apply_setpoint(-2000, read_back=False)
+
+    driver._pv_verdict_monotonic -= _PV_PROBE_INTERVAL_S + 1
+    driver._last_write_monotonic -= _MIN_WRITE_INTERVAL_S + 1
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks(watts=0).get(start)
+    )
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+
+    driver._last_write_monotonic -= _PV_PROBE_SETTLE_S + 1
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _dim_blocks().get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_lit is False
+    assert driver._pv_probe_until == 0.0
+
+    # Taking the battery back is throttled like any other write, so a probe
+    # costs the settle window plus the ramp interval — about 20 s in 120 s on
+    # the constants above. That is the price of not missing sunrise.
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+    driver._last_write_monotonic -= _MIN_WRITE_INTERVAL_S + 1
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == -2000
+
+
+@pytest.mark.asyncio
+async def test_a_probe_whose_release_never_landed_is_abandoned():
+    """No reading beats a reading the driver did not actually cause."""
+    driver = _driver(_fake_client(_dim_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    await driver.apply_setpoint(-2000, read_back=False)
+
+    driver._pv_verdict_monotonic -= _PV_PROBE_INTERVAL_S + 1
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: _lit_blocks(watts=0).get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_probe_until > 0.0
+
+    # The release never reached the hardware: the command still stands.
+    driver._pv_probe_until -= _PV_PROBE_WINDOW_S + 1
+    await driver.read_telemetry()
+    assert driver._pv_probe_until == 0.0
+    assert driver._pv_lit is False
+
+
+@pytest.mark.asyncio
+async def test_darkness_needs_no_probe():
+    driver = _driver(_fake_client(_dark_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    await driver.apply_setpoint(-2000, read_back=False)
+    driver._pv_verdict_monotonic -= 600.0
+    await driver.read_telemetry()
+    assert driver._pv_probe_until == 0.0
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == -2000
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_roof_leaves_the_verdict_alone():
+    driver = _driver(_fake_client(_lit_blocks()))
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
+
+    table = _lit_blocks()
+    table.pop(32064)
+    driver._client.async_read_holding_block = AsyncMock(
+        side_effect=lambda start, count: table.get(start)
+    )
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_huawei_driver.py
+++ b/tests/test_huawei_driver.py
@@ -1974,12 +1974,92 @@ def test_the_grid_sensor_is_named_in_every_language():
 
 
 # ----------------------------------------------------------------------
-# releasing on shutdown
+# a forcible command caps this inverter's own production
 #
-# A forcible command left standing does not expire in any useful sense: one
-# written at 04:32 was still in force at 09:22 on the reference installation,
-# and on this hybrid a latched discharge keeps the strings dark, so the roof
-# produces nothing until the registers are cleared by hand.
+# The worst fault this driver has caused, and the one most specific to a hybrid.
+# A forcible command is not a request but a ceiling: the inverter produces
+# exactly what it was told and curtails the rest of the roof.
+#
+# Caught in the act with a 315 W charge standing — 288 W harvested, 5054 W six
+# seconds after it ended. A discharge is worse still: it serves the house from
+# the battery and leaves the tracker down entirely, so the roof makes nothing,
+# and the missing production reads as a deficit that asks for more discharge.
+# That one ran from 04:32 to 09:22 through a cloudless sunrise.
+#
+# So while there is light on the panels this driver commands nothing at all and
+# leaves the inverter to its own regulation, which harvests everything.
+# ----------------------------------------------------------------------
+def _lit_blocks():
+    """Strings under load on a sunny morning: 374 V."""
+    return {**_LIVE_BLOCKS, 32016: [3741, 1141, 3757, 1143]}
+
+
+def _dark_blocks():
+    """After sunset the voltage collapses with the light."""
+    return {**_LIVE_BLOCKS, 32016: [0, 0, 0, 0]}
+
+
+@pytest.mark.asyncio
+async def test_light_on_the_panels_is_read_from_the_string_voltage():
+    driver = _driver(_fake_client(_lit_blocks()))
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
+
+
+@pytest.mark.asyncio
+async def test_darkness_is_read_the_same_way():
+    """No forecast, sun elevation or clock: the strings say it themselves."""
+    driver = _driver(_fake_client(_dark_blocks()))
+    await driver.read_telemetry()
+    assert driver._pv_lit is False
+
+
+@pytest.mark.asyncio
+async def test_a_string_at_voltage_but_idle_still_counts_as_lit():
+    """The state a held command leaves behind — 374 V at 0.00 A."""
+    driver = _driver(_fake_client({**_LIVE_BLOCKS, 32016: [3741, 0, 3757, 0]}))
+    await driver.read_telemetry()
+    assert driver._pv_lit is True
+
+
+@pytest.mark.asyncio
+async def test_no_charge_is_commanded_while_the_panels_are_lit():
+    """315 W commanded, 288 W harvested, 5054 W once it stopped."""
+    driver = _driver(_fake_client(_lit_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(315, read_back=False)).net_power_w == 0
+
+
+@pytest.mark.asyncio
+async def test_no_discharge_is_commanded_while_the_panels_are_lit():
+    driver = _driver(_fake_client(_lit_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+
+
+@pytest.mark.asyncio
+async def test_after_dark_the_battery_is_commanded_as_normal():
+    """The whole point of the driver, and none of this applies without sun."""
+    driver = _driver(_fake_client(_dark_blocks()), hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == -2000
+
+
+@pytest.mark.asyncio
+async def test_sunrise_hands_control_over_without_a_restart():
+    table = dict(_dark_blocks())
+    client = _fake_client()
+    client.async_read_holding_block = AsyncMock(side_effect=lambda start, count: table.get(start))
+    driver = _driver(client, hass=_hass_with_services())
+    await driver.read_telemetry()
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == -2000
+
+    table.update(_lit_blocks())
+    await driver.read_telemetry()
+    driver._last_write_monotonic = 0.0
+    assert (await driver.apply_setpoint(-2000, read_back=False)).net_power_w == 0
+
+
 # ----------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_shutdown_releases_over_the_path_the_commands_took():
@@ -2002,6 +2082,7 @@ async def test_the_service_path_still_releases_through_the_service():
     driver = _driver(_fake_client(), hass=hass)
     assert await driver.standby() is True
     assert hass.services.async_call.await_args.args[1] == "stop_forcible_charge"
+
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Second of the split from #335. Huawei only — no control-layer code, and `dc_coupled` stays behind with the rest of that work.

You asked for two things here. The first I agree with and have done: the behaviour change is now the point of the PR rather than an undescribed side effect. The second I want to argue with before implementing, because the measurement that produced this gate is already in the tree and it says the opposite.

### What the change is

`apply_setpoint` drops to 0 whenever the strings carry voltage. That is a driver-wide behaviour change and it deserves the headline, so here it is in full.

**A forcible command on this hybrid is a ceiling, not a request.** The inverter produces exactly what it was told and curtails the rest of the array. Caught with a 315 W charge standing: **288 W harvested from strings that made 5054 W six seconds after the command ended**, while a separate balcony array on the same roof held steady throughout — so not weather.

A forcible discharge is worse, and this is the part that matters for your objection. It serves the house from the battery and leaves the MPPT tracker down entirely: **374 V at 0.00 A**. With the roof producing nothing, the meter shows a real deficit — which is what asks for discharge. The command goes on justifying itself. **Commanded at 04:32 against a genuinely dark sky, still standing at 09:22.**

So while there is light on the strings this driver commands nothing and hands back to the inverter's own regulation. On a DC-coupled hybrid the inverter is the better controller in daylight: it is the only party that knows what the array could be making. The cost is real and stated in §13.8 — a Huawei battery is under Omnibattery's control after dark only.

### Why I have not gated it on harvested power

Your dawn case is real. At 300 V and 50 W the gate opens and a discharge the house needs is refused. I want that fixed.

But gating on harvested power reintroduces the 04:32→09:22 bug, because our own command destroys the signal:

| State | String voltage | Harvested |
|---|---|---|
| Night | 0 V | 0 W |
| Overcast dawn | ~300 V | ~50 W |
| **Sun up, curtailed by our own discharge** | **374 V** | **~0 W** |

The last two rows are indistinguishable by harvested power. A discharge standing through sunrise holds the tracker down, `solar_power` stays near zero, the gate never closes, and the command survives the whole day — which is exactly what was observed before the voltage test went in. Voltage is the only signal that survives our own curtailment.

### What I think the right gate is

The driver knows whether a command is standing (`_last_written_w`), and that is what makes the harvested reading trustworthy or not:

- **While released** — which is the steady state under sun, since the gate releases — `solar_power` (register 32064) is the true harvest, and a threshold on it closes your dawn hole cleanly.
- **While a command stands**, harvested power is our own artefact and must not be read. The verdict has to latch, with a short periodic release to re-sample.

That is a small state machine rather than a one-line change, and it is your driver's direction, so I would rather have your call than guess it. I have the hardware to measure whatever threshold you want, across as many dawns as it takes.

Say which way and I will push it onto this branch: the probe design above, a plain harvested-power gate if you have a reason to think the curtailment case is narrower than I measured, or something else you prefer.

### Also in here

- The EMMA register map (`site-docs/reference/huawei-emma-registers.md`), read off the reference installation.
- §13.8–13.10 of the driver assessment: the curtailment finding, what a second battery looks like to the hybrid's energy manager (1391 W of PV over a 529 W house, one battery taking in 1110 W while the other gave up 205 W, meter at 3 W), and the form-schema serialisation failure that made the config flow unreachable for this brand.

### Tests and base

190 pass in `tests/test_huawei_driver.py`, including lit and dark string fixtures. Full suite 1925 passed, 10 skipped.

The one failure is `tests/test_charge_delay.py::test_balance_needs_charge_unlocks_low_forecast`, which fails on clean `release/v1.4.0` before this branch touches anything — `assert 'energy_balance' == 'low_forecast'`. Same note as on #380; not mine, not fixed here.
