### PR TITLE
Address #413 review feedback (SoH zero, precision, panel sig)

### DIFF
--- a/custom_components/omnibattery/drivers/anker.py
+++ b/custom_components/omnibattery/drivers/anker.py
@@ -152,8 +152,8 @@ SENSOR_DEFINITIONS: list[dict] = [
      "device_class": "battery", "state_class": "measurement", "scale": 1, "precision": 0,
      "scan_interval": "medium", "enabled_by_default": True},
     {"key": "battery_soh", "name": "Battery State of Health (SoH)", "unit": "%",
-     "device_class": None, "state_class": "measurement", "scale": 1, "precision": 1,
-     "icon": "mdi:battery-heart", "scan_interval": "low", "enabled_by_default": True},
+     "device_class": None, "state_class": "measurement", "scale": 1, "precision": 0,
+     "icon": "mdi:battery-heart", "enabled_by_default": True},
     {"key": "battery_power", "name": "Battery Power", "unit": "W",
      "device_class": "power", "state_class": "measurement", "scale": 1, "precision": 0,
      "scan_interval": "high", "enabled_by_default": True},
@@ -580,6 +580,12 @@ class AnkerModbusDriver(BatteryDriver):
                     capped = max(0, min(_HW_MAX_POWER_W, int(value)))
                     snapshot[field["key"]] = capped or _HW_MAX_POWER_W
                     self._dynamic_max_discharge_w = snapshot[field["key"]]
+
+        # Register 10015 is shared across Solarbank SKUs but only field-verified on
+        # DMWH. Units that do not implement SoH may answer 0 instead of omitting the
+        # field; treat that as unknown rather than a dead battery.
+        if snapshot.get("battery_soh") == 0:
+            snapshot.pop("battery_soh", None)
 
         pv_power = snapshot.get("pv_power")
         third_party_pv_power = snapshot.get("third_party_pv_power")

