### PR TITLE
fix: keep the system up when a battery is switched off at start-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **One switched-off battery no longer takes the whole system down at start-up**: a battery that did not answer during setup failed the config entry, so every other battery, the controller and the dashboard disappeared with it and Home Assistant retried setup in a loop for as long as the device stayed off — a battery left on its side switch was enough. That battery now starts unreachable while the rest of the system runs, is reported through the non-responsive batteries sensor, and the integration reloads itself once the battery answers again, which restores its hardware configuration write, its model-specific entities and its telemetry. A driver whose connection attempt raises instead of returning a refusal is treated the same way, and the interrupted-active-balance migration waits for a battery it cannot reach rather than latching manual mode on it.
+
 ## [1.4.0] - 2026-09-04
 
 ### Added

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -9394,6 +9394,17 @@ async def _async_migrate_legacy_active_balance(
 
         legacy_notification_config = dict(battery)
         active = _legacy_active_balance_is_running(battery)
+        if active and not getattr(coordinator, "is_available", True):
+            # An interrupted run is handed off through the hardware (idle,
+            # verify, restore), which an unreachable battery cannot do: the
+            # failure path would latch manual mode into the entry and freeze the
+            # battery once it returns. Keep the legacy record and migrate it on
+            # the reload that follows the battery answering again.
+            _LOGGER.info(
+                "[%s] Deferring the integrated active-balance handoff: the battery is unreachable",
+                coordinator.name,
+            )
+            continue
         if not active:
             for key in legacy_keys:
                 battery.pop(key, None)
@@ -9684,62 +9695,94 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     connected = await coordinator.connect()
                     if connected:
                         break
-            if not connected:
-                # Don't silently continue with an unconnected coordinator (entities
-                # would be unavailable and HA would think setup succeeded). Raise
-                # ConfigEntryNotReady so HA retries setup with backoff.
-                raise ConfigEntryNotReady(
-                    f"Could not connect to {coordinator.host}:{coordinator.port} — "
-                    "the device may still be releasing the previous TCP connection slot. "
-                    "HA will retry setup automatically."
-                )
+        except Exception as e:
+            # A driver whose connect() raises (an HTTP session, an entity lookup)
+            # is no different from one returning False: the battery is not there.
+            _LOGGER.warning(
+                "Connecting to %s at %s:%s raised %s",
+                battery_config[CONF_NAME], coordinator.host, coordinator.port, e,
+            )
+            await coordinator.disconnect()
+            connected = False
+
+        if not connected:
+            # A battery that does not answer is set up unreachable instead of
+            # failing the config entry. Raising ConfigEntryNotReady here tore the
+            # whole system down over one switched-off battery: every other
+            # battery, the controller and the dashboard went with it, and the
+            # entry stayed in a setup-retry loop for as long as the device stayed
+            # off. This battery instead starts unreachable, and the coordinator
+            # reloads the entry once the device answers (the connect-time entity
+            # definitions and the initial hardware configuration write can only
+            # be redone by re-running setup) — see the coordinator's
+            # _schedule_setup_reload_if_deferred.
+            _LOGGER.warning(
+                "Battery %s at %s:%s did not answer during setup; it starts unreachable "
+                "and the integration reloads once it responds",
+                battery_config[CONF_NAME], coordinator.host, coordinator.port,
+            )
+            coordinator.reload_entry_when_reachable = True
+            # _consecutive_failures is what every consumer gates on to tell an
+            # unreachable battery from an idle one (non_responsive_battery_names,
+            # the non_responsive_batteries sensor, diagnostics). A battery that
+            # never answered starts counted, so it is visibly unreachable before
+            # the first poll instead of looking healthy until then.
+            coordinator._consecutive_failures = 1
+            # Every consumer of coordinator.data assumes setup ran a first
+            # refresh, so hand them the same empty snapshot a battery whose reads
+            # all failed produces. Assigned rather than pushed through
+            # async_set_updated_data: nothing was read, so this is not an update.
+            coordinator.data = {}
+            coordinators.append(coordinator)
+            continue
+
+        try:
+            # Enable RS485 Control Mode first (required to apply configuration changes)
+            # Only done during integration setup/reload, not repeated during runtime
+            # Skip if the user explicitly disabled RS485 via the switch.
+            if coordinator.rs485_user_disabled:
+                _LOGGER.info("Skipping RS485 enable for %s (user disabled)", battery_config[CONF_NAME])
             else:
-                # Enable RS485 Control Mode first (required to apply configuration changes)
-                # Only done during integration setup/reload, not repeated during runtime
-                # Skip if the user explicitly disabled RS485 via the switch.
-                if coordinator.rs485_user_disabled:
-                    _LOGGER.info("Skipping RS485 enable for %s (user disabled)", battery_config[CONF_NAME])
-                else:
-                    _LOGGER.info("Enabling RS485 Control Mode for %s (only on initial setup)", battery_config[CONF_NAME])
-                    if coordinator.capabilities.has_rs485_control:
-                        await coordinator.set_rs485_control(True)
-                        await asyncio.sleep(0.1)
+                _LOGGER.info("Enabling RS485 Control Mode for %s (only on initial setup)", battery_config[CONF_NAME])
+                if coordinator.capabilities.has_rs485_control:
+                    await coordinator.set_rs485_control(True)
+                    await asyncio.sleep(0.1)
 
-                # Write initial configuration values to the battery: hardware SOC
-                # cut-offs (v2 only) + max charge/discharge power caps. The driver
-                # owns which registers exist for this version and the scaling.
-                #
-                # Registerless drivers (Zendure) are skipped: their SOC limits live
-                # in device flash and are written directly by the soc_set/min_soc
-                # number entities, which do NOT round-trip through battery_config.
-                # So battery_config still holds the config-flow defaults (max_soc=100,
-                # min_soc=12); re-asserting them here would clobber the user's
-                # device-set values on every restart and re-arm the full-charge
-                # taper/hysteresis machinery. The device is the source of truth and
-                # the coordinator syncs soc_set/min_soc back from the poll.
-                if _device_owns_initial_config(coordinator.brand):
-                    _LOGGER.info("Skipping initial SOC config write for %s (registerless driver; device flash holds the user values)",
-                               battery_config[CONF_NAME])
-                else:
-                    max_charge_power = int(battery_config["max_charge_power"])
-                    max_discharge_power = int(battery_config["max_discharge_power"])
+            # Write initial configuration values to the battery: hardware SOC
+            # cut-offs (v2 only) + max charge/discharge power caps. The driver
+            # owns which registers exist for this version and the scaling.
+            #
+            # Registerless drivers (Zendure) are skipped: their SOC limits live
+            # in device flash and are written directly by the soc_set/min_soc
+            # number entities, which do NOT round-trip through battery_config.
+            # So battery_config still holds the config-flow defaults (max_soc=100,
+            # min_soc=12); re-asserting them here would clobber the user's
+            # device-set values on every restart and re-arm the full-charge
+            # taper/hysteresis machinery. The device is the source of truth and
+            # the coordinator syncs soc_set/min_soc back from the poll.
+            if _device_owns_initial_config(coordinator.brand):
+                _LOGGER.info("Skipping initial SOC config write for %s (registerless driver; device flash holds the user values)",
+                           battery_config[CONF_NAME])
+            else:
+                max_charge_power = int(battery_config["max_charge_power"])
+                max_discharge_power = int(battery_config["max_discharge_power"])
 
-                    _LOGGER.info("Writing initial configuration for %s (%s): max_soc=%d%%, min_soc=%d%%, max_charge=%dW, max_discharge=%dW",
-                               battery_config[CONF_NAME], coordinator.battery_version,
-                               battery_config["max_soc"], battery_config["min_soc"],
-                               max_charge_power, max_discharge_power)
+                _LOGGER.info("Writing initial configuration for %s (%s): max_soc=%d%%, min_soc=%d%%, max_charge=%dW, max_discharge=%dW",
+                           battery_config[CONF_NAME], coordinator.battery_version,
+                           battery_config["max_soc"], battery_config["min_soc"],
+                           max_charge_power, max_discharge_power)
 
-                    await coordinator.apply_config(
-                        max_soc_pct=battery_config["max_soc"],
-                        min_soc_pct=battery_config["min_soc"],
-                        max_charge_power_w=max_charge_power,
-                        max_discharge_power_w=max_discharge_power,
-                    )
+                await coordinator.apply_config(
+                    max_soc_pct=battery_config["max_soc"],
+                    min_soc_pct=battery_config["min_soc"],
+                    max_charge_power_w=max_charge_power,
+                    max_discharge_power_w=max_discharge_power,
+                )
 
-                # Manually trigger first refresh and wait for it
-                await coordinator.async_request_refresh()
-                # Give a moment for the data to be processed
-                await asyncio.sleep(0.5)
+            # Manually trigger first refresh and wait for it
+            await coordinator.async_request_refresh()
+            # Give a moment for the data to be processed
+            await asyncio.sleep(0.5)
         except Exception as e:
             # Disconnect on any setup error
             await coordinator.disconnect()

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -109,6 +109,32 @@ def is_untrusted_energy_reading(key: str, value, prev) -> bool:
     return False
 
 
+def _schedule_setup_reload_if_deferred(coordinator) -> None:
+    """Reload the entry once a battery that missed its setup answers.
+
+    A battery that was unreachable during setup was created without the
+    hardware configuration write, without the driver's connect-time entity
+    definitions (model detection, pack discovery) and without a first telemetry
+    snapshot. Writing the configuration from here would leave the other two
+    missing, and entities cannot be added to a platform that already finished
+    setting up, so the battery is adopted by re-running setup with the device
+    present. One-shot: the reloaded runtime only re-arms the flag if the battery
+    is unreachable again.
+    """
+    if not getattr(coordinator, "reload_entry_when_reachable", False):
+        return
+    coordinator.reload_entry_when_reachable = False
+    entry = getattr(coordinator, "_config_entry", None)
+    if entry is None:
+        return
+    _LOGGER.info(
+        "[%s] Battery answered after starting unreachable - reloading the "
+        "integration to complete its setup",
+        coordinator.name,
+    )
+    coordinator.hass.config_entries.async_schedule_reload(entry.entry_id)
+
+
 class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
     """Manages polling for data from a single Marstek Venus battery."""
 
@@ -257,6 +283,13 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
         # read before the first write returns None rather than raising.
         self._last_write_failure_reason = None
         self._last_rs485_reenable_success = None
+        # Set by setup for a battery that did not answer: setup no longer fails
+        # the whole config entry over one unreachable battery, so this battery
+        # was created without the hardware configuration write, the driver's
+        # connect-time entity definitions and its first telemetry. The entry is
+        # reloaded once the battery answers, which is the only path that
+        # rebuilds all three. See _schedule_setup_reload_if_deferred.
+        self.reload_entry_when_reachable = False
 
         # Timestamp-based update tracking
         self._last_update_times = {}
@@ -879,6 +912,9 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                     else:
                         self._last_rs485_reenable_success = False
                         _LOGGER.warning("[%s] Failed to re-enable RS485 after reconnection", self.name)
+
+                _schedule_setup_reload_if_deferred(self)
+
             else:
                 self._is_connected = False
                 _LOGGER.warning("[%s] Fresh reconnection failed", self.name)
@@ -1280,6 +1316,10 @@ class MarstekVenusDataUpdateCoordinator(DataUpdateCoordinator):
                 )
             self._consecutive_failures = 0
             self._is_connected = True
