### PR TITLE
fix(setup): one reload for an offline fleet, and never let close() fail the entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- **One switched-off battery no longer takes the whole system down at start-up**: a battery that did not answer during setup failed the config entry, so every other battery, the controller and the dashboard disappeared with it and Home Assistant retried setup in a loop for as long as the device stayed off — a battery left on its side switch was enough. That battery now starts unreachable while the rest of the system runs, is reported through the non-responsive batteries sensor, and the integration reloads itself once the battery answers again, which restores its hardware configuration write, its model-specific entities and its telemetry. A driver whose connection attempt raises instead of returning a refusal is treated the same way, and the interrupted-active-balance migration waits for a battery it cannot reach rather than latching manual mode on it.
+- **A battery switched off at start-up no longer takes the whole system down** (#403): it starts unreachable, is reported by the non-responsive batteries sensor, and the integration reloads once it answers. Thanks to @syphernl for the contribution.
 
 ## [1.4.0] - 2026-09-04
 

--- a/custom_components/omnibattery/__init__.py
+++ b/custom_components/omnibattery/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import math
 import time
@@ -9702,7 +9703,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "Connecting to %s at %s:%s raised %s",
                 battery_config[CONF_NAME], coordinator.host, coordinator.port, e,
             )
-            await coordinator.disconnect()
+            # A close on a link that never came up can raise in its own right
+            # (an MQTT publish, a second client). Letting that escape would put
+            # the entry in ERROR with no retry, which is the failure this whole
+            # branch exists to avoid.
+            with contextlib.suppress(Exception):
+                await coordinator.disconnect()
             connected = False
 
         if not connected:

--- a/custom_components/omnibattery/infra/coordinator.py
+++ b/custom_components/omnibattery/infra/coordinator.py
@@ -120,6 +120,13 @@ def _schedule_setup_reload_if_deferred(coordinator) -> None:
     setting up, so the battery is adopted by re-running setup with the device
     present. One-shot: the reloaded runtime only re-arms the flag if the battery
     is unreachable again.