--- a/custom_components/omnibattery/frontend/marstek-panel.js
+++ b/custom_components/omnibattery/frontend/marstek-panel.js
@@ -894,6 +894,12 @@ const K = {
 
 const MPPT_KEYS = ["mppt1_power", "mppt2_power", "mppt3_power", "mppt4_power"];
 
+// translation_keys that change which health-metric rows a battery card renders.
+const BAT_CARD_LAYOUT_KEYS = [
+  K.batterySoh, K.batteryVoltage, K.cellMax, K.cellMin, K.cellDelta,
+  K.cycles, K.cyclesCalc, K.rte, K.chargeHysteresisActive,
+];
+
 // Diagnostic rows shown in the SOC card's second section (2-column grid).
 // One per diagnostic-category entity on the system device, except balance_neto
 // (own dedicated card).
@@ -5494,10 +5500,15 @@ class MarstekVenusPanel extends HTMLElement {
     return list;
   }
 
+  _batteryCardSig(b) {
+    const keys = BAT_CARD_LAYOUT_KEYS.filter((k) => b.entIds[k]).sort().join(",");
+    return `${b.dev}:${keys}`;
+  }
+
   _renderBaterias() {
     this._batCards = {};
     const list = this._batteryModel();
-    this._batSig = list.map((b) => b.dev).sort().join("|");
+    this._batSig = list.map((b) => this._batteryCardSig(b)).sort().join("|");
     const wrap = document.createElement("div");
     wrap.className = "bat-grid";
     if (!list.length) {
@@ -5701,7 +5712,7 @@ class MarstekVenusPanel extends HTMLElement {
 
   _patchBatteries(list) {
     if (!this._batCards) return;
-    const sig = list.map((b) => b.dev).sort().join("|");
+    const sig = list.map((b) => this._batteryCardSig(b)).sort().join("|");
     if (sig !== this._batSig && this._main) {
       // battery set changed under us: rebuild the whole view, then patch fresh
       this._main.innerHTML = "";
@@ -5823,7 +5834,7 @@ class MarstekVenusPanel extends HTMLElement {
 
     // health / cells
     const M = r.M;
-    if (M.soh) M.soh.textContent = b.soh != null ? `${this._nf(b.soh, 1)} %` : "—";
+    if (M.soh) M.soh.textContent = b.soh != null ? `${this._nf(b.soh, 0)} %` : "—";
     M.temp.textContent = b.temp != null ? `${this._nf(b.temp, 1)} °C` : "—";
     if (M.volt) M.volt.textContent = b.voltage != null ? `${this._nf(b.voltage, 2)} V` : "—";
     if (M.cmax) M.cmax.textContent = b.cellMax != null ? `${this._nf(b.cellMax, 3)} V` : "—";

--- a/site-docs/configuration/batteries/anker.es.md
+++ b/site-docs/configuration/batteries/anker.es.md
@@ -51,7 +51,7 @@ Mantén **Third-Party Control** activado en la aplicación de Anker; el driver y
 el BMS siguen siendo responsables de sus propios límites de seguridad de
 hardware.
 
-## Diagnóstico
+## Telemetría de salud
 
 | Lectura | Entidad | Fuente |
 |---|---|---|
@@ -60,7 +60,11 @@ hardware.
 El SoH se expone para todos los modelos Anker Solarbank compatibles que comparten
 el mapa de registros común. Solo se ha verificado en campo en **Solarbank Max AC**
 (código de producto **DMWH**); otros modelos pueden informar el mismo registro,
-pero aún no están confirmados en campo.
+pero aún no están confirmados en campo. Un valor de registro **0** se trata como
+no disponible (desconocido o no implementado) en lugar de 0 % SoH.
+
+El sensor SoH es una entidad de medición normal (no categoría de diagnóstico de
+HA) y se muestra en el panel cuando está disponible.
 
 Anker no expone tensión del pack, tensiones por celda ni telemetría de equilibrio
 de celdas por Modbus. Por eso Omnibattery no crea `battery_voltage`,
@@ -78,5 +82,5 @@ muestra solo las métricas disponibles en cada dispositivo:
   de celda y cualquier otro sensor expuesto por el driver.
 
 Las filas de tensión y celdas se omiten automáticamente cuando la integración no
-tiene entidades equivalentes, de modo que las tarjetas Anker ya no muestran
-marcadores vacíos.
+tiene entidades equivalentes (esto aplica a todas las marcas de batería, no solo
+Anker), de modo que las tarjetas Anker ya no muestran marcadores vacíos.

--- a/site-docs/configuration/batteries/anker.md
+++ b/site-docs/configuration/batteries/anker.md
@@ -47,7 +47,7 @@ driver while **Battery Manual Control** is enabled. Keep **Third-Party Control**
 enabled in the Anker app; the driver and BMS remain responsible for their own
 hardware safety limits.
 
-## Diagnostics
+## Health telemetry
 
 | Reading | Entity | Source |
 |---|---|---|
@@ -56,7 +56,11 @@ hardware safety limits.
 SoH is exposed for all supported Anker Solarbank models that share the common
 register map. It has only been field-verified on **Solarbank Max AC** (product
 code **DMWH**); other models may report the same register but are not yet
-confirmed in the field.
+confirmed in the field. A register value of **0** is treated as unavailable
+(unknown or unimplemented) rather than 0 % SoH.
+
+The SoH sensor is a normal measurement entity (not an HA diagnostic category) and
+is shown on the dashboard when available.
 
 Anker does not expose pack voltage, per-cell voltages or cell-balance telemetry
 over Modbus. Omnibattery therefore does not create `battery_voltage`,
@@ -73,4 +77,5 @@ exist for each device:
   delta and any other sensors exposed by the driver.
 
 Voltage and cell rows are omitted automatically when the integration has no
-matching entities, so Anker cards no longer show empty placeholders.
+matching entities (this applies across all battery brands, not only Anker), so
+Anker cards no longer show empty placeholders.

--- a/tests/test_anker_driver.py
+++ b/tests/test_anker_driver.py
@@ -287,6 +287,18 @@ async def test_read_telemetry_decodes_battery_soh_from_register_10015():
     assert snap["battery_soh"] == 92
 
 
+@pytest.mark.asyncio
+async def test_read_telemetry_omits_battery_soh_when_register_10015_is_zero():
+    client = _fake_client()
+    buf = [0] * 51
+    client.async_read_input_block = AsyncMock(return_value=buf)
+
+    drv = _driver(client=client)
+    snap = await drv.read_telemetry(["battery_soh"])
+
+    assert "battery_soh" not in snap
+
+
 def test_battery_soh_in_sensor_definitions_for_e5000_and_max_ac():
     client = _fake_client()
     drv = _driver(client=client)


### PR DESCRIPTION
Follow-up to #413 with the review feedback from [#405 (comment)](https://github.com/ffunes/Omnibattery/pull/405#issuecomment-5558551136).

Cherry-picked onto `feature/anker-soh-v150` (2 commits):

1. **Treat Anker SoH zero as unknown; fix precision and panel card signature**
   - Map register **10015** value `0` → unavailable in `read_telemetry` (chosen over product-code gating; trade-off: genuine 0 % SoH also shows as unavailable)
   - SoH `precision: 0` in driver + panel
   - Remove inert `scan_interval` from SoH sensor definition
   - Extend `_batSig` / `_batteryCardSig()` so health rows rebuild when entities appear

2. **Rename Anker health docs and document SoH zero semantics**
   - Diagnostics → Health telemetry (en/es)
   - Cross-brand entity-driven dashboard wording
   - Note SoH is a normal measurement entity, not HA diagnostic category

Entity naming (`Battery State of Health (SoH)`) left as-is for consistency with Battery SOC.

## Test plan

- [x] `pytest tests/test_anker_driver.py` — 51 passed (includes new zero-register test)

Made with [Cursor](https://cursor.com)