+            # A battery can also come back through a plain successful read (a
+            # client that reconnects itself, an entity-backed driver whose
+            # source turned available), without async_reconnect_fresh running.
+            _schedule_setup_reload_if_deferred(self)
         else:
             # All attempted reads failed - connection issue
             self._consecutive_failures += 1

--- a/tests/test_offline_battery_setup.py
+++ b/tests/test_offline_battery_setup.py
@@ -1,0 +1,109 @@
+"""A battery that is switched off at setup must not take the system down.
+
+Setup used to raise ``ConfigEntryNotReady`` when a battery did not answer, so
+one battery on its side switch removed every other battery, the controller and
+the dashboard, and the entry stayed in a setup-retry loop for as long as the
+device stayed off. The battery is now set up unreachable, and the entry is
+reloaded once it answers — the only path that redoes the hardware configuration
+write, the connect-time entity definitions and the first telemetry read.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from custom_components.omnibattery.infra.coordinator import (
+    MarstekVenusDataUpdateCoordinator,
+    _schedule_setup_reload_if_deferred,
+)
+
+
+def _deferred_coordinator(*, deferred: bool, entry=SimpleNamespace(entry_id="abc")):
+    """Only the attributes the deferred-reload helper touches."""
+    return SimpleNamespace(
+        name="Battery 1",
+        reload_entry_when_reachable=deferred,
+        _config_entry=entry,
+        hass=SimpleNamespace(
+            config_entries=SimpleNamespace(async_schedule_reload=Mock())
+        ),
+    )
+
+
+def _schedule(coordinator):
+    _schedule_setup_reload_if_deferred(coordinator)
+
+
+def test_a_battery_that_started_unreachable_reloads_the_entry_when_it_answers():
+    coordinator = _deferred_coordinator(deferred=True)
+
+    _schedule(coordinator)
+
+    coordinator.hass.config_entries.async_schedule_reload.assert_called_once_with("abc")
+    assert coordinator.reload_entry_when_reachable is False
+
+
+def test_the_reload_fires_once_and_not_on_every_recovery():
+    coordinator = _deferred_coordinator(deferred=True)
+
+    _schedule(coordinator)
+    _schedule(coordinator)
+
+    assert coordinator.hass.config_entries.async_schedule_reload.call_count == 1
+
+
+def test_a_battery_that_was_present_at_setup_never_reloads_the_entry():
+    coordinator = _deferred_coordinator(deferred=False)
+
+    _schedule(coordinator)
+
+    coordinator.hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+def _reconnecting_coordinator(*, deferred: bool):
+    """A coordinator whose driver reconnects, with RS485 out of the way."""
+    return SimpleNamespace(
+        name="Battery 1",
+        host="192.0.2.10",
+        port=502,
+        lock=asyncio.Lock(),
+        _consecutive_failures=5,
+        _is_connected=False,
+        _suspension_reset_time=object(),
+        _last_rs485_reenable_success=None,
+        _last_update_times={},
+        _critical_group_failures={},
+        rs485_user_disabled=True,
+        capabilities=SimpleNamespace(has_rs485_control=False),
+        reload_entry_when_reachable=deferred,
+        _config_entry=SimpleNamespace(entry_id="abc"),
+        hass=SimpleNamespace(
+            config_entries=SimpleNamespace(async_schedule_reload=Mock())
+        ),
+        driver=SimpleNamespace(connect=AsyncMock(return_value=True)),
+    )
+
+
+def test_a_successful_reconnection_carries_the_deferred_reload():
+    coordinator = _reconnecting_coordinator(deferred=True)
+
+    reconnected = asyncio.run(
+        MarstekVenusDataUpdateCoordinator.async_reconnect_fresh(coordinator)
+    )
+
+    assert reconnected is True
+    coordinator.hass.config_entries.async_schedule_reload.assert_called_once_with("abc")
+
+
+def test_a_failed_reconnection_leaves_the_deferred_reload_armed():
+    coordinator = _reconnecting_coordinator(deferred=True)
+    coordinator.driver.connect = AsyncMock(return_value=False)
+
+    reconnected = asyncio.run(
+        MarstekVenusDataUpdateCoordinator.async_reconnect_fresh(coordinator)
+    )
+
+    assert reconnected is False
+    coordinator.hass.config_entries.async_schedule_reload.assert_not_called()
+    assert coordinator.reload_entry_when_reachable is True


### PR DESCRIPTION
### Problem

A battery that does not answer during setup raises `ConfigEntryNotReady`, which fails the whole config entry: every other battery, the controller and the dashboard go with it, and Home Assistant retries setup in a loop for as long as the device stays off. Someone switching one battery off at its side switch and restarting Home Assistant loses the entire integration until they switch it back on. Nothing detects the unreachable battery either, because the non-responsive tracking only runs once setup has succeeded.

### Change

The unreachable battery is set up unreachable instead of failing the entry. It gets an empty telemetry snapshot and a seeded failure counter, so it appears in `non_responsive_battery_names`, the `non_responsive_batteries` sensor and diagnostics immediately rather than looking healthy.

Adopting it later cannot be done from the coordinator alone: the hardware configuration write, the driver's connect-time entity definitions (model detection, pack discovery) and the first telemetry read all happen in setup, and entities cannot be added to a platform that already finished setting up. So the coordinator schedules one entry reload the first time the battery answers, from either recovery path (a fresh reconnection, or a plain successful poll for a client that reconnects itself). The flag is one-shot; the reloaded runtime re-arms it only if the battery is unreachable again.

Two adjacent failure modes are fixed with it:

- A driver whose `connect()` raises rather than returning `False` (Huawei reads telemetry, ESPHome resolves entities, Zendure/Sessy do aiohttp work) escaped the setup `try` block and left the entry in ERROR with no retry at all. It is now treated as "not there", like a refused connection.
- The interrupted-active-balance migration hands off through the hardware. On an unreachable battery that path fails and latches manual mode into the entry data, freezing the battery once it returns. It now waits for the reload.

Behaviour for a fully reachable system is unchanged.

### Tests

`tests/test_offline_battery_setup.py` covers the deferred reload: armed only for a battery that started unreachable, fired once, carried by a successful reconnection, left armed by a failed one. Full suite: 1957 passed, 10 skipped.