+
+    This depends on the unreachable battery still getting its entities at setup:
+    they are what subscribe to the coordinator, and without a subscriber
+    DataUpdateCoordinator never schedules a poll, so nothing would ever notice
+    the battery answering. Every driver therefore has to seed its entity
+    definitions in ``__init__`` (connect may only refine them), or a battery of
+    that brand that starts unreachable would stay that way until a restart.
     """
     if not getattr(coordinator, "reload_entry_when_reachable", False):
         return
@@ -127,6 +134,21 @@ def _schedule_setup_reload_if_deferred(coordinator) -> None:
     entry = getattr(coordinator, "_config_entry", None)
     if entry is None:
         return
+    # The flag is per battery, so several batteries that were all switched off
+    # would each schedule a full teardown/rebuild of the same entry when they
+    # come back together. One reload adopts all of them. The marker lives in the
+    # entry's runtime dict, which setup rebuilds, so the reloaded runtime starts
+    # unmarked.
+    runtime = coordinator.hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if isinstance(runtime, dict):
+        if runtime.get("setup_reload_scheduled"):
+            _LOGGER.info(
+                "[%s] Battery answered after starting unreachable - joining the "
+                "reload already scheduled for this entry",
+                coordinator.name,
+            )
+            return
+        runtime["setup_reload_scheduled"] = True
     _LOGGER.info(
         "[%s] Battery answered after starting unreachable - reloading the "
         "integration to complete its setup",

--- a/tests/test_offline_battery_setup.py
+++ b/tests/test_offline_battery_setup.py
@@ -13,21 +13,30 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+from custom_components.omnibattery.const import DOMAIN
 from custom_components.omnibattery.infra.coordinator import (
     MarstekVenusDataUpdateCoordinator,
     _schedule_setup_reload_if_deferred,
 )
 
 
-def _deferred_coordinator(*, deferred: bool, entry=SimpleNamespace(entry_id="abc")):
+def _deferred_coordinator(
+    *, deferred: bool, entry=SimpleNamespace(entry_id="abc"), hass=None
+):
     """Only the attributes the deferred-reload helper touches."""
     return SimpleNamespace(
         name="Battery 1",
         reload_entry_when_reachable=deferred,
         _config_entry=entry,
-        hass=SimpleNamespace(
-            config_entries=SimpleNamespace(async_schedule_reload=Mock())
-        ),
+        hass=hass if hass is not None else _hass(),
+    )
+
+
+def _hass(runtime=None):
+    """A hass stub with the entry runtime dict the dedupe marker lives in."""
+    return SimpleNamespace(
+        config_entries=SimpleNamespace(async_schedule_reload=Mock()),
+        data={DOMAIN: {"abc": runtime}} if runtime is not None else {},
     )
 
 
@@ -78,9 +87,7 @@ def _reconnecting_coordinator(*, deferred: bool):
         capabilities=SimpleNamespace(has_rs485_control=False),
         reload_entry_when_reachable=deferred,
         _config_entry=SimpleNamespace(entry_id="abc"),
-        hass=SimpleNamespace(
-            config_entries=SimpleNamespace(async_schedule_reload=Mock())
-        ),
+        hass=_hass(),
         driver=SimpleNamespace(connect=AsyncMock(return_value=True)),
     )
 
@@ -107,3 +114,29 @@ def test_a_failed_reconnection_leaves_the_deferred_reload_armed():
     assert reconnected is False
     coordinator.hass.config_entries.async_schedule_reload.assert_not_called()
     assert coordinator.reload_entry_when_reachable is True
+
+
+def test_batteries_that_come_back_together_share_one_entry_reload():
+    """The flag is per battery; the reload it asks for is per entry."""
+    runtime: dict = {}
+    hass = _hass(runtime)
+    first = _deferred_coordinator(deferred=True, hass=hass)
+    second = _deferred_coordinator(deferred=True, hass=hass)
+
+    _schedule(first)
+    _schedule(second)
+
+    hass.config_entries.async_schedule_reload.assert_called_once_with("abc")
+    assert second.reload_entry_when_reachable is False
+
+
+def test_the_reload_marker_does_not_survive_into_the_reloaded_runtime():
+    """Setup rebuilds the runtime dict, so a second outage reloads again."""
+    hass = _hass({})
+    _schedule(_deferred_coordinator(deferred=True, hass=hass))
+    assert hass.data[DOMAIN]["abc"]["setup_reload_scheduled"] is True
+
+    hass.data[DOMAIN]["abc"] = {}
+    _schedule(_deferred_coordinator(deferred=True, hass=hass))
+
+    assert hass.config_entries.async_schedule_reload.call_count == 2


### PR DESCRIPTION
Follow-up to #403, from reviewing it after the merge.

### `close()` on a link that never came up

`connect()` raising is now treated as "the battery is not there", and that path calls `coordinator.disconnect()`. But a close can raise in its own right — the Hoymiles driver publishes over MQTT when `_connected` is set, Huawei closes a second client — and that exception escaped `async_setup_entry` uncaught, leaving the entry in ERROR with no retry. That is exactly the failure #403 exists to prevent, reachable through its own recovery path. Suppressed.

### One reload for a fleet that was switched off together

`reload_entry_when_reachable` is per battery, so three batteries coming back in the same poll cycle scheduled three `async_schedule_reload` calls: three sequential teardown/rebuilds of the same entry, where one adopts all of them.

The marker now lives in the entry's runtime dict. Setup rebuilds that dict, so the reloaded runtime starts unmarked and a later outage still gets its own reload.

### Note on the recovery path

Documented on `_schedule_setup_reload_if_deferred`: the whole mechanism depends on the unreachable battery still getting entities at setup, because entities are what subscribe to the coordinator and `DataUpdateCoordinator` never schedules a poll without a subscriber. Every driver seeds its definitions in `__init__` today (connect only refines them), so this holds — but a future driver that resolved its entities at connect would leave a battery that started unreachable stuck until a restart.

### Tests

Two added to `tests/test_offline_battery_setup.py`: batteries returning together share one reload, and the marker does not survive into the reloaded runtime. Full suite: 1959 